### PR TITLE
fix: repopulate struct input fields on relaunch form

### DIFF
--- a/src/components/Launch/LaunchForm/StructInput.tsx
+++ b/src/components/Launch/LaunchForm/StructInput.tsx
@@ -53,12 +53,6 @@ export const StructInput: React.FC<InputProps> = props => {
     const hasError = !!error;
     const helperText = hasError ? error : props.helperText;
 
-    const [paramData, setParamData] = useState({});
-    const onFormChange = ({ formData }, e) => {
-        onChange(JSON.stringify(formData));
-        setParamData(formData);
-    };
-
     let jsonFormRenderable = false;
     let parsedJson: PrimitiveType = {};
 
@@ -80,6 +74,15 @@ export const StructInput: React.FC<InputProps> = props => {
             }
         }
     }
+
+    const [paramData, setParamData] = useState(
+        jsonFormRenderable ? JSON.parse(value as string) : {}
+    );
+
+    const onFormChange = ({ formData }, e) => {
+        onChange(JSON.stringify(formData));
+        setParamData(formData);
+    };
 
     return jsonFormRenderable ? (
         <MuiThemeProvider theme={muiTheme}>


### PR DESCRIPTION
Signed-off-by: Pianist038801 <steven@union.ai>

This PR repopulates the input values when relaunching a wf/task that has an input of type struct/dataclass/json type.


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue


## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/1418

## Follow-up issue
_NA_
