### PR TITLE
moved ServePlugin to both env

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -279,7 +279,18 @@ export const clientConfig: webpack.Configuration = {
             new ForkTsCheckerWebpackPlugin({ checkSyntacticErrors: true }),
             favIconPlugin,
             statsWriterPlugin,
-            getDefinePlugin(false)
+            getDefinePlugin(false),
+            new ServePlugin({
+                middleware: (app, builtins) =>
+                    app.use(async (ctx, next) => {
+                        await next();
+                        ctx.setHeader(
+                            'Content-Type',
+                            'application/javascript; charset=UTF-8'
+                        );
+                    }),
+                port: 7777
+            })
         ];
 
         // Apply production specific configs
@@ -291,19 +302,8 @@ export const clientConfig: webpack.Configuration = {
 
         if (isDev) {
             return [
-                ...plugins,
+                ...plugins
                 // namedModulesPlugin,
-                new ServePlugin({
-                    middleware: (app, builtins) =>
-                        app.use(async (ctx, next) => {
-                            await next();
-                            ctx.setHeader(
-                                'Content-Type',
-                                'application/javascript; charset=UTF-8'
-                            );
-                        }),
-                    port: 7777
-                })
             ];
         }
 


### PR DESCRIPTION
This commit moves the `webpack-plugin-serve` middleware to apply to both prod and dev builds

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Serve middleware sets the MIME type of main-[hash].js to `application/javascrtipt'.  This middleware was initially configured to apply to dev-only; this change applies it to both prod and dev builds.

## Tracking Issue

## Follow-up issue
https://github.com/flyteorg/flyteconsole/pull/235
