### PR TITLE
Use cr.flyte.org endpoint for Docker run command in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Quickstart
 
   .. code:: bash
 
-     docker run --rm --privileged -p 30081:30081 -p 30082:30082 -p 30084:30084 ghcr.io/flyteorg/flyte-sandbox
+     docker run --rm --privileged -p 30081:30081 -p 30082:30082 -p 30084:30084 cr.flyte.org/flyteorg/flyte-sandbox
 
 #. Now Export these 2 env variables
 


### PR DESCRIPTION
Signed-off-by: aviaviavi <avipress@gmail.com>

# TL;DR
This change updates the README to use cr.flyte.org domain for the `docker run` example.

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

I believe these unchecked ones are N/A, but please let me know if I'm mistaken!

## Complete description
This change updates the README to use cr.flyte.org domain for the `docker run` example. It doesn't affect anything else beyond where the example points.

## Tracking Issue
_NA_

## Follow-up issue
_NA_

