### PR TITLE
fix: this is rfc, do not deploy until resolved; details in comments

### DIFF
--- a/src/components/Executions/utils.ts
+++ b/src/components/Executions/utils.ts
@@ -112,8 +112,9 @@ export const taskExecutionIsTerminal = (taskExecution: TaskExecution) =>
     taskExecution.closure &&
     terminalTaskExecutionStates.includes(taskExecution.closure.phase);
 
+/** Returns a NodeId from a given NodeExecution  */
 export function getNodeExecutionSpecId(nodeExecution: NodeExecution): string {
-    return nodeExecution.metadata?.specNodeId || nodeExecution.id.nodeId;
+    return nodeExecution.id.nodeId;
 }
 
 interface GetExecutionDurationMSArgs {


### PR DESCRIPTION
## RFC: DO NOT DEPLOY UNTIL RESOLVED

I am working on the fix for https://github.com/flyteorg/flyte/issues/1085 and have identified where the workflow breaks. This change fixes the issue (short version: id's were being used as keys but their values were truncated and thus we had duplicates) however I am new to the code base and unclear on the implications of removing this ternary.  Where/why do we use `metadata` rather than `id`? 

Can someone with more context please take a look and help me understand if there are any edge cases I am missing here?

## Type
 - [ X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1085
