### PR TITLE
chore: cleanup eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,12 +16,21 @@ module.exports = {
         'prettier/@typescript-eslint'
     ],
     rules: {
-        'no-case-declarations': 'warn',
+        // Rules we don't want to be enabled
+        'no-unused-vars': 'off', // disabled to let "@typescript-eslint/no-unused-vars" do it's job
+        '@typescript-eslint/no-unused-vars': [
+            'warn',
+            { argsIgnorePattern: '^_' }
+        ],
         'jest/no-mocks-import': 'off',
-        'jest/valid-title': 'off',
-        '@typescript-eslint/no-var-requires': 'off',
-        '@typescript-eslint/ban-types': 'warn',
-        '@typescript-eslint/no-empty-function': 'warn',
-        '@typescript-eslint/explicit-module-boundary-types': 'off'
+
+        // temporarily disabled
+        '@typescript-eslint/no-var-requires': 'off', // 27
+        '@typescript-eslint/ban-types': 'warn', // 62
+        '@typescript-eslint/no-empty-function': 'warn', // 60
+        '@typescript-eslint/explicit-module-boundary-types': 'off', // 296
+        '@typescript-eslint/no-explicit-any': 'warn', // 134
+        '@typescript-eslint/no-non-null-assertion': 'warn', // 59
+        'react-hooks/exhaustive-deps': 'warn' // 24
     }
 };

--- a/src/components/Executions/ExecutionDetails/NodeExecutionDetailsPanelContent.tsx
+++ b/src/components/Executions/ExecutionDetails/NodeExecutionDetailsPanelContent.tsx
@@ -348,11 +348,6 @@ export const NodeExecutionDetailsPanelContent: React.FC<NodeExecutionDetailsProp
     const commonStyles = useCommonStyles();
     const styles = useStyles();
     const detailsQuery = useNodeExecutionDetails(nodeExecution);
