### PR TITLE
fix: handle fullInputs for relaunch workflow

### DIFF
--- a/src/components/Executions/ExecutionDetails/test/RelaunchExecutionForm.test.tsx
+++ b/src/components/Executions/ExecutionDetails/test/RelaunchExecutionForm.test.tsx
@@ -185,6 +185,44 @@ describe('RelaunchExecutionForm', () => {
         });
     });
 
+    describe('Launch form with full inputs', () => {
+        let values: LiteralValueMap;
+        beforeEach(() => {
+            workflowInputDefinitions = {
+                workflowSimpleString: mockSimpleVariables.simpleString,
+                workflowSimpleInteger: mockSimpleVariables.simpleInteger
+            };
+            workflow.closure!.compiledWorkflow!.primary.template.interface!.inputs = {
+                variables: workflowInputDefinitions
+            };
+            executionInputs = {
+                literals: {
+                    workflowSimpleString: primitiveLiteral({
+                        stringValue: simpleStringValue
+                    }),
+                    workflowSimpleInteger: primitiveLiteral({
+                        integer: simpleIntegerValue
+                    })
+                }
+            };
+            executionData.fullInputs = executionInputs;
+            execution.closure.computedInputs = executionInputs;
+            values = createValuesMap(workflowInputDefinitions, executionInputs);
+        });
+        it('correctly uses fullInputs when value is present and does not call getRemoteLiteralMap()', async () => {
+            delete execution.closure.computedInputs;
+            const { getByText } = renderForm();
+            await waitFor(() => getByText(mockContentString));
+            expect(mockGetExecutionData).toHaveBeenCalledWith(execution.id);
+            expect(mockGetRemoteLiteralMap).not.toHaveBeenCalled();
+            checkLaunchFormProps({
+                initialParameters: expect.objectContaining({
+                    values
+                })
+            });
+        });
+    });
+
     describe('with single task execution', () => {
         let values: LiteralValueMap;
         let authRole: Admin.IAuthRole;

--- a/src/components/Executions/useWorkflowExecution.ts
+++ b/src/components/Executions/useWorkflowExecution.ts
@@ -73,7 +73,17 @@ export const fetchWorkflowExecutionInputs = async (
     if (execution.closure.computedInputs) {
         return execution.closure.computedInputs;
     }
-    const { inputs } = await getExecutionData(execution.id);
+    /** Note:
+     * getExecutionData will retun signed urls (`inputs`) as well as raw values
+     * (`fullInputs`) if input payload isn't too large.
+     *
+     * If a signed URL is returned `fullInputs` will be null; use `fullInputs`
+     * when available.
+     */
+    const { inputs, fullInputs } = await getExecutionData(execution.id);
+    if (fullInputs) {
+        return LiteralMap.create(fullInputs);
+    }
     if (
         !inputs.url ||
         !inputs.bytes ||


### PR DESCRIPTION
Fixes issue where recent changes made to `flyteadmin` were not being supported in UI. The use-case is when a user goes to relaunch a workflow, we now return raw/full inputs when the payload is small enough; this adds support for `fullInputs`

see: https://github.com/flyteorg/flyteadmin/commit/067dc911bae09ee73cfcc6d46a658aa9a1c1d7d1#diff-9b311b663f43eccf79220bfcae3a565ad26d83532c945f39cfc1f7ba029c22e3