### PR TITLE
Changed the return order to prioritize literal maps over blobs

### DIFF
--- a/src/components/Literals/RemoteLiteralMapViewer.tsx
+++ b/src/components/Literals/RemoteLiteralMapViewer.tsx
@@ -30,16 +30,17 @@ export const RemoteLiteralMapViewer: React.FC<{
     blob: UrlBlob;
     map: LiteralMap | null;
 }> = ({ blob, map }) => {
+    /** Note: if full_outputs has a value, we want to use that first */
+    if (map != null) {
+        return <LiteralMapViewer map={map} />;
+    }
+
     if (!blob.url || !blob.bytes) {
         return (
             <p>
                 <em>No data is available.</em>
             </p>
         );
-    }
-
-    if (map != null) {
-        return <LiteralMapViewer map={map} />;
     }
 
     return blob.bytes.gt(maxBlobDownloadSizeBytes) ? (


### PR DESCRIPTION
Signed-off-by: Jason Porter <jason@union.ai>

This fix supports a recent change to admin where the default response for node_executions no longer defaults to type-blob.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The previous code would early exit if the value for blob was null.  Previously, FlyteAdmin would default to returning this value so this pattern was appropriate.  However, with the new change we now want to check if literalMap exists first and only progress to checking the blob if the literal map is null.

## Tracking Issue
_NA_

## Follow-up issue
_NA_