-    const displayId = detailsQuery.data ? (
-        detailsQuery.data.displayId
-    ) : (
-        <Skeleton />
-    );
     const displayName = detailsQuery.data ? (
         detailsQuery.data.displayName
     ) : (

--- a/src/components/Executions/ExecutionDetails/test/ExecutionDetailsAppBarContent.test.tsx
+++ b/src/components/Executions/ExecutionDetails/test/ExecutionDetailsAppBarContent.test.tsx
@@ -60,7 +60,7 @@ describe('ExecutionDetailsAppBarContent', () => {
 
         it('renders an overflow menu', async () => {
             const { getByLabelText } = renderContent();
-            await waitFor(() => getByLabelText(commonLabels.moreOptionsButton));
+            expect(getByLabelText(commonLabels.moreOptionsButton)).toBeTruthy();
         });
 
         describe('in overflow menu', () => {

--- a/src/components/Executions/ExecutionDetails/test/RelaunchExecutionForm.test.tsx
+++ b/src/components/Executions/ExecutionDetails/test/RelaunchExecutionForm.test.tsx
@@ -116,9 +116,9 @@ describe('RelaunchExecutionForm', () => {
 
     it('passes original execution as a referenceExecution', async () => {
         const { getByText } = renderForm();
-        await waitFor(() => getByText(mockContentString));
+        await waitFor(() => expect(getByText(mockContentString)).toBeDefined());
         checkLaunchFormProps({
-            referenceExecutionId: execution.id
+            referenceExecutionId: expect.objectContaining(execution.id)
         });
     });
 
@@ -152,9 +152,11 @@ describe('RelaunchExecutionForm', () => {
 
         it('passes workflowId to LaunchForm', async () => {
             const { getByText } = renderForm();
-            await waitFor(() => getByText(mockContentString));
+            await waitFor(() => expect(getByText(mockContentString)));
             checkLaunchFormProps({
-                workflowId: execution.closure.workflowId
+                workflowId: expect.objectContaining(
+                    execution.closure.workflowId
+                )
             });
         });
 
@@ -256,10 +258,12 @@ describe('RelaunchExecutionForm', () => {
         });
 
         it('passes taskId to LaunchForm', async () => {
-            const { getByText } = renderForm();
-            await waitFor(() => getByText(mockContentString));
+            renderForm();
+            await waitFor(() => {
+                /**/
+            });
             checkLaunchFormProps({
-                taskId: execution.spec.launchPlan
+                taskId: expect.objectContaining(execution.spec.launchPlan)
             });
         });
 

--- a/src/components/Executions/Tables/test/NodeExecutionsTable.test.tsx
+++ b/src/components/Executions/Tables/test/NodeExecutionsTable.test.tsx
@@ -333,7 +333,7 @@ describe('NodeExecutionsTable', () => {
             });
         });
 
-        describe('without isParentNode flag, using taskNodeMetadata ', () => {
+        describe('without isParentNode flag, using taskNodeMetadata', () => {
             let fixture: ReturnType<typeof dynamicPythonTaskWorkflow.generate>;
             beforeEach(() => {
                 fixture = dynamicPythonTaskWorkflow.generate();

--- a/src/components/Executions/useNodeExecutionDetails.ts
+++ b/src/components/Executions/useNodeExecutionDetails.ts
@@ -5,11 +5,9 @@ import { fetchWorkflow } from 'components/Workflow/workflowQueries';
 import { Identifier } from 'models/Common/types';
 import { NodeExecution } from 'models/Execution/types';
 import { CompiledNode } from 'models/Node/types';
-import { TaskType } from 'models/Task/constants';
 import { TaskTemplate } from 'models/Task/types';
 import { CompiledWorkflow, Workflow } from 'models/Workflow/types';
 import { QueryClient, useQuery, useQueryClient } from 'react-query';
-import { taskTypeToNodeExecutionDisplayType } from './constants';
 import { fetchTaskExecutionList } from './taskExecutionQueries';
 import {
     CompiledBranchNode,

--- a/src/components/Launch/LaunchForm/LaunchFormAdvancedInputs.tsx
+++ b/src/components/Launch/LaunchForm/LaunchFormAdvancedInputs.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Admin } from 'flyteidl';
 import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles';
 import Accordion from '@material-ui/core/Accordion';
 import AccordionSummary from '@material-ui/core/AccordionSummary';

--- a/src/components/Launch/LaunchForm/SimpleInput.tsx
+++ b/src/components/Launch/LaunchForm/SimpleInput.tsx
@@ -15,7 +15,7 @@ import { InputProps, InputType } from './types';
 import { UnsupportedInput } from './UnsupportedInput';
 import { getLaunchInputId } from './utils';
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles(() => ({
     formControl: {
         minWidth: '100%'
     }

--- a/src/components/Launch/LaunchForm/StructInput.tsx
+++ b/src/components/Launch/LaunchForm/StructInput.tsx
@@ -86,7 +86,7 @@ export const StructInput: React.FC<InputProps> = props => {
         jsonFormRenderable && value ? JSON.parse(value as string) : {}
     );
 
-    const onFormChange = ({ formData }, e) => {
+    const onFormChange = ({ formData }, _e) => {
         onChange(JSON.stringify(formData));
         setParamData(formData);
     };

--- a/src/components/Launch/LaunchForm/inputHelpers/test/utils.test.ts
+++ b/src/components/Launch/LaunchForm/inputHelpers/test/utils.test.ts
@@ -49,6 +49,7 @@ describe('Launch/inputHelpers/utils', () => {
         ];
 
         cases.forEach(([description, value, expected]) =>
+            // eslint-disable-next-line jest/valid-title
             it(description, () => expect(typeIsSupported(value)).toBe(expected))
         );
     });

--- a/src/components/Launch/LaunchForm/test/LaunchTaskForm.test.tsx
+++ b/src/components/Launch/LaunchForm/test/LaunchTaskForm.test.tsx
@@ -12,17 +12,14 @@ import { APIContext } from 'components/data/apiContext';
 import { mockAPIContextValue } from 'components/data/__mocks__/apiContext';
 import { muiTheme } from 'components/Theme/muiTheme';
 import { Core } from 'flyteidl';
-import { cloneDeep, get } from 'lodash';
+import { cloneDeep } from 'lodash';
 import { RequestConfig } from 'models/AdminEntity/types';
 import {
     Identifier,
     NamedEntityIdentifier,
     Variable
 } from 'models/Common/types';
-import {
-    createWorkflowExecution,
-    CreateWorkflowExecutionArguments
-} from 'models/Execution/api';
+import { createWorkflowExecution } from 'models/Execution/api';
 import { getTask, listTasks } from 'models/Task/api';
 import { Task } from 'models/Task/types';
 import { createMockTaskClosure } from 'models/__mocks__/taskData';
@@ -50,11 +47,9 @@ import {
 } from '../__mocks__/mockInputs';
 import {
     binaryInputName,
-    booleanInputName,
     floatInputName,
     iamRoleString,
     integerInputName,
-    k8sServiceAccountString,
     stringInputName
 } from './constants';
 import { createMockObjects } from './utils';

--- a/src/components/Launch/LaunchForm/utils.ts
+++ b/src/components/Launch/LaunchForm/utils.ts
@@ -100,7 +100,7 @@ export function formatLabelWithType(label: string, type: InputTypeDefinition) {
 export function versionsToSearchableSelectorOptions(
     items: SearchableVersion[]
 ): SearchableSelectorOption<Identifier>[] {
-    return items.map<SearchableSelectorOption<Identifier>>((item, index) => ({
+    return items.map<SearchableSelectorOption<Identifier>>((item, _index) => ({
         data: item.id,
         id: item.id.version,
         name: item.id.version,

--- a/src/components/Literals/Scalar/ProtobufStructValue.tsx
+++ b/src/components/Literals/Scalar/ProtobufStructValue.tsx
@@ -27,7 +27,7 @@ const RenderedProtobufValue: React.FC<{
     switch (value.kind) {
         case 'nullValue':
             return <PrintValue label={label} value={<NoneTypeValue />} />;
-        case 'listValue':
+        case 'listValue': {
             const list = value.listValue as ProtobufListValue;
             return (
                 <>
@@ -38,6 +38,7 @@ const RenderedProtobufValue: React.FC<{
                     />
                 </>
             );
+        }
         case 'structValue':
             return (
                 <>

--- a/src/components/Notifications/SystemStatusBanner.tsx
+++ b/src/components/Notifications/SystemStatusBanner.tsx
@@ -1,4 +1,4 @@
-import { ButtonBase, SvgIcon, Typography } from '@material-ui/core';
+import { ButtonBase, Typography } from '@material-ui/core';
 import Paper from '@material-ui/core/Paper';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import Close from '@material-ui/icons/Close';
@@ -68,11 +68,6 @@ const useStyles = makeStyles((theme: Theme) => ({
         marginRight: theme.spacing(2)
     }
 }));
-
-interface StatusConstantValues {
-    color: string;
-    IconComponent: typeof SvgIcon;
-}
 
 const InfoIcon = () => (
     <Info data-testid="info-icon" htmlColor={infoIconColor} />

--- a/src/components/common/Shimmer.tsx
+++ b/src/components/common/Shimmer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles(() => ({
     animate: {
         height: 10,
         animation: '$shimmer 4s infinite linear',

--- a/src/components/common/__stories__/ButtonCircularProgress.stories.tsx
+++ b/src/components/common/__stories__/ButtonCircularProgress.stories.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@material-ui/core';
-import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
 import { basicStoryContainer } from '__stories__/decorators';
 import * as React from 'react';

--- a/src/components/common/test/MoreOptionsMenu.test.tsx
+++ b/src/components/common/test/MoreOptionsMenu.test.tsx
@@ -37,7 +37,8 @@ describe('MoreOptionsMenu', () => {
     };
 
     it('shows menu when button is clicked', async () => {
-        await getMenu(renderMenu());
+        const menuEl = await getMenu(renderMenu());
+        expect(getByText(menuEl, options[0].label)).toBeInTheDocument();
     });
 
     it('renders element for each option', async () => {
@@ -58,15 +59,21 @@ describe('MoreOptionsMenu', () => {
     it('hides menu when item is selected', async () => {
         const result = renderMenu();
         const menuEl = await getMenu(result);
+        expect(getByText(menuEl, options[0].label)).toBeInTheDocument();
+
         const itemEl = getByText(menuEl, options[0].label);
         fireEvent.click(itemEl);
         await waitForElementToBeRemoved(menuEl);
+        expect(getByText(menuEl, options[0].label)).not.toBeInTheDocument();
     });
 
     it('hides menu on escape', async () => {
         const result = renderMenu();
         const menuEl = await getMenu(result);
+        expect(getByText(menuEl, options[0].label)).toBeInTheDocument();
+
         fireEvent.keyDown(menuEl, { key: 'Escape', code: 'Escape' });
         await waitForElementToBeRemoved(menuEl);
+        expect(getByText(menuEl, options[0].label)).not.toBeInTheDocument();
     });
 });

--- a/src/components/common/test/SearchableList.spec.tsx
+++ b/src/components/common/test/SearchableList.spec.tsx
@@ -68,6 +68,7 @@ describe('SearchableList', () => {
                 ? `should match ${expectedValues} with input ${input}`
                 : `should have no matches for input ${input}`;
 
+            // eslint-disable-next-line jest/valid-title
             it(expectString, () => {
                 const {
                     getByRole,

--- a/src/components/flytegraph/ReactFlow/customNodeComponents.tsx
+++ b/src/components/flytegraph/ReactFlow/customNodeComponents.tsx
@@ -279,7 +279,7 @@ export const ReactFlowCustomTaskNode = ({ data }: any) => {
         fontSize: '.3rem'
     };
 
-    const handleClick = e => {
+    const handleClick = _e => {
         setSelectedNode(true);
     };
 

--- a/src/components/hooks/__mocks__/fetchableData.ts
+++ b/src/components/hooks/__mocks__/fetchableData.ts
@@ -1,5 +1,5 @@
 import { State } from 'xstate';
-import { FetchableData, FetchFn, fetchStates } from '../types';
+import { FetchableData, fetchStates } from '../types';
 
 export function createMockFetchable<T>(
     value: any,

--- a/src/components/hooks/test/useFetchableData.test.tsx
+++ b/src/components/hooks/test/useFetchableData.test.tsx
@@ -1,5 +1,4 @@
 import {
-    act,
     fireEvent,
     getByLabelText,
     render,

--- a/src/components/hooks/test/utils.test.ts
+++ b/src/components/hooks/test/utils.test.ts
@@ -53,7 +53,7 @@ describe('hooks/utils', () => {
 
         it('assigns parent workflow id to subworkflow nodes', () => {
             const nodes = extractAndIdentifyNodes(workflow);
-            subWorkflow.template.nodes.forEach(node =>
+            subWorkflow.template.nodes.forEach(_node =>
                 expect(nodes).toContainEqual(
                     expect.objectContaining({
                         id: {

--- a/src/models/AdminEntity/AdminEntity.ts
+++ b/src/models/AdminEntity/AdminEntity.ts
@@ -1,9 +1,5 @@
 import axios, { AxiosRequestConfig, Method } from 'axios';
-import { env } from 'common/env';
-import { toBoolean } from 'common/utils';
-
 import { generateAdminApiQuery } from './AdminApiQuery';
-
 import { transformRequestError } from './transformRequestError';
 import {
     AdminEntityTransformer,

--- a/src/models/Graph/types.ts
+++ b/src/models/Graph/types.ts
@@ -1,4 +1,3 @@
-import { CompiledNode } from 'models/Node/types';
 import { NodeExecution } from 'models/Execution/types';
 import { TaskTemplate } from 'models/Task/types';
 

--- a/src/models/Node/types.ts
+++ b/src/models/Node/types.ts
@@ -1,6 +1,5 @@
 import { Core } from 'flyteidl';
 import { Alias, Binding, Identifier } from 'models/Common/types';
-import { TaskTemplate } from 'models/Task/types';
 
 /** A graph node indicating a subworkflow execution */
 export type WorkflowNode = Core.IWorkflowNode;


### PR DESCRIPTION
Signed-off-by: Nastya Rusina <nastya@union.ai>

**No code changes, only cleanup of unused code, or ensuring that tests are valid**

Cleanup some eslint rules violation, which allowed as to
- remove **no-case-declarations** rule
- remove **'jest/valid-title'** rule
- go down from 393 to 357 current warnings in repo
- added all warning implicitly with their count in code

In future we would be able to move to more modern rules and code practices.

## Type
 - [ ] Bug Fix
 - [x] Cleanup 

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

