### PR TITLE
fix: duration is not always calculated for task executions

### DIFF
--- a/src/components/Executions/TaskExecutionsList/TaskExecutionDetails.tsx
+++ b/src/components/Executions/TaskExecutionsList/TaskExecutionDetails.tsx
@@ -10,30 +10,42 @@ import * as React from 'react';
 export const TaskExecutionDetails: React.FC<{
     taskExecution: TaskExecution;
 }> = ({ taskExecution }) => {
+    const labelWidthGridUnits = taskExecution.closure.startedAt ? 7 : 10;
+    const detailItems = React.useMemo(() => {
+        if (taskExecution.closure.startedAt) {
+            return [
+                {
+                    name: 'started',
+                    content: dateWithFromNow(
+                        timestampToDate(taskExecution.closure.startedAt)
+                    )
+                },
+                {
+                    name: 'run time',
+                    content: taskExecution.closure.duration
+                        ? protobufDurationToHMS(taskExecution.closure.duration)
+                        : unknownValueString
+                }
+            ];
+        } else {
+            return [
+                {
+                    name: 'last updated',
+                    content: taskExecution.closure.updatedAt
+                        ? dateWithFromNow(
+                              timestampToDate(taskExecution.closure.updatedAt)
+                          )
+                        : unknownValueString
+                }
+            ];
+        }
+    }, [taskExecution]);
+
     return (
         <section>
             <DetailsGroup
-                labelWidthGridUnits={7}
-                items={[
-                    {
-                        name: 'started',
-                        content: taskExecution.closure.startedAt
-                            ? dateWithFromNow(
-                                  timestampToDate(
-                                      taskExecution.closure.startedAt
-                                  )
-                              )
-                            : unknownValueString
-                    },
-                    {
-                        name: 'run time',
-                        content: taskExecution.closure.duration
-                            ? protobufDurationToHMS(
-                                  taskExecution.closure.duration
-                              )
-                            : unknownValueString
-                    }
-                ]}
+                labelWidthGridUnits={labelWidthGridUnits}
+                items={detailItems}
             />
         </section>
     );


### PR DESCRIPTION

# TL;DR

Fixed the `unknown` is being present for both `start time` and `duration` in task details panel for nodes.
Added `last updated` to be shown instead if both of above fields are absent in API response.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Created a `fallback` option when `started_at` and `duration` fields are not present in the API response.

## Tracking Issue

fixes https://github.com/flyteorg/flyte/issues/885

## Follow-up issue
_NA_
