### PR TITLE
feat: Remove disable auth var

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,6 @@ Quickstart
    .. code:: bash
 
        export ADMIN_API_URL=http://localhost:30081
-       export DISABLE_AUTH=1
 
    .. note::
 
@@ -217,7 +216,7 @@ URL of your target FlyteAdmin API instance. These instructions will use
 
 .. note:: Hint
 
-   Ensure you don't have `ADMIN_API_URL` or `DISABLE_AUTH` set (eg, in your `/.profile`.)
+   Ensure you don't have `ADMIN_API_URL` set (eg, in your `/.profile`.)
 
 =======
 Release

--- a/env.js
+++ b/env.js
@@ -23,16 +23,11 @@ const PLUGINS_MODULE = process.env.PLUGINS_MODULE;
 // If it has no protocol, it will be treated as relative to window.location.origin
 const STATUS_URL = process.env.STATUS_URL;
 
-// Disable all code related to authorization for requests to Admin.
-// This should only be used when Admin is also in unsecured mode.
-const DISABLE_AUTH = process.env.DISABLE_AUTH;
-
 module.exports = {
     ADMIN_API_URL,
     ADMIN_API_USE_SSL,
     BASE_URL,
     CORS_PROXY_PREFIX,
-    DISABLE_AUTH,
     NODE_ENV,
     PLUGINS_MODULE,
     STATUS_URL,
@@ -40,7 +35,6 @@ module.exports = {
         ADMIN_API_URL,
         BASE_URL,
         CORS_PROXY_PREFIX,
-        DISABLE_AUTH,
         NODE_ENV,
         STATUS_URL
     }

--- a/src/components/flytegraph/ReactFlow/ReactFlowGraphComponent.tsx
+++ b/src/components/flytegraph/ReactFlow/ReactFlowGraphComponent.tsx
@@ -16,7 +16,7 @@ const ReactFlowGraphComponent = props => {
         root: data,
         nodeExecutionsById: nodeExecutionsById,
         onNodeSelectionChanged: onNodeSelectionChanged,
-        maxRenderDepth: 2
+        maxRenderDepth: 1
     } as ConvertDagProps);
 
     const backgroundStyle = getRFBackground().nested;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -5,5 +5,4 @@ export interface Env extends NodeJS.ProcessEnv {
     DISABLE_ANALYTICS?: string;
     NODE_ENV?: 'development' | 'production';
     STATUS_URL?: string;
-    DISABLE_AUTH?: string;
 }

--- a/src/models/AdminEntity/AdminEntity.ts
+++ b/src/models/AdminEntity/AdminEntity.ts
@@ -47,7 +47,7 @@ async function request(
     const finalOptions = {
         ...options,
         url: adminApiUrl(endpoint),
-        withCredentials: !toBoolean(env.DISABLE_AUTH)
+        withCredentials: true
     };
 
     try {
@@ -73,7 +73,7 @@ export async function getProtobufObject<ResponseType>(
         headers,
         method: 'get',
         responseType: 'arraybuffer',
-        withCredentials: !toBoolean(env.DISABLE_AUTH)
+        withCredentials: true
     };
 
     const { data } = await axios.request(options);


### PR DESCRIPTION
This PR removes `DISABLE_AUTH`.

The reasoning behind this decision is that the app itself does not use this value and is simply pass along with requests to Admin as `withCredentials`. However, this value has consequence on the server side as it informs `Access-control`; specifically if cross domain cookies can be set which can cause issues when connecting to Admin (and has no affect otherwise). 

see: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials

Edit:
- This PR also includes a minor fix for displaying nested graphs

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Removes `DISABLE_AUTH` from flyteconsole.

## Tracking Issue
_NA_

## Follow-up issue
_NA_
