### PR TITLE
feat: handle 'Aborting' workflow execution phases

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-conventional": "^8.3.4",
     "@date-io/moment": "1.3.9",
-    "@flyteorg/flyteidl": "0.21.10",
+    "@flyteorg/flyteidl": "0.21.16",
     "@material-ui/core": "^4.0.0",
     "@material-ui/icons": "^4.0.0",
     "@material-ui/pickers": "^3.2.2",

--- a/src/components/Executions/constants.ts
+++ b/src/components/Executions/constants.ts
@@ -25,6 +25,11 @@ export const workflowExecutionPhaseConstants: {
         text: 'Aborted',
         textColor: negativeTextColor
     },
+    [WorkflowExecutionPhase.ABORTING]: {
+        badgeColor: statusColors.SKIPPED,
+        text: 'Aborting',
+        textColor: negativeTextColor
+    },
     [WorkflowExecutionPhase.FAILING]: {
         badgeColor: statusColors.FAILURE,
         text: 'Failing',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1377,10 +1377,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@flyteorg/flyteidl@0.21.10":
-  version "0.21.10"
-  resolved "https://registry.yarnpkg.com/@flyteorg/flyteidl/-/flyteidl-0.21.10.tgz#b5fc60aa33a9f2ca56e066e3a1ab8750894b8ae0"
-  integrity sha512-9ykCwIrCs9PKHOSZZK0cAha/P+n2XDR0hEvVY4h6xOiUw3rVJmSCxKiAvRSp2hGgLXK9ZFnFhCgUXwkB1O1epQ==
+"@flyteorg/flyteidl@0.21.16":
+  version "0.21.16"
+  resolved "https://registry.yarnpkg.com/@flyteorg/flyteidl/-/flyteidl-0.21.16.tgz#3feece4565bcae532a6de5641b2f8cc763a26e88"
+  integrity sha512-yYi0IrDj2WhpLaCcw4AmLTpcVeVcJ9n6UQEei5WJjDodl+v+KZY6348/yTRE+iFXsQUzUSoEAjFnanYyaveSMA==
 
 "@iarna/cli@^1.2.0":
   version "1.2.0"


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
Workflow executions now transition from 'running' -> 'aborting' -> 'aborted'. This change handles rendering the 'aborting' phase.

Note: I wasn't sure whether it was worth updating the [workflow status filters](https://github.com/flyteorg/flyteconsole/blob/master/src/components/Executions/filters/statusFilters.ts#L7) since this phase is transitive and ideally short-lived

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
See linked issue below.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1978

## Follow-up issue
_NA_
