### PR TITLE
fix: auth role to be aligned with launch plan and be editable by user

### DIFF
--- a/src/components/Executions/ExecutionDetails/RelaunchExecutionForm.tsx
+++ b/src/components/Executions/ExecutionDetails/RelaunchExecutionForm.tsx
@@ -38,7 +38,8 @@ function useRelaunchWorkflowFormState({
                         launchPlan,
                         disableAll,
                         maxParallelism,
-                        qualityOfService
+                        labels,
+                        annotations
                     }
                 } = execution;
                 const workflow = await apiContext.getWorkflow(workflowId);
@@ -56,7 +57,8 @@ function useRelaunchWorkflowFormState({
                     workflowId,
                     disableAll,
                     maxParallelism,
-                    qualityOfService
+                    labels,
+                    annotations
                 };
             }
         },

--- a/src/components/Launch/LaunchForm/LaunchFormAdvancedInputs.tsx
+++ b/src/components/Launch/LaunchForm/LaunchFormAdvancedInputs.tsx
@@ -38,7 +38,8 @@ const muiTheme = createMuiTheme({
         },
         MuiCard: {
             root: {
-                marginBottom: 16
+                marginBottom: 16,
+                width: '100%'
             }
         }
     },
@@ -51,7 +52,6 @@ const muiTheme = createMuiTheme({
 });
 
 interface LaunchAdvancedOptionsProps {
-    spec: Admin.IExecutionSpec;
     state: State<
         WorkflowLaunchContext,
         WorkflowLaunchEvent,
@@ -70,9 +70,8 @@ export const LaunchFormAdvancedInputs = React.forwardRef<
 >(
     (
         {
-            spec,
             state: {
-                context: { launchPlan }
+                context: { launchPlan, ...other }
             }
         },
         ref
@@ -89,11 +88,11 @@ export const LaunchFormAdvancedInputs = React.forwardRef<
         );
 
         React.useEffect(() => {
-            if (isValueValid(spec.disableAll)) {
-                setDisableAll(spec.disableAll!);
+            if (isValueValid(other.disableAll)) {
+                setDisableAll(other.disableAll!);
             }
-            if (isValueValid(spec.maxParallelism)) {
-                setMaxParallelism(`${spec.maxParallelism}`);
+            if (isValueValid(other.maxParallelism)) {
+                setMaxParallelism(`${other.maxParallelism}`);
             }
             if (
                 launchPlan?.spec.rawOutputDataConfig?.outputLocationPrefix !==
@@ -105,19 +104,23 @@ export const LaunchFormAdvancedInputs = React.forwardRef<
                     launchPlan.spec.rawOutputDataConfig.outputLocationPrefix
                 );
             }
-            if (
-                launchPlan?.spec.labels?.values !== undefined &&
-                launchPlan?.spec.labels.values !== null
-            ) {
-                setLabelsParamData(launchPlan.spec.labels.values);
-            }
-            if (
-                launchPlan?.spec.annotations?.values !== undefined &&
-                launchPlan?.spec.annotations.values !== null
-            ) {
-                setAnnotationsParamData(launchPlan.spec.annotations.values);
-            }
-        }, [spec, launchPlan?.spec]);
+            const newLabels = {
+                ...(other.labels?.values || {}),
+                ...(launchPlan?.spec?.labels?.values || {})
+            };
+            const newAnnotations = {
+                ...(other.annotations?.values || {}),
+                ...(launchPlan?.spec?.annotations?.values || {})
+            };
+            setLabelsParamData(newLabels);
+            setAnnotationsParamData(newAnnotations);
+        }, [
+            other.disableAll,
+            other.maxParallelism,
+            other.labels,
+            other.annotations,
+            launchPlan?.spec
+        ]);
 
         React.useImperativeHandle(
             ref,

--- a/src/components/Launch/LaunchForm/LaunchFormAdvancedInputs.tsx
+++ b/src/components/Launch/LaunchForm/LaunchFormAdvancedInputs.tsx
@@ -1,176 +1,277 @@
 import * as React from 'react';
 import { Admin } from 'flyteidl';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles';
+import Accordion from '@material-ui/core/Accordion';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
 import Checkbox from '@material-ui/core/Checkbox';
-import FormControl from '@material-ui/core/FormControl';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
-import InputLabel from '@material-ui/core/InputLabel';
-import MenuItem from '@material-ui/core/MenuItem';
-import Select from '@material-ui/core/Select';
+import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import Form from '@rjsf/material-ui';
 
-import { qualityOfServiceTier, qualityOfServiceTierLabels } from './constants';
 import { LaunchAdvancedOptionsRef } from './types';
 import { flyteidl } from '@flyteorg/flyteidl/gen/pb-js/flyteidl';
 import IExecutionSpec = flyteidl.admin.IExecutionSpec;
-import { Grid, TextField } from '@material-ui/core';
+import { State } from 'xstate';
+import {
+    WorkflowLaunchContext,
+    WorkflowLaunchEvent,
+    WorkflowLaunchTypestate
+} from './launchMachine';
+import { useStyles } from './styles';
 
-const useStyles = makeStyles((theme: Theme) => ({
-    sectionTitle: {
-        marginBottom: theme.spacing(2)
+const muiTheme = createMuiTheme({
+    props: {
+        MuiTextField: {
+            variant: 'outlined'
+        }
     },
-    sectionContainer: {
-        display: 'flex',
-        flexDirection: 'column'
+    overrides: {
+        MuiButton: {
+            label: {
+                color: 'gray'
+            }
+        },
+        MuiCard: {
+            root: {
+                marginBottom: 16
+            }
+        }
     },
-    qosContainer: {
-        display: 'flex'
-    },
-    autoFlex: {
-        flex: 1,
-        display: 'flex'
+    typography: {
+        h5: {
+            fontSize: '.875rem',
+            fontWeight: 500
+        }
     }
-}));
+});
 
 interface LaunchAdvancedOptionsProps {
     spec: Admin.IExecutionSpec;
+    state: State<
+        WorkflowLaunchContext,
+        WorkflowLaunchEvent,
+        any,
+        WorkflowLaunchTypestate
+    >;
 }
+
+const isValueValid = (value: any) => {
+    return value !== undefined && value !== null;
+};
 
 export const LaunchFormAdvancedInputs = React.forwardRef<
     LaunchAdvancedOptionsRef,
     LaunchAdvancedOptionsProps
->(({ spec }, ref) => {
-    const styles = useStyles();
-    const [qosTier, setQosTier] = React.useState(
-        qualityOfServiceTier.UNDEFINED.toString()
-    );
-    const [disableAll, setDisableAll] = React.useState(false);
-    const [maxParallelism, setMaxParallelism] = React.useState('');
-    const [queueingBudget, setQueueingBudget] = React.useState('');
-
-    React.useEffect(() => {
-        if (spec.disableAll !== undefined && spec.disableAll !== null) {
-            setDisableAll(spec.disableAll);
-        }
-        if (spec.maxParallelism !== undefined && spec.maxParallelism !== null) {
-            setMaxParallelism(`${spec.maxParallelism}`);
-        }
-        if (
-            spec.qualityOfService?.tier !== undefined &&
-            spec.qualityOfService?.tier !== null
-        ) {
-            setQosTier(spec.qualityOfService.tier.toString());
-        }
-    }, [spec]);
-
-    React.useImperativeHandle(
-        ref,
-        () => ({
-            getValues: () => {
-                return {
-                    disableAll,
-                    qualityOfService: {
-                        tier: parseInt(qosTier || '0', 10)
-                    },
-                    maxParallelism: parseInt(maxParallelism || '', 10)
-                } as IExecutionSpec;
-            },
-            validate: () => {
-                return true;
+>(
+    (
+        {
+            spec,
+            state: {
+                context: { launchPlan }
             }
-        }),
-        [disableAll, qosTier, maxParallelism]
-    );
-
-    const handleQosTierChange = React.useCallback(({ target: { value } }) => {
-        setQosTier(value);
-    }, []);
-
-    const handleDisableAllChange = React.useCallback(() => {
-        setDisableAll(prevState => !prevState);
-    }, []);
-
-    const handleMaxParallelismChange = React.useCallback(
-        ({ target: { value } }) => {
-            setMaxParallelism(value);
         },
-        []
-    );
+        ref
+    ) => {
+        const styles = useStyles();
+        const [labelsParamData, setLabelsParamData] = React.useState({});
+        const [annotationsParamData, setAnnotationsParamData] = React.useState(
+            {}
+        );
+        const [disableAll, setDisableAll] = React.useState(false);
+        const [maxParallelism, setMaxParallelism] = React.useState('');
+        const [rawOutputDataConfig, setRawOutputDataConfig] = React.useState(
+            ''
+        );
 
-    const handleQueueingBudgetChange = React.useCallback(
-        ({ target: { value } }) => {
-            setQueueingBudget(value);
-        },
-        []
-    );
+        React.useEffect(() => {
+            if (isValueValid(spec.disableAll)) {
+                setDisableAll(spec.disableAll!);
+            }
+            if (isValueValid(spec.maxParallelism)) {
+                setMaxParallelism(`${spec.maxParallelism}`);
+            }
+            if (
+                launchPlan?.spec.rawOutputDataConfig?.outputLocationPrefix !==
+                    undefined &&
+                launchPlan?.spec.rawOutputDataConfig.outputLocationPrefix !==
+                    null
+            ) {
+                setRawOutputDataConfig(
+                    launchPlan.spec.rawOutputDataConfig.outputLocationPrefix
+                );
+            }
+            if (
+                launchPlan?.spec.labels?.values !== undefined &&
+                launchPlan?.spec.labels.values !== null
+            ) {
+                setLabelsParamData(launchPlan.spec.labels.values);
+            }
+            if (
+                launchPlan?.spec.annotations?.values !== undefined &&
+                launchPlan?.spec.annotations.values !== null
+            ) {
+                setAnnotationsParamData(launchPlan.spec.annotations.values);
+            }
+        }, [spec, launchPlan?.spec]);
 
-    return (
-        <>
-            <section title="Enable/Disable all notifications">
-                <FormControlLabel
-                    control={
-                        <Checkbox
-                            checked={disableAll}
-                            onChange={handleDisableAllChange}
-                        />
-                    }
-                    label="Disable all notifications"
-                />
-            </section>
-            <section title="Max parallelism">
-                <TextField
-                    variant="outlined"
-                    label="Max parallelism"
-                    fullWidth
-                    margin="normal"
-                    value={maxParallelism}
-                    onChange={handleMaxParallelismChange}
-                />
-            </section>
-            <section
-                title="Quality of Service"
-                className={styles.sectionContainer}
-            >
-                <Typography variant="h6" className={styles.sectionTitle}>
-                    Quality of Service
-                </Typography>
-                <Grid container spacing={2}>
-                    <Grid item sm={6}>
-                        <FormControl variant="outlined" fullWidth>
-                            <InputLabel id="quality-of-service-tier-id">
-                                Quality of Service Tier
-                            </InputLabel>
-                            <Select
-                                variant="outlined"
-                                id="quality-of-service-tier-id"
-                                label="Quality of Service Tier"
-                                value={qosTier}
-                                onChange={handleQosTierChange}
-                            >
-                                {Object.keys(qualityOfServiceTierLabels).map(
-                                    tier => (
-                                        <MenuItem
-                                            key={`quality-of-service-${tier}`}
-                                            value={tier}
+        React.useImperativeHandle(
+            ref,
+            () => ({
+                getValues: () => {
+                    return {
+                        disableAll,
+                        maxParallelism: parseInt(maxParallelism || '', 10),
+                        labels: {
+                            values: labelsParamData
+                        },
+                        annotations: {
+                            values: annotationsParamData
+                        }
+                    } as IExecutionSpec;
+                },
+                validate: () => {
+                    return true;
+                }
+            }),
+            [disableAll, maxParallelism, labelsParamData, annotationsParamData]
+        );
+
+        const handleDisableAllChange = React.useCallback(() => {
+            setDisableAll(prevState => !prevState);
+        }, []);
+
+        const handleMaxParallelismChange = React.useCallback(
+            ({ target: { value } }) => {
+                setMaxParallelism(value);
+            },
+            []
+        );
+
+        const handleLabelsChange = React.useCallback(({ formData }) => {
+            setLabelsParamData(formData);
+        }, []);
+
+        const handleAnnotationsParamData = React.useCallback(({ formData }) => {
+            setAnnotationsParamData(formData);
+        }, []);
+
+        const handleRawOutputDataConfigChange = React.useCallback(
+            ({ target: { value } }) => {
+                setRawOutputDataConfig(value);
+            },
+            []
+        );
+
+        return (
+            <>
+                <section title="Labels" className={styles.collapsibleSection}>
+                    <Accordion>
+                        <AccordionSummary
+                            expandIcon={<ExpandMoreIcon />}
+                            aria-controls="Labels"
+                            id="labels-form"
+                        >
+                            <header className={styles.sectionHeader}>
+                                <Typography variant="h6">Labels</Typography>
+                            </header>
+                        </AccordionSummary>
+
+                        <AccordionDetails>
+                            <MuiThemeProvider theme={muiTheme}>
+                                <Card variant="outlined">
+                                    <CardContent>
+                                        <Form
+                                            schema={{
+                                                type: 'object',
+                                                additionalProperties: true
+                                            }}
+                                            formData={labelsParamData}
+                                            onChange={handleLabelsChange}
                                         >
-                                            {qualityOfServiceTierLabels[tier]}
-                                        </MenuItem>
-                                    )
-                                )}
-                            </Select>
-                        </FormControl>
-                    </Grid>
-                    <Grid item sm={6}>
-                        <TextField
-                            variant="outlined"
-                            label="Queueing budget"
-                            fullWidth
-                            value={queueingBudget}
-                            onChange={handleQueueingBudgetChange}
-                        />
-                    </Grid>
-                </Grid>
-            </section>
-        </>
-    );
-});
+                                            <div />
+                                        </Form>
+                                    </CardContent>
+                                </Card>
+                            </MuiThemeProvider>
+                        </AccordionDetails>
+                    </Accordion>
+                </section>
+                <section
+                    title="Annotations"
+                    className={styles.collapsibleSection}
+                >
+                    <Accordion>
+                        <AccordionSummary
+                            expandIcon={<ExpandMoreIcon />}
+                            aria-controls="Annotations"
+                            id="annotations-form"
+                        >
+                            <header className={styles.sectionHeader}>
+                                <Typography variant="h6">
+                                    Annotations
+                                </Typography>
+                            </header>
+                        </AccordionSummary>
+
+                        <AccordionDetails>
+                            <MuiThemeProvider theme={muiTheme}>
+                                <Card variant="outlined">
+                                    <CardContent>
+                                        <Form
+                                            schema={{
+                                                type: 'object',
+                                                additionalProperties: true
+                                            }}
+                                            formData={annotationsParamData}
+                                            onChange={
+                                                handleAnnotationsParamData
+                                            }
+                                        >
+                                            <div />
+                                        </Form>
+                                    </CardContent>
+                                </Card>
+                            </MuiThemeProvider>
+                        </AccordionDetails>
+                    </Accordion>
+                </section>
+                <section title="Enable/Disable all notifications">
+                    <FormControlLabel
+                        control={
+                            <Checkbox
+                                checked={disableAll}
+                                onChange={handleDisableAllChange}
+                            />
+                        }
+                        label="Disable all notifications"
+                    />
+                </section>
+                <section title="Raw output data config">
+                    <TextField
+                        variant="outlined"
+                        label="Raw output data config"
+                        fullWidth
+                        margin="normal"
+                        value={rawOutputDataConfig}
+                        onChange={handleRawOutputDataConfigChange}
+                    />
+                </section>
+                <section title="Max parallelism">
+                    <TextField
+                        variant="outlined"
+                        label="Max parallelism"
+                        fullWidth
+                        margin="normal"
+                        value={maxParallelism}
+                        onChange={handleMaxParallelismChange}
+                    />
+                </section>
+            </>
+        );
+    }
+);

--- a/src/components/Launch/LaunchForm/LaunchRoleInput.tsx
+++ b/src/components/Launch/LaunchForm/LaunchRoleInput.tsx
@@ -77,7 +77,7 @@ function getInitialValues(
     // field from the initial value if no cached value was passed.
     if (initialValue != null) {
         const initialRoleType = Object.values(roleTypes).find(
-            rt => initialValue[rt.value] != null
+            rt => initialValue[rt.value]
         );
         if (initialRoleType != null && roleType == null) {
             roleType = initialRoleType;

--- a/src/components/Launch/LaunchForm/LaunchWorkflowForm.tsx
+++ b/src/components/Launch/LaunchForm/LaunchWorkflowForm.tsx
@@ -118,7 +118,10 @@ export const LaunchWorkflowForm: React.FC<LaunchWorkflowFormProps> = props => {
                     <AccordionDetails classes={{ root: styles.detailsWrapper }}>
                         {isEnterInputsState(baseState) ? (
                             <LaunchRoleInput
-                                initialValue={state.context.defaultAuthRole}
+                                initialValue={
+                                    selectedLaunchPlan?.data.spec.authRole ||
+                                    state.context.defaultAuthRole
+                                }
                                 ref={roleInputRef}
                                 showErrors={state.context.showErrors}
                             />

--- a/src/components/Launch/LaunchForm/LaunchWorkflowForm.tsx
+++ b/src/components/Launch/LaunchForm/LaunchWorkflowForm.tsx
@@ -128,10 +128,10 @@ export const LaunchWorkflowForm: React.FC<LaunchWorkflowFormProps> = props => {
                         ) : null}
                         <LaunchFormAdvancedInputs
                             ref={advancedOptionsRef}
+                            state={state}
                             spec={{
                                 disableAll: state.context.disableAll,
-                                maxParallelism: state.context.maxParallelism,
-                                qualityOfService: state.context.qualityOfService
+                                maxParallelism: state.context.maxParallelism
                             }}
                         />
                     </AccordionDetails>

--- a/src/components/Launch/LaunchForm/LaunchWorkflowForm.tsx
+++ b/src/components/Launch/LaunchForm/LaunchWorkflowForm.tsx
@@ -129,10 +129,6 @@ export const LaunchWorkflowForm: React.FC<LaunchWorkflowFormProps> = props => {
                         <LaunchFormAdvancedInputs
                             ref={advancedOptionsRef}
                             state={state}
-                            spec={{
-                                disableAll: state.context.disableAll,
-                                maxParallelism: state.context.maxParallelism
-                            }}
                         />
                     </AccordionDetails>
                 </Accordion>

--- a/src/components/Launch/LaunchForm/launchMachine.ts
+++ b/src/components/Launch/LaunchForm/launchMachine.ts
@@ -80,7 +80,8 @@ export interface WorkflowLaunchContext extends BaseLaunchContext {
     defaultAuthRole?: Admin.IAuthRole;
     disableAll?: boolean | null;
     maxParallelism?: number | null;
-    qualityOfService?: Core.IQualityOfService | null;
+    labels?: Admin.ILabels | null;
+    annotations?: Admin.IAnnotations | null;
 }
 
 export interface TaskLaunchContext extends BaseLaunchContext {

--- a/src/components/Launch/LaunchForm/styles.ts
+++ b/src/components/Launch/LaunchForm/styles.ts
@@ -52,5 +52,8 @@ export const useStyles = makeStyles((theme: Theme) => ({
         '& section': {
             flex: 1
         }
+    },
+    collapsibleSection: {
+        margin: '0 -16px'
     }
 }));

--- a/src/components/Launch/LaunchForm/types.ts
+++ b/src/components/Launch/LaunchForm/types.ts
@@ -57,7 +57,8 @@ export interface WorkflowInitialLaunchParameters
     authRole?: Admin.IAuthRole;
     disableAll?: boolean | null;
     maxParallelism?: number | null;
-    qualityOfService?: Core.IQualityOfService | null;
+    labels?: Admin.ILabels | null;
+    annotations?: Admin.IAnnotations | null;
 }
 export interface LaunchWorkflowFormProps extends BaseLaunchFormProps {
     workflowId: NamedEntityIdentifier;

--- a/src/components/Launch/LaunchForm/useLaunchWorkflowFormState.ts
+++ b/src/components/Launch/LaunchForm/useLaunchWorkflowFormState.ts
@@ -180,17 +180,18 @@ async function submit(
 
     const authRole = roleInputRef.current?.getValue();
     const literals = formInputsRef.current.getValues();
-    const { disableAll, qualityOfService, maxParallelism } =
+    const { disableAll, labels, annotations, maxParallelism } =
         advancedOptionsRef.current?.getValues() || {};
     const launchPlanId = launchPlan.id;
     const { domain, project } = workflowVersion;
 
     const response = await createWorkflowExecution({
+        annotations,
         authRole,
         disableAll,
-        qualityOfServiceTier: qualityOfService?.tier,
         maxParallelism,
         domain,
+        labels,
         launchPlanId,
         project,
         referenceExecutionId,

--- a/src/components/Launch/LaunchForm/useLaunchWorkflowFormState.ts
+++ b/src/components/Launch/LaunchForm/useLaunchWorkflowFormState.ts
@@ -263,7 +263,8 @@ export function useLaunchWorkflowFormState({
         values: defaultInputValues,
         disableAll,
         maxParallelism,
-        qualityOfService
+        labels,
+        annotations
     } = initialParameters;
 
     const apiContext = useAPIContext();
@@ -298,7 +299,8 @@ export function useLaunchWorkflowFormState({
             sourceId,
             disableAll,
             maxParallelism,
-            qualityOfService
+            labels,
+            annotations
         }
     });
 

--- a/src/models/Execution/api.ts
+++ b/src/models/Execution/api.ts
@@ -92,10 +92,11 @@ export const getExecutionData = (
     );
 
 export interface CreateWorkflowExecutionArguments {
+    annotations?: Admin.IAnnotations | null;
     authRole?: Admin.IAuthRole;
     domain: string;
     disableAll?: boolean | null;
-    qualityOfServiceTier?: Core.QualityOfService.Tier | null;
+    labels?: Admin.ILabels | null;
     maxParallelism?: number | null;
     inputs: Core.ILiteralMap;
     launchPlanId: Identifier;
@@ -107,10 +108,11 @@ export interface CreateWorkflowExecutionArguments {
  */
 export const createWorkflowExecution = (
     {
+        annotations,
         authRole,
         domain,
         disableAll,
-        qualityOfServiceTier,
+        labels,
         maxParallelism,
         inputs,
         launchPlanId: launchPlan,
@@ -125,18 +127,15 @@ export const createWorkflowExecution = (
         metadata: {
             referenceExecution,
             principal: defaultExecutionPrincipal
-        }
+        },
+        labels,
+        annotations
     };
     if (authRole?.assumableIamRole || authRole?.kubernetesServiceAccount) {
         spec.authRole = authRole;
     }
     if (disableAll) {
         spec.disableAll = disableAll;
-    }
-    if (qualityOfServiceTier !== undefined) {
-        spec.qualityOfService = {
-            tier: qualityOfServiceTier
-        };
     }
     if (maxParallelism !== undefined) {
         spec.maxParallelism = maxParallelism;


### PR DESCRIPTION
Signed-off-by: csirius <85753828+csirius@users.noreply.github.com>

# TL;DR
Display the original execution IAM or k8s role under "advanced options" in the launch form. Roles can be changed according to the `launch plan` if it has auth role in it; users can edit those roles manually. This fix also adds additional functionality to the launch from with the support of Annotations and Labels

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Make the `Advanced options` in relaunch form shows the original execution IAM or k8s role.
Also those roles could be changed according to the `launch plan` changes if it has auth role in it.
And user can edit those roles manually.

## Tracking Issue

fixes https://github.com/flyteorg/flyte/issues/1737

## Follow-up issue
_NA_

