### PR TITLE
Added documentation for running docker from localhost

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Sets the local endpoint for `CORS request proxying <cors-proxying_>`_.
 Running from docker image as localhost
 ======================================
 To run flyteconsole directly from your docker image as localhost you must set a
-few enviornment variables in your run command to setup the appliation.
+few environment variables in your run command to setup the appliation.
 
 ``BASE_URL="/console"`` (required)
 

--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,26 @@ usually not needed, so the default behavior is to run without a prefix.
 
 Sets the local endpoint for `CORS request proxying <cors-proxying_>`_.
 
+======================================
+Running from docker image as localhost
+======================================
+To run flyteconsole directly from your docker image as localhost you must set a
+few enviornment variables in your run command to setup the appliation.
+
+``BASE_URL="/console"`` (required)
+
+``CONFIG_DIR="/etc/flyte/config"`` (required)
+
+``DISABLE_AUTH="1"`` (optional)
+
+This example assumes building from ``v0.30.0`` on port ``8080``
+
+   .. code:: bash
+
+      docker run -p 8080:8080 -e BASE_URL="/console" -e CONFIG_DIR="/etc/flyte/config" -e DISABLE_AUTH="1" ghcr.io/flyteorg/flyteconsole:v0.30.0
+
+
+
 ===============
 Run the server
 ===============


### PR DESCRIPTION
This updates the documentation with instructions for how to run flyteconsole locally (localhost). 

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Updated docs

## Tracking Issue
_NA_

## Follow-up issue
_NA_
