### PR TITLE
fix: Use name if preferredUsername is empty

### DIFF
--- a/src/components/Navigation/UserInformation.tsx
+++ b/src/components/Navigation/UserInformation.tsx
@@ -26,7 +26,11 @@ export const UserInformation: React.FC<{}> = () => {
                 {profile.value == null ? (
                     <LoginLink />
                 ) : (
-                    profile.value.preferredUsername
+                    profile.value.preferredUsername == null ? (
+                            profile.value.name
+                        ) : (
+                            profile.value.preferredUsername
+                        )
                 )}
             </div>
         </WaitForData>

--- a/src/components/Navigation/UserInformation.tsx
+++ b/src/components/Navigation/UserInformation.tsx
@@ -26,12 +26,12 @@ export const UserInformation: React.FC<{}> = () => {
                 {profile.value == null ? (
                     <LoginLink />
                 ) : (
-                    profile.value.preferredUsername == null ? (
+                        profile.value.preferredUsername == null || profile.value.preferredUsername == "" ? (
                             profile.value.name
                         ) : (
-                            profile.value.preferredUsername
-                        )
-                )}
+                                profile.value.preferredUsername
+                            )
+                    )}
             </div>
         </WaitForData>
     );


### PR DESCRIPTION
# TL;DR
Use `name` from `/me` response if `preferred_username` is null.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Not all OIdP providers fill in all user info fields. Google, we found, uses the `name` field but not the `preferred_username` field.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/657