### PR TITLE
fix: hide recover button for successful executions

### DIFF
--- a/src/components/Executions/ExecutionDetails/ExecutionDetailsAppBarContent.tsx
+++ b/src/components/Executions/ExecutionDetails/ExecutionDetailsAppBarContent.tsx
@@ -14,6 +14,7 @@ import * as React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { history } from 'routes/history';
 import { Routes } from 'routes/routes';
+import { WorkflowExecutionPhase } from 'models/Execution/enums';
 import { ExecutionInputsOutputsModal } from '../ExecutionInputsOutputsModal';
 import { ExecutionStatusBadge } from '../ExecutionStatusBadge';
 import { TerminateExecutionButton } from '../TerminateExecution/TerminateExecutionButton';
@@ -123,24 +124,36 @@ export const ExecutionDetailsAppBarContent: React.FC<{
         await recoverExecution();
     }, [recoverExecution]);
 
+    const isRecoverVisible = React.useMemo(
+        () =>
+            [
+                WorkflowExecutionPhase.FAILED,
+                WorkflowExecutionPhase.ABORTED,
+                WorkflowExecutionPhase.TIMED_OUT
+            ].includes(phase),
+        [phase]
+    );
+
     const actionContent = isRunning ? (
         <TerminateExecutionButton className={styles.actionButton} />
     ) : isTerminal ? (
         <>
-            <Button
-                variant="outlined"
-                color="primary"
-                disabled={recovering}
-                className={classnames(
-                    styles.actionButton,
-                    commonStyles.buttonWhiteOutlined
-                )}
-                onClick={onClickRecover}
-                size="small"
-            >
-                Recover
-                {recovering && <ButtonCircularProgress />}
-            </Button>
+            {isRecoverVisible && (
+                <Button
+                    variant="outlined"
+                    color="primary"
+                    disabled={recovering}
+                    className={classnames(
+                        styles.actionButton,
+                        commonStyles.buttonWhiteOutlined
+                    )}
+                    onClick={onClickRecover}
+                    size="small"
+                >
+                    Recover
+                    {recovering && <ButtonCircularProgress />}
+                </Button>
+            )}
             <Button
                 variant="outlined"
                 color="primary"


### PR DESCRIPTION
Signed-off-by: Pianist038801 <steven@union.ai>

This hides recover button for the successful executions.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/1416

## Follow-up issue
_NA_
