### PR TITLE
Fix: Fixed missing Authrole values on ExecutionMetaDataExtra

### DIFF
--- a/src/components/Executions/ExecutionDetails/ExecutionMetadataExtra.tsx
+++ b/src/components/Executions/ExecutionDetails/ExecutionMetadataExtra.tsx
@@ -34,7 +34,12 @@ export const ExecutionMetadataExtra: React.FC<{
     const commonStyles = useCommonStyles();
     const styles = useStyles();
 
-    const { launchPlan: launchPlanId, maxParallelism } = execution.spec;
+    const {
+        launchPlan: launchPlanId,
+        maxParallelism,
+        authRole
+    } = execution.spec;
+
     const [launchPlanSpec, setLaunchPlanSpec] = React.useState<
         Partial<LaunchPlanSpec>
     >({});
@@ -45,8 +50,16 @@ export const ExecutionMetadataExtra: React.FC<{
 
     const details: DetailItem[] = [
         {
+            label: ExecutionMetadataLabels.iam,
+            value:
+                authRole?.assumableIamRole ||
+                ExecutionMetadataLabels.securityContextDefault
+        },
+        {
             label: ExecutionMetadataLabels.serviceAccount,
-            value: launchPlanSpec?.authRole?.kubernetesServiceAccount
+            value:
+                authRole?.kubernetesServiceAccount ||
+                ExecutionMetadataLabels.securityContextDefault
         },
         {
             label: ExecutionMetadataLabels.rawOutputPrefix,

--- a/src/components/Executions/ExecutionDetails/constants.ts
+++ b/src/components/Executions/ExecutionDetails/constants.ts
@@ -6,8 +6,10 @@ export enum ExecutionMetadataLabels {
     relatedTo = 'Related to',
     version = 'Version',
     serviceAccount = 'Service Account',
+    iam = 'IAM Role',
     rawOutputPrefix = 'Raw Output Prefix',
-    parallelism = 'Parallelism'
+    parallelism = 'Parallelism',
+    securityContextDefault = 'default'
 }
 
 export const tabs = {


### PR DESCRIPTION
This fix addresses a bug where authRole values would be missing from ExecutionData header.  This fix also includes adding both IAM and k8 values. 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Values for authRole of an execution will not be returned with getLaunchPlan(); this fix correctly uses the execution.spec to populate those values.

## Tracking Issue
_NA_

## Follow-up issue
_NA_
