### PR TITLE
minor: Use readable names for TaskNode display

### DIFF
--- a/src/components/Executions/ExecutionDetails/NodeExecutionDetailsPanelContent.tsx
+++ b/src/components/Executions/ExecutionDetails/NodeExecutionDetailsPanelContent.tsx
@@ -256,6 +256,11 @@ export const NodeExecutionDetailsPanelContent: React.FC<NodeExecutionDetailsProp
     ) : (
         <Skeleton />
     );
+    const displayName = detailsQuery.data ? (
+        detailsQuery.data.displayName
+    ) : (
+        <Skeleton />
+    );
     const taskTemplate = detailsQuery.data
         ? detailsQuery.data.taskTemplate
         : null;
@@ -343,7 +348,7 @@ export const NodeExecutionDetailsPanelContent: React.FC<NodeExecutionDetailsProp
                         variant="subtitle1"
                         color="textSecondary"
                     >
-                        {displayId}
+                        {displayName}
                     </Typography>
                     {statusContent}
                     {detailsContent}

--- a/src/components/Executions/Tables/nodeExecutionColumns.tsx
+++ b/src/components/Executions/Tables/nodeExecutionColumns.tsx
@@ -31,36 +31,45 @@ const NodeExecutionName: React.FC<NodeExecutionCellRendererData> = ({
     const detailsQuery = useNodeExecutionDetails(execution);
     const commonStyles = useCommonStyles();
     const styles = useColumnStyles();
-    const name = execution.id.nodeId;
+    const nodeId = execution.id.nodeId;
 
     const isSelected =
         state.selectedExecution != null &&
         isEqual(execution.id, state.selectedExecution);
 
-    const nameContent = isSelected ? (
-        <Typography variant="body1" className={styles.selectedExecutionName}>
-            {name}
-        </Typography>
-    ) : (
-        <SelectNodeExecutionLink
-            className={commonStyles.primaryLink}
-            execution={execution}
-            linkText={name}
-            state={state}
-        />
-    );
-
-    const renderNodeSpecName = ({ displayId }: NodeExecutionDetails) => (
-        <Typography variant="subtitle1" color="textSecondary">
-            {displayId}
-        </Typography>
-    );
+    const renderReadableName = ({
+        displayId,
+        displayName
+    }: NodeExecutionDetails) => {
+        const readableName = isSelected ? (
+            <Typography
+                variant="body1"
+                className={styles.selectedExecutionName}
+            >
+                {displayId || nodeId}
+            </Typography>
+        ) : (
+            <SelectNodeExecutionLink
+                className={commonStyles.primaryLink}
+                execution={execution}
+                linkText={displayId || nodeId}
+                state={state}
+            />
+        );
+        return (
+            <>
+                {readableName}
+                <Typography variant="subtitle1" color="textSecondary">
+                    {displayName}
+                </Typography>
+            </>
+        );
+    };
 
     return (
         <>
-            {nameContent}
             <WaitForQuery query={detailsQuery}>
-                {renderNodeSpecName}
+                {renderReadableName}
             </WaitForQuery>
         </>
     );

--- a/src/components/Executions/Tables/test/NodeExecutionsTable.test.tsx
+++ b/src/components/Executions/Tables/test/NodeExecutionsTable.test.tsx
@@ -413,14 +413,15 @@ describe('NodeExecutionsTable', () => {
             });
 
             it('correctly renders groups', async () => {
-                const parentNodeExecution =
+                const parentNodeId =
                     fixture.workflowExecutions.top.nodeExecutions
-                        .dynamicWorkflowGenerator.data;
+                        .dynamicWorkflowGenerator.data.metadata?.specNodeId ||
+                    'not found';
                 // We returned a single WF execution child, so there should only
                 // be one child group
                 const { container } = renderTable();
                 const nodeNameEl = await waitFor(() =>
-                    getByText(container, parentNodeExecution.id.nodeId)
+                    getByText(container, parentNodeId)
                 );
                 const rowEl = findNearestAncestorByRole(nodeNameEl, 'listitem');
                 const childGroups = await expandParentNode(rowEl);

--- a/src/components/Executions/types.ts
+++ b/src/components/Executions/types.ts
@@ -61,8 +61,9 @@ export interface WorkflowNodeExecution extends NodeExecution {
 }
 
 export interface NodeExecutionDetails {
+    displayId?: string;
+    displayName?: string;
     displayType: string;
-    displayId: string;
     taskTemplate?: TaskTemplate;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "jsx": "react",
-    "lib": ["es2015", "es2017", "dom", "dom.iterable"],
+    "lib": ["es2015", "es2017", "es2019", "dom", "dom.iterable"],
     "module": "commonjs",
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Signed-off-by: Fernando Diaz <fediazgon@gmail.com>


# TL;DR
As described in https://github.com/flyteorg/flyte/issues/1242. UI should show readable names to the user instead of execution ids.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

Currently, Flyte Console shows [NodeExecutionIdentifier#node_id](https://github.com/flyteorg/flyteidl/blob/master/protos/flyteidl/core/identifier.proto#L53) which can be auto-generated and not readable for the user. Instead, I propose to use (Compiled)[Node#id](https://github.com/flyteorg/flyteidl/blob/master/protos/flyteidl/core/workflow.proto#L103) which is usually set to a readable name and can be overriden the user (using `with_overrides(node_name=....`) in `flytekit-python` and `builder.apply(/*nodeId=*/...,...)` in `flytekit-java`.

I've also improved the lookup nodes code to also lookup for nodes inside branches.

This is the before and after for a complex workflow:

Before:

<img width="300" alt="Screenshot 2021-11-23 at 10 31 15" src="https://user-images.githubusercontent.com/12219405/143000710-a73ed1b1-d3c9-406b-9a50-d109b62a4073.png">

After

<img width="300" alt="Screenshot 2021-11-23 at 11 23 44" src="https://user-images.githubusercontent.com/12219405/143007684-b50cc35c-7413-4ee1-9bd5-049c132e73b1.png">


## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/1242

