### PR TITLE
feat: Add support for securityContext in launch form.

### DIFF
--- a/src/components/Executions/ExecutionDetails/RelaunchExecutionForm.tsx
+++ b/src/components/Executions/ExecutionDetails/RelaunchExecutionForm.tsx
@@ -39,9 +39,12 @@ function useRelaunchWorkflowFormState({
                         disableAll,
                         maxParallelism,
                         labels,
-                        annotations
+                        annotations,
+                        authRole,
+                        securityContext
                     }
                 } = execution;
+
                 const workflow = await apiContext.getWorkflow(workflowId);
                 const inputDefinitions = getWorkflowInputs(workflow);
                 const values = await fetchAndMapExecutionInputValues(
@@ -51,6 +54,7 @@ function useRelaunchWorkflowFormState({
                     },
                     apiContext
                 );
+
                 return {
                     values,
                     launchPlan,
@@ -58,7 +62,9 @@ function useRelaunchWorkflowFormState({
                     disableAll,
                     maxParallelism,
                     labels,
-                    annotations
+                    annotations,
+                    authRole,
+                    securityContext
                 };
             }
         },
@@ -119,6 +125,7 @@ const RelaunchWorkflowForm: React.FC<RelaunchExecutionFormProps> = props => {
     const {
         closure: { workflowId }
     } = props.execution;
+
     return (
         <WaitForData {...initialParameters}>
             {initialParameters.state.matches(fetchStates.LOADED) ? (

--- a/src/components/Launch/LaunchForm/LaunchRoleInput.tsx
+++ b/src/components/Launch/LaunchForm/LaunchRoleInput.tsx
@@ -1,163 +1,25 @@
-import {
-    FormControl,
-    FormControlLabel,
-    FormLabel,
-    Radio,
-    RadioGroup,
-    TextField,
-    Typography
-} from '@material-ui/core';
-import { log } from 'common/log';
+import { TextField, Typography } from '@material-ui/core';
 import { NewTargetLink } from 'components/common/NewTargetLink';
-import { useDebouncedValue } from 'components/hooks/useDebouncedValue';
-import { Admin } from 'flyteidl';
 import * as React from 'react';
-import { launchInputDebouncDelay, roleTypes } from './constants';
+import { AuthRoleStrings } from './constants';
 import { makeStringChangeHandler } from './handlers';
-import { useInputValueCacheContext } from './inputValueCache';
 import { useStyles } from './styles';
-import { InputValueMap, LaunchRoleInputRef, RoleType } from './types';
+import { LaunchRoleInputRef, LaunchRoles } from './types';
+import { AuthRoleTypes } from './types';
 
-const roleHeader = 'Role';
-const roleDocLinkUrl =
-    'https://github.com/flyteorg/flyteidl/blob/3789005a1372221eba28fa20d8386e44b32388f5/protos/flyteidl/admin/common.proto#L241';
-const roleTypeLabel = 'type';
-const roleInputId = 'launch-auth-role';
-const defaultRoleTypeValue = roleTypes.iamRole;
+const docLink =
+    'https://github.com/flyteorg/flyteidl/blob/f4809c1a52073ec80de41be109bccc6331cdbac3/protos/flyteidl/core/security.proto#L111';
 
 export interface LaunchRoleInputProps {
-    initialValue?: Admin.IAuthRole;
+    initialValue?: any;
     showErrors: boolean;
 }
-
-interface LaunchRoleInputState {
-    error?: string;
-    roleType: RoleType;
-    roleString?: string;
-    getValue(): Admin.IAuthRole;
-    onChangeRoleString(newValue: string): void;
-    onChangeRoleType(newValue: string): void;
-    validate(): boolean;
-}
-
-function getRoleTypeByValue(value: string): RoleType | undefined {
-    return Object.values(roleTypes).find(
-        ({ value: roleTypeValue }) => value === roleTypeValue
-    );
-}
-
-const roleTypeCacheKey = '__roleType';
-const roleStringCacheKey = '__roleString';
-
-interface AuthRoleInitialValues {
-    roleType: RoleType;
-    roleString: string;
-}
-
-function getInitialValues(
-    cache: InputValueMap,
-    initialValue?: Admin.IAuthRole
-): AuthRoleInitialValues {
-    let roleType: RoleType | undefined;
-    let roleString: string | undefined;
-
-    // Prefer cached value first, since that is user input
-    if (cache.has(roleTypeCacheKey)) {
-        const cachedValue = `${cache.get(roleTypeCacheKey)}`;
-        roleType = getRoleTypeByValue(cachedValue);
-        if (roleType === undefined) {
-            log.error(`Unexepected cached role type: ${cachedValue}`);
-        }
-    }
-    if (cache.has(roleStringCacheKey)) {
-        roleString = cache.get(roleStringCacheKey)?.toString();
-    }
-
-    // After trying cache, check for an initial value and populate either
-    // field from the initial value if no cached value was passed.
-    if (initialValue != null) {
-        const initialRoleType = Object.values(roleTypes).find(
-            rt => initialValue[rt.value]
-        );
-        if (initialRoleType != null && roleType == null) {
-            roleType = initialRoleType;
-        }
-        if (initialRoleType != null && roleString == null) {
-            roleString = initialValue[initialRoleType.value]?.toString();
-        }
-    }
-
-    return {
-        roleType: roleType ?? defaultRoleTypeValue,
-        roleString: roleString ?? ''
-    };
-}
-
-export function useRoleInputState(
-    props: LaunchRoleInputProps
-): LaunchRoleInputState {
-    const inputValueCache = useInputValueCacheContext();
-    const initialValues = getInitialValues(inputValueCache, props.initialValue);
-
-    const [error, setError] = React.useState<string>();
-    const [roleString, setRoleString] = React.useState<string>(
-        initialValues.roleString
-    );
-
-    const [roleType, setRoleType] = React.useState<RoleType>(
-        initialValues.roleType
-    );
-
-    const validationValue = useDebouncedValue(
-        roleString,
-        launchInputDebouncDelay
-    );
-
-    const getValue = () => ({ [roleType.value]: roleString });
-    const validate = () => {
-        if (roleString == null || roleString.length === 0) {
-            setError('Value is required');
-            return false;
-        }
-        setError(undefined);
-        return true;
-    };
-
-    const onChangeRoleString = (value: string) => {
-        inputValueCache.set(roleStringCacheKey, value);
-        setRoleString(value);
-    };
-
-    const onChangeRoleType = (value: string) => {
-        const newRoleType = getRoleTypeByValue(value);
-        if (newRoleType === undefined) {
-            throw new Error(`Unexpected role type value: ${value}`);
-        }
-        inputValueCache.set(roleTypeCacheKey, value);
-        setRoleType(newRoleType);
-    };
-
-    React.useEffect(() => {
-        validate();
-    }, [validationValue]);
-
-    return {
-        error,
-        getValue,
-        onChangeRoleString,
-        onChangeRoleType,
-        roleType,
-        roleString,
-        validate
-    };
-}
-
 const RoleDescription = () => (
     <>
         <Typography variant="body2">
-            Enter a
-            <NewTargetLink inline={true} href={roleDocLinkUrl}>
-                &nbsp;role&nbsp;
+            Enter values for
+            <NewTargetLink inline={true} href={docLink}>
+                &nbsp;Security Context&nbsp;
             </NewTargetLink>
             to assume for this execution.
         </Typography>
@@ -168,64 +30,116 @@ export const LaunchRoleInputImpl: React.RefForwardingComponent<
     LaunchRoleInputRef,
     LaunchRoleInputProps
 > = (props, ref) => {
-    const styles = useStyles();
-    const {
-        error,
-        getValue,
-        roleType,
-        roleString = '',
-        onChangeRoleString,
-        onChangeRoleType,
-        validate
-    } = useRoleInputState(props);
-    const hasError = props.showErrors && !!error;
-    const helperText = hasError ? error : roleType.helperText;
+    const [state, setState] = React.useState({
+        [AuthRoleTypes.IAM]: '',
+        [AuthRoleTypes.k8]: ''
+    });
+
+    React.useEffect(() => {
+        /* Note: if errors are present in other form elements don't reload new values */
+        if (!props.showErrors) {
+            if (props.initialValue?.securityContext) {
+                setState(state => ({
+                    ...state,
+                    [AuthRoleTypes.IAM]:
+                        props.initialValue.securityContext.runAs?.iamRole || '',
+                    [AuthRoleTypes.k8]:
+                        props.initialValue.securityContext.runAs
+                            ?.k8sServiceAccount || ''
+                }));
+            } else if (props.initialValue) {
+                setState(state => ({
+                    ...state,
+                    [AuthRoleTypes.IAM]:
+                        props.initialValue?.assumableIamRole || '',
+                    [AuthRoleTypes.k8]:
+                        props.initialValue?.kubernetesServiceAccount || ''
+                }));
+            }
+        }
+    }, [props]);
+
+    const getValue = () => {
+        const authRole = {};
+        const securityContext = { runAs: {} };
+
+        if (state[AuthRoleTypes.k8].length > 0) {
+            authRole['kubernetesServiceAccount'] = state[AuthRoleTypes.k8];
+            securityContext['runAs']['k8sServiceAccount'] =
+                state[AuthRoleTypes.k8];
+        }
+
+        if (state[AuthRoleTypes.IAM].length > 0) {
+            authRole['assumableIamRole'] = state[AuthRoleTypes.IAM];
+            securityContext['runAs']['iamRole'] = state[AuthRoleTypes.IAM];
+        }
+        return { authRole, securityContext } as LaunchRoles;
+    };
+
+    const handleInputChange = (value, type) => {
+        setState(state => ({
+            ...state,
+            [type]: value
+        }));
+    };
 
     React.useImperativeHandle(ref, () => ({
         getValue,
-        validate
+        validate: () => true
     }));
+
+    const containerStyle: React.CSSProperties = {
+        padding: '0 .5rem'
+    };
+    const inputContainerStyle: React.CSSProperties = {
+        margin: '.5rem 0'
+    };
+    const styles = useStyles();
 
     return (
         <section>
             <header className={styles.sectionHeader}>
-                <Typography variant="h6">{roleHeader}</Typography>
+                <Typography variant="h6">Security Context</Typography>
                 <RoleDescription />
             </header>
-            <FormControl component="fieldset">
-                <FormLabel component="legend">{roleTypeLabel}</FormLabel>
-                <RadioGroup
-                    aria-label="roleType"
-                    name="roleType"
-                    value={roleType.value}
-                    row={true}
-                    onChange={makeStringChangeHandler(onChangeRoleType)}
-                >
-                    {Object.values(roleTypes).map(({ label, value }) => (
-                        <FormControlLabel
-                            key={value}
-                            value={value}
-                            control={<Radio />}
-                            label={label}
-                        />
-                    ))}
-                </RadioGroup>
-            </FormControl>
-            <div className={styles.formControl}>
+            <section style={containerStyle}>
+                <div style={inputContainerStyle}>
+                    <Typography variant="body1">
+                        {AuthRoleStrings[AuthRoleTypes.IAM].label}
+                    </Typography>
+                </div>
                 <TextField
-                    error={hasError}
-                    id={roleInputId}
-                    helperText={helperText}
+                    id={`launchform-role-${AuthRoleStrings[AuthRoleTypes.IAM]}`}
+                    helperText={AuthRoleStrings[AuthRoleTypes.IAM].helperText}
                     fullWidth={true}
-                    label={roleType.inputLabel}
-                    onChange={makeStringChangeHandler(onChangeRoleString)}
-                    value={roleString}
+                    label={AuthRoleStrings[AuthRoleTypes.IAM].inputLabel}
+                    value={state[AuthRoleTypes.IAM]}
                     variant="outlined"
+                    onChange={makeStringChangeHandler(
+                        handleInputChange,
+                        AuthRoleTypes.IAM
+                    )}
                 />
-            </div>
+                <div style={inputContainerStyle}>
+                    <Typography variant="body1">
+                        {AuthRoleStrings[AuthRoleTypes.k8].label}
+                    </Typography>
+                </div>
+                <TextField
+                    id={`launchform-role-${AuthRoleStrings[AuthRoleTypes.k8]}`}
+                    helperText={AuthRoleStrings[AuthRoleTypes.k8].helperText}
+                    fullWidth={true}
+                    label={AuthRoleStrings[AuthRoleTypes.k8].inputLabel}
+                    value={state[AuthRoleTypes.k8]}
+                    variant="outlined"
+                    onChange={makeStringChangeHandler(
+                        handleInputChange,
+                        AuthRoleTypes.k8
+                    )}
+                />
+            </section>
         </section>
     );
 };
 
-/** Renders controls for selecting an AuthRole type and inputting a value for it. */
 export const LaunchRoleInput = React.forwardRef(LaunchRoleInputImpl);

--- a/src/components/Launch/LaunchForm/LaunchRoleInput.tsx
+++ b/src/components/Launch/LaunchForm/LaunchRoleInput.tsx
@@ -109,9 +109,7 @@ export const LaunchRoleInputImpl: React.RefForwardingComponent<
                     </Typography>
                 </div>
                 <TextField
-                    id={`launchform-role-${
-                        AuthRoleStrings[AuthRoleTypes.IAM].inputLabel
-                    }`}
+                    id={`launchform-role-${AuthRoleTypes.IAM}`}
                     helperText={AuthRoleStrings[AuthRoleTypes.IAM].helperText}
                     fullWidth={true}
                     label={AuthRoleStrings[AuthRoleTypes.IAM].inputLabel}
@@ -128,9 +126,7 @@ export const LaunchRoleInputImpl: React.RefForwardingComponent<
                     </Typography>
                 </div>
                 <TextField
-                    id={`launchform-role-${
-                        AuthRoleStrings[AuthRoleTypes.k8].inputLabel
-                    }`}
+                    id={`launchform-role-${AuthRoleTypes.k8}`}
                     helperText={AuthRoleStrings[AuthRoleTypes.k8].helperText}
                     fullWidth={true}
                     label={AuthRoleStrings[AuthRoleTypes.k8].inputLabel}

--- a/src/components/Launch/LaunchForm/LaunchRoleInput.tsx
+++ b/src/components/Launch/LaunchForm/LaunchRoleInput.tsx
@@ -109,7 +109,9 @@ export const LaunchRoleInputImpl: React.RefForwardingComponent<
                     </Typography>
                 </div>
                 <TextField
-                    id={`launchform-role-${AuthRoleStrings[AuthRoleTypes.IAM]}`}
+                    id={`launchform-role-${
+                        AuthRoleStrings[AuthRoleTypes.IAM].inputLabel
+                    }`}
                     helperText={AuthRoleStrings[AuthRoleTypes.IAM].helperText}
                     fullWidth={true}
                     label={AuthRoleStrings[AuthRoleTypes.IAM].inputLabel}
@@ -126,7 +128,9 @@ export const LaunchRoleInputImpl: React.RefForwardingComponent<
                     </Typography>
                 </div>
                 <TextField
-                    id={`launchform-role-${AuthRoleStrings[AuthRoleTypes.k8]}`}
+                    id={`launchform-role-${
+                        AuthRoleStrings[AuthRoleTypes.k8].inputLabel
+                    }`}
                     helperText={AuthRoleStrings[AuthRoleTypes.k8].helperText}
                     fullWidth={true}
                     label={AuthRoleStrings[AuthRoleTypes.k8].inputLabel}

--- a/src/components/Launch/LaunchForm/LaunchTaskForm.tsx
+++ b/src/components/Launch/LaunchForm/LaunchTaskForm.tsx
@@ -51,6 +51,7 @@ export const LaunchTaskForm: React.FC<LaunchTaskFormProps> = props => {
     // TODO: We removed all loading indicators here. Decide if we want skeletons
     // instead.
     // https://github.com/lyft/flyte/issues/666
+
     return (
         <>
             <LaunchFormHeader title={state.context.sourceId?.name} />

--- a/src/components/Launch/LaunchForm/LaunchWorkflowForm.tsx
+++ b/src/components/Launch/LaunchForm/LaunchWorkflowForm.tsx
@@ -33,6 +33,7 @@ export const LaunchWorkflowForm: React.FC<LaunchWorkflowFormProps> = props => {
         service,
         workflowSourceSelectorState
     } = useLaunchWorkflowFormState(props);
+
     const styles = useStyles();
     const baseState = state as BaseInterpretedLaunchState;
     const baseService = service as BaseLaunchService;
@@ -64,9 +65,6 @@ export const LaunchWorkflowForm: React.FC<LaunchWorkflowFormProps> = props => {
             LaunchState.FAILED_LOADING_LAUNCH_PLANS
         ].some(state.matches);
 
-    // TODO: We removed all loading indicators here. Decide if we want skeletons
-    // instead.
-    // https://github.com/lyft/flyte/issues/666
     return (
         <>
             <LaunchFormHeader title={state.context.sourceId?.name} />
@@ -119,8 +117,10 @@ export const LaunchWorkflowForm: React.FC<LaunchWorkflowFormProps> = props => {
                         {isEnterInputsState(baseState) ? (
                             <LaunchRoleInput
                                 initialValue={
-                                    selectedLaunchPlan?.data.spec.authRole ||
-                                    state.context.defaultAuthRole
+                                    state.context.defaultAuthRole ||
+                                    selectedLaunchPlan?.data.spec
+                                        .securityContext ||
+                                    selectedLaunchPlan?.data.spec.authRole
                                 }
                                 ref={roleInputRef}
                                 showErrors={state.context.showErrors}

--- a/src/components/Launch/LaunchForm/constants.ts
+++ b/src/components/Launch/LaunchForm/constants.ts
@@ -12,22 +12,6 @@ export const formStrings = {
     launchPlan: 'Launch Plan'
 };
 
-// type RoleTypesKey = 'iamRole' | 'k8sServiceAccount';
-// export const roleTypes: { [k in RoleTypesKey]: RoleType } = {
-//     iamRole: {
-//         helperText: 'example: arn:aws:iam::12345678:role/defaultrole',
-//         inputLabel: 'role urn',
-//         label: 'IAM Role',
-//         value: 'assumableIamRole'
-//     },
-//     k8sServiceAccount: {
-//         helperText: 'example: default-service-account',
-//         inputLabel: 'service account name',
-//         label: 'Kubernetes Service Account',
-//         value: 'kubernetesServiceAccount'
-//     }
-// };
-
 export const AuthRoleStrings: { [k in AuthRoleTypes]: AuthRoleMeta } = {
     [AuthRoleTypes.k8]: {
         helperText: 'example: default-service-account',

--- a/src/components/Launch/LaunchForm/constants.ts
+++ b/src/components/Launch/LaunchForm/constants.ts
@@ -1,5 +1,11 @@
 import { BlobDimensionality, SimpleType } from 'models/Common/types';
-import { BlobValue, InputType, RoleType } from './types';
+import {
+    BlobValue,
+    InputType,
+    RoleType,
+    AuthRoleTypes,
+    AuthRoleMeta
+} from './types';
 
 export const formStrings = {
     cancel: 'Cancel',
@@ -25,6 +31,21 @@ export const roleTypes: { [k in RoleTypesKey]: RoleType } = {
         inputLabel: 'service account name',
         label: 'Kubernetes Service Account',
         value: 'kubernetesServiceAccount'
+    }
+};
+
+export const AuthRoleStrings: { [k in AuthRoleTypes]: AuthRoleMeta } = {
+    [AuthRoleTypes.k8]: {
+        helperText: 'example: default-service-account',
+        inputLabel: 'service account name',
+        label: 'Kubernetes Service Account',
+        value: 'kubernetesServiceAccount'
+    },
+    [AuthRoleTypes.IAM]: {
+        helperText: 'example: arn:aws:iam::12345678:role/defaultrole',
+        inputLabel: 'role urn',
+        label: 'IAM Role',
+        value: 'assumableIamRole'
     }
 };
 

--- a/src/components/Launch/LaunchForm/constants.ts
+++ b/src/components/Launch/LaunchForm/constants.ts
@@ -1,11 +1,5 @@
 import { BlobDimensionality, SimpleType } from 'models/Common/types';
-import {
-    BlobValue,
-    InputType,
-    RoleType,
-    AuthRoleTypes,
-    AuthRoleMeta
-} from './types';
+import { BlobValue, InputType, AuthRoleTypes, AuthRoleMeta } from './types';
 
 export const formStrings = {
     cancel: 'Cancel',
@@ -18,21 +12,21 @@ export const formStrings = {
     launchPlan: 'Launch Plan'
 };
 
-type RoleTypesKey = 'iamRole' | 'k8sServiceAccount';
-export const roleTypes: { [k in RoleTypesKey]: RoleType } = {
-    iamRole: {
-        helperText: 'example: arn:aws:iam::12345678:role/defaultrole',
-        inputLabel: 'role urn',
-        label: 'IAM Role',
-        value: 'assumableIamRole'
-    },
-    k8sServiceAccount: {
-        helperText: 'example: default-service-account',
-        inputLabel: 'service account name',
-        label: 'Kubernetes Service Account',
-        value: 'kubernetesServiceAccount'
-    }
-};
+// type RoleTypesKey = 'iamRole' | 'k8sServiceAccount';
+// export const roleTypes: { [k in RoleTypesKey]: RoleType } = {
+//     iamRole: {
+//         helperText: 'example: arn:aws:iam::12345678:role/defaultrole',
+//         inputLabel: 'role urn',
+//         label: 'IAM Role',
+//         value: 'assumableIamRole'
+//     },
+//     k8sServiceAccount: {
+//         helperText: 'example: default-service-account',
+//         inputLabel: 'service account name',
+//         label: 'Kubernetes Service Account',
+//         value: 'kubernetesServiceAccount'
+//     }
+// };
 
 export const AuthRoleStrings: { [k in AuthRoleTypes]: AuthRoleMeta } = {
     [AuthRoleTypes.k8]: {

--- a/src/components/Launch/LaunchForm/handlers.ts
+++ b/src/components/Launch/LaunchForm/handlers.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { InputChangeHandler } from './types';
+import { AuthRoleTypes, InputChangeHandler } from './types';
 
 export function makeSwitchChangeHandler(onChange: InputChangeHandler) {
     return ({ target: { checked } }: React.ChangeEvent<HTMLInputElement>) => {
@@ -7,11 +7,15 @@ export function makeSwitchChangeHandler(onChange: InputChangeHandler) {
     };
 }
 
-type StringChangeHandler = (value: string) => void;
+type StringChangeHandler = (
+    value: string,
+    roleType: AuthRoleTypes | null
+) => void;
 export function makeStringChangeHandler(
-    onChange: InputChangeHandler | StringChangeHandler
+    onChange: StringChangeHandler | InputChangeHandler,
+    roleType: AuthRoleTypes | null = null
 ) {
     return ({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => {
-        onChange(value);
+        onChange(value, roleType);
     };
 }

--- a/src/components/Launch/LaunchForm/launchMachine.ts
+++ b/src/components/Launch/LaunchForm/launchMachine.ts
@@ -82,6 +82,7 @@ export interface WorkflowLaunchContext extends BaseLaunchContext {
     maxParallelism?: number | null;
     labels?: Admin.ILabels | null;
     annotations?: Admin.IAnnotations | null;
+    securityContext?: Core.ISecurityContext | null;
 }
 
 export interface TaskLaunchContext extends BaseLaunchContext {

--- a/src/components/Launch/LaunchForm/types.ts
+++ b/src/components/Launch/LaunchForm/types.ts
@@ -71,6 +71,7 @@ export interface TaskInitialLaunchParameters
     extends BaseInitialLaunchParameters {
     taskId?: Identifier;
     authRole?: Admin.IAuthRole;
+    securityContext?: Core.ISecurityContext;
 }
 export interface LaunchTaskFormProps extends BaseLaunchFormProps {
     taskId: NamedEntityIdentifier;

--- a/src/components/Launch/LaunchForm/types.ts
+++ b/src/components/Launch/LaunchForm/types.ts
@@ -55,11 +55,13 @@ export interface WorkflowInitialLaunchParameters
     launchPlan?: Identifier;
     workflowId?: WorkflowId;
     authRole?: Admin.IAuthRole;
+    securityContext?: Core.ISecurityContext;
     disableAll?: boolean | null;
     maxParallelism?: number | null;
     labels?: Admin.ILabels | null;
     annotations?: Admin.IAnnotations | null;
 }
+
 export interface LaunchWorkflowFormProps extends BaseLaunchFormProps {
     workflowId: NamedEntityIdentifier;
     initialParameters?: WorkflowInitialLaunchParameters;
@@ -86,8 +88,14 @@ export interface LaunchFormInputsRef {
     getValues(): Record<string, Core.ILiteral>;
     validate(): boolean;
 }
+
+export interface LaunchRoles {
+    authRole?: Admin.IAuthRole;
+    securityContext?: Core.ISecurityContext;
+}
+
 export interface LaunchRoleInputRef {
-    getValue(): Admin.IAuthRole;
+    getValue(): LaunchRoles;
     validate(): boolean;
 }
 export interface LaunchAdvancedOptionsRef {
@@ -204,6 +212,20 @@ export interface ParsedInput
     > {
     /** Provides an initial value for the input, which can be changed by the user. */
     initialValue?: Core.ILiteral;
+}
+
+export enum AuthRoleTypes {
+    k8 = 'k8',
+    IAM = 'IAM'
+}
+
+export interface AuthRoleMeta {
+    helperText: string;
+    inputLabel: string;
+    label: string;
+    value: RoleTypeValue;
+    validate?: any;
+    error?: any;
 }
 
 export type RoleTypeValue = keyof Admin.IAuthRole;

--- a/src/components/Launch/LaunchForm/useLaunchTaskFormState.ts
+++ b/src/components/Launch/LaunchForm/useLaunchTaskFormState.ts
@@ -122,13 +122,14 @@ async function submit(
         throw new Error('Unexpected empty role input ref');
     }
 
-    const authRole = roleInputRef.current.getValue();
+    const { authRole, securityContext } = roleInputRef.current?.getValue();
     const literals = formInputsRef.current.getValues();
     const launchPlanId = taskVersion;
     const { domain, project } = taskVersion;
 
     const response = await createWorkflowExecution({
         authRole,
+        securityContext,
         domain,
         launchPlanId,
         project,

--- a/src/components/Launch/LaunchForm/useLaunchWorkflowFormState.ts
+++ b/src/components/Launch/LaunchForm/useLaunchWorkflowFormState.ts
@@ -23,11 +23,11 @@ import {
     LaunchAdvancedOptionsRef,
     LaunchWorkflowFormProps,
     LaunchWorkflowFormState,
-    ParsedInput
+    ParsedInput,
+    LaunchRoles
 } from './types';
 import { useWorkflowSourceSelectorState } from './useWorkflowSourceSelectorState';
 import { getUnsupportedRequiredInputs } from './utils';
-import { correctInputErrors } from './constants';
 
 async function loadLaunchPlans(
     { listLaunchPlans }: APIContextValue,
@@ -171,14 +171,11 @@ async function submit(
     if (formInputsRef.current === null) {
         throw new Error('Unexpected empty form inputs ref');
     }
-    // if (roleInputRef.current === null) {
-    //     throw new Error('Unexpected empty role input ref');
-    // }
-    // if (advancedOptionsRef.current === null) {
-    //     throw new Error('Unexpected empty advanced options ref');
-    // }
 
-    const authRole = roleInputRef.current?.getValue();
+    const {
+        authRole,
+        securityContext
+    } = roleInputRef.current?.getValue() as LaunchRoles;
     const literals = formInputsRef.current.getValues();
     const { disableAll, labels, annotations, maxParallelism } =
         advancedOptionsRef.current?.getValues() || {};
@@ -188,6 +185,7 @@ async function submit(
     const response = await createWorkflowExecution({
         annotations,
         authRole,
+        securityContext,
         disableAll,
         maxParallelism,
         domain,
@@ -264,7 +262,8 @@ export function useLaunchWorkflowFormState({
         disableAll,
         maxParallelism,
         labels,
-        annotations
+        annotations,
+        securityContext
     } = initialParameters;
 
     const apiContext = useAPIContext();
@@ -292,6 +291,7 @@ export function useLaunchWorkflowFormState({
         services,
         context: {
             defaultAuthRole,
+            securityContext,
             defaultInputValues,
             preferredLaunchPlanId,
             preferredWorkflowId,

--- a/src/models/Execution/api.ts
+++ b/src/models/Execution/api.ts
@@ -94,6 +94,7 @@ export const getExecutionData = (
 export interface CreateWorkflowExecutionArguments {
     annotations?: Admin.IAnnotations | null;
     authRole?: Admin.IAuthRole;
+    securityContext?: Core.ISecurityContext;
     domain: string;
     disableAll?: boolean | null;
     labels?: Admin.ILabels | null;
@@ -110,6 +111,7 @@ export const createWorkflowExecution = (
     {
         annotations,
         authRole,
+        securityContext,
         domain,
         disableAll,
         labels,
@@ -131,15 +133,26 @@ export const createWorkflowExecution = (
         labels,
         annotations
     };
+
     if (authRole?.assumableIamRole || authRole?.kubernetesServiceAccount) {
         spec.authRole = authRole;
     }
+
+    if (
+        securityContext?.runAs?.iamRole ||
+        securityContext?.runAs?.k8sServiceAccount
+    ) {
+        spec.securityContext = securityContext;
+    }
+
     if (disableAll) {
         spec.disableAll = disableAll;
     }
+
     if (maxParallelism !== undefined) {
         spec.maxParallelism = maxParallelism;
     }
+
     return postAdminEntity<
         Admin.IExecutionCreateRequest,
         Admin.ExecutionCreateResponse

--- a/src/models/Execution/types.ts
+++ b/src/models/Execution/types.ts
@@ -46,6 +46,7 @@ export interface ExecutionMetadata extends Admin.IExecutionMetadata {
 
 export interface ExecutionSpec extends Admin.IExecutionSpec {
     authRole?: Admin.IAuthRole;
+    securityContext?: Core.ISecurityContext;
     inputs: LiteralMap;
     launchPlan: Identifier;
     metadata: ExecutionMetadata;


### PR DESCRIPTION
This PR adds support for `securityContext` in Admin requests.  Currently this feature is not fully rolled out but this change will support both `authRole` and `securityContext` during the migration to prevent any breaking changes. The change will appear on Launch/Relaunch/Recover actions. This change also removes the either/or toggle between K8 and IAM roles - now users can enter both/either/none. 

see: https://github.com/flyteorg/flyteidl/blob/f4809c1a52073ec80de41be109bccc6331cdbac3/protos/flyteidl/core/security.proto#L111

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
FlyteAdmin is planning to migrate to using `securityContext` in the future however to support older versions of Admin we will send and receive both values for the time being.

## Tracking Issue
_NA_

## Follow-up issue
_NA_
