### PR TITLE
feat(#281): allow to collapse/expand workflow version section   #patch

### DIFF
--- a/src/basics/LocalCache/defaultConfig.ts
+++ b/src/basics/LocalCache/defaultConfig.ts
@@ -1,0 +1,24 @@
+export enum LocalCacheItem {
+    // Test flag is created only for unit-tests
+    TestUndefined = 'test-undefined',
+    TestSettingBool = 'test-setting-bool',
+    TestObject = 'test-object',
+
+    // Production flags
+    ShowWorkflowVersions = 'flyte.show-workflow-versions'
+}
+
+type LocalCacheConfig = { [k: string]: string };
+
+/*
+ * THe default value could be present as any simple type or as a valid JSON object
+ * with all field names wrapped in double quotes
+ **/
+export const defaultLocalCacheConfig: LocalCacheConfig = {
+    // Test
+    'test-setting-bool': 'false',
+    'test-object': '{"name":"Stella","age":"125"}',
+
+    // Production
+    'flyte.show-workflow-versions': 'true'
+};

--- a/src/basics/LocalCache/index.tsx
+++ b/src/basics/LocalCache/index.tsx
@@ -1,0 +1,49 @@
+// More info on Local storage: https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage
+import { useState } from 'react';
+import { defaultLocalCacheConfig, LocalCacheItem } from './defaultConfig';
+
+export { LocalCacheItem } from './defaultConfig';
+
+export function ClearLocalCache() {
+    localStorage.clear();
+}
+
+const getDefault = (setting: LocalCacheItem) => {
+    const result = defaultLocalCacheConfig[setting];
+    if (!result) {
+        console.error(
+            `ERROR: LocalCacheItem ${setting} doesn't have default value provided in defaultLocalCacheConfig`
+        );
+        return null;
+    }
+    return JSON.parse(result);
+};
+
+export function useLocalCache<T>(setting: LocalCacheItem) {
+    const defaultValue = getDefault(setting);
+    const [value, setValue] = useState<T>(() => {
+        const data = localStorage.getItem(setting);
+        const value = data ? JSON.parse(data) : defaultValue;
+        if (typeof value === typeof defaultValue) {
+            return value;
+        }
+
+        return defaultValue;
+    });
+
+    const setLocalCache = (newValue: T) => {
+        localStorage.setItem(setting, JSON.stringify(newValue));
+        setValue(newValue);
+    };
+
+    const clearState = () => {
+        localStorage.removeItem(setting);
+        setValue(defaultValue);
+    };
+
+    return [value, setLocalCache, clearState];
+}
+
+export const onlyForTesting = {
+    getDefault
+};

--- a/src/basics/LocalCache/localCache.test.tsx
+++ b/src/basics/LocalCache/localCache.test.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import {
+    render,
+    screen,
+    act,
+    fireEvent,
+    getByTestId
+} from '@testing-library/react';
+import {
+    ClearLocalCache,
+    LocalCacheItem,
+    useLocalCache,
+    onlyForTesting
+} from '.';
+
+const SHOW_TEXT = 'SHOWED';
+const HIDDEN_TEXT = 'HIDDEN';
+
+const TestFrame = () => {
+    const [show, setShow, clearShow] = useLocalCache(
+        LocalCacheItem.TestSettingBool
+    );
+
+    const toShow = () => setShow(true);
+    const toClear = () => clearShow();
+
+    return (
+        <div>
+            <div>{show ? SHOW_TEXT : HIDDEN_TEXT}</div>
+            <button onClick={toShow} data-testid="show" />
+            <button onClick={toClear} data-testid="clear" />
+        </div>
+    );
+};
+
+describe('LocalCache', () => {
+    beforeAll(() => {
+        ClearLocalCache();
+    });
+
+    afterAll(() => {
+        ClearLocalCache();
+    });
+
+    it('Can be used by component as expected', () => {
+        const { container } = render(<TestFrame />);
+        const show = getByTestId(container, 'show');
+        const clear = getByTestId(container, 'clear');
+
+        expect(screen.getByText(HIDDEN_TEXT)).toBeTruthy();
+
+        // change value
+        act(() => {
+            fireEvent.click(show);
+        });
+        expect(screen.getByText(SHOW_TEXT)).toBeTruthy();
+
+        // reset to default
+        act(() => {
+            fireEvent.click(clear);
+        });
+        expect(screen.getByText(HIDDEN_TEXT)).toBeTruthy();
+    });
+
+    it('With no default value - assumes null', () => {
+        const { getDefault } = onlyForTesting;
+        expect(getDefault(LocalCacheItem.TestUndefined)).toBeNull();
+    });
+
+    it('Can store use default as an object', () => {
+        const { getDefault } = onlyForTesting;
+        expect(getDefault(LocalCacheItem.TestObject)).toMatchObject({
+            name: 'Stella',
+            age: '125'
+        });
+    });
+});

--- a/src/components/Entities/EntityDescription.tsx
+++ b/src/components/Entities/EntityDescription.tsx
@@ -7,7 +7,8 @@ import { useNamedEntity } from 'components/hooks/useNamedEntity';
 import { NamedEntityMetadata, ResourceIdentifier } from 'models/Common/types';
 import * as React from 'react';
 import reactLoadingSkeleton from 'react-loading-skeleton';
-import { noDescriptionStrings } from './constants';
+import { entityStrings } from './constants';
+import t from './strings';
 
 const Skeleton = reactLoadingSkeleton;
 
@@ -42,7 +43,10 @@ export const EntityDescription: React.FC<{
                     >
                         {hasDescription
                             ? metadata.description
-                            : noDescriptionStrings[id.resourceType]}
+                            : t(
+                                  'noDescription',
+                                  entityStrings[id.resourceType]
+                              )}
                     </span>
                 </WaitForData>
             </Typography>

--- a/src/components/Entities/EntityDetailsHeader.tsx
+++ b/src/components/Entities/EntityDetailsHeader.tsx
@@ -1,19 +1,20 @@
-import { Button } from '@material-ui/core';
+import { Button, Dialog } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import ArrowBack from '@material-ui/icons/ArrowBack';
 import * as classnames from 'classnames';
 import { useCommonStyles } from 'components/common/styles';
-import { ResourceIdentifier } from 'models/Common/types';
+import { ResourceIdentifier, ResourceType } from 'models/Common/types';
 import { Project } from 'models/Project/types';
 import { getProjectDomain } from 'models/Project/utils';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { Routes } from 'routes/routes';
-import { launchStrings } from './constants';
 import { backUrlGenerator } from './generators';
+import { LaunchForm } from 'components/Launch/LaunchForm/LaunchForm';
+import { entityStrings } from './constants';
+import t from './strings';
 
 const useStyles = makeStyles((theme: Theme) => ({
-    actionsContainer: {},
     headerContainer: {
         alignItems: 'center',
         display: 'flex',
@@ -35,66 +36,90 @@ interface EntityDetailsHeaderProps {
     project: Project;
     id: ResourceIdentifier;
     launchable?: boolean;
-    versionView: boolean;
-    onClickLaunch?(): void;
+    backToWorkflow?: boolean;
+}
+
+function getLaunchProps(id: ResourceIdentifier) {
+    if (id.resourceType === ResourceType.TASK) {
+        return { taskId: id };
+    }
+
+    return { workflowId: id };
 }
 
 /**
  * Renders the entity name and any applicable actions.
  * @param id
- * @param onClickLaunch
- * @param launchable
- * @param versionView
  * @param project
+ * @param launchable - controls if we show launch button
+ * @param backToWorkflow - if true breadcrumb navigates to main workflow details view.
  * @constructor
  */
 export const EntityDetailsHeader: React.FC<EntityDetailsHeaderProps> = ({
     id,
-    onClickLaunch,
+    project,
     launchable = false,
-    versionView,
-    project
+    backToWorkflow = false
 }) => {
     const styles = useStyles();
     const commonStyles = useCommonStyles();
+
+    const [showLaunchForm, setShowLaunchForm] = React.useState(false);
+    const onCancelLaunch = () => setShowLaunchForm(false);
+
     const domain = getProjectDomain(project, id.domain);
     const headerText = `${domain.name} / ${id.name}`;
     return (
-        <div className={styles.headerContainer}>
-            <div
-                className={classnames(
-                    commonStyles.mutedHeader,
-                    styles.headerTextContainer
-                )}
-            >
-                <Link
-                    className={commonStyles.linkUnstyled}
-                    to={
-                        versionView
-                            ? Routes.WorkflowDetails.makeUrl(
-                                  id.project,
-                                  id.domain,
-                                  id.name
-                              )
-                            : backUrlGenerator[id.resourceType](id)
-                    }
+        <>
+            <div className={styles.headerContainer}>
+                <div
+                    className={classnames(
+                        commonStyles.mutedHeader,
+                        styles.headerTextContainer
+                    )}
                 >
-                    <ArrowBack color="inherit" />
-                </Link>
-                <span className={styles.headerText}>{headerText}</span>
-            </div>
-            <div className={styles.actionsContainer}>
-                {launchable ? (
-                    <Button
-                        color="primary"
-                        id="launch-workflow"
-                        onClick={onClickLaunch}
-                        variant="contained"
+                    <Link
+                        className={commonStyles.linkUnstyled}
+                        to={
+                            backToWorkflow
+                                ? Routes.WorkflowDetails.makeUrl(
+                                      id.project,
+                                      id.domain,
+                                      id.name
+                                  )
+                                : backUrlGenerator[id.resourceType](id)
+                        }
                     >
-                        {launchStrings[id.resourceType]}
-                    </Button>
-                ) : null}
+                        <ArrowBack color="inherit" />
+                    </Link>
+                    <span className={styles.headerText}>{headerText}</span>
+                </div>
+                <div>
+                    {launchable ? (
+                        <Button
+                            color="primary"
+                            id="launch-workflow"
+                            onClick={() => setShowLaunchForm(true)}
+                            variant="contained"
+                        >
+                            {t('launchStrings', entityStrings[id.resourceType])}
+                        </Button>
+                    ) : null}
+                </div>
             </div>
-        </div>
+            {launchable ? (
+                <Dialog
+                    scroll="paper"
+                    maxWidth="sm"
+                    fullWidth={true}
+                    open={showLaunchForm}
+                >
+                    <LaunchForm
+                        onClose={onCancelLaunch}
+                        {...getLaunchProps(id)}
+                    />
+                </Dialog>
+            ) : null}
+        </>
     );
 };

--- a/src/components/Entities/EntitySchedules.tsx
+++ b/src/components/Entities/EntitySchedules.tsx
@@ -10,7 +10,8 @@ import { useWorkflowSchedules } from 'components/hooks/useWorkflowSchedules';
 import { ResourceIdentifier } from 'models/Common/types';
 import { LaunchPlan } from 'models/Launch/types';
 import * as React from 'react';
-import { noSchedulesStrings, schedulesHeader } from './constants';
+import { entityStrings } from './constants';
+import t from './strings';
 
 const useStyles = makeStyles((theme: Theme) => ({
     schedulesContainer: {
@@ -46,7 +47,7 @@ export const EntitySchedules: React.FC<{
     return (
         <>
             <WaitForData {...scheduledLaunchPlans} spinnerVariant="none">
-                <Typography variant="h6">{schedulesHeader}</Typography>
+                <Typography variant="h6">{t('schedulesHeader')}</Typography>
                 <div className={styles.schedulesContainer}>
                     {scheduledLaunchPlans.value.length > 0 ? (
                         <RenderSchedules
@@ -57,7 +58,7 @@ export const EntitySchedules: React.FC<{
                             variant="body2"
                             className={commonStyles.hintText}
                         >
-                            {noSchedulesStrings[id.resourceType]}
+                            {t('noSchedules', entityStrings[id.resourceType])}
                         </Typography>
                     )}
                 </div>

--- a/src/components/Entities/EntityVersions.tsx
+++ b/src/components/Entities/EntityVersions.tsx
@@ -1,5 +1,11 @@
+import * as React from 'react';
+import { Routes } from 'routes/routes';
+import { history } from 'routes/history';
 import Typography from '@material-ui/core/Typography';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { IconButton, makeStyles, Theme } from '@material-ui/core';
+import ExpandLess from '@material-ui/icons/ExpandLess';
+import ExpandMore from '@material-ui/icons/ExpandMore';
+import { LocalCacheItem, useLocalCache } from 'basics/LocalCache';
 import { WaitForData } from 'components/common/WaitForData';
 import { WorkflowVersionsTable } from 'components/Executions/Tables/WorkflowVersionsTable';
 import { isLoadingState } from 'components/hooks/fetchMachine';
@@ -8,43 +14,50 @@ import { interactiveTextColor } from 'components/Theme/constants';
 import { SortDirection } from 'models/AdminEntity/types';
 import { ResourceIdentifier } from 'models/Common/types';
 import { executionSortFields } from 'models/Execution/constants';
-import { Routes } from 'routes/routes';
-import { history } from 'routes/history';
-import * as React from 'react';
 import { executionFilterGenerator } from './generators';
 import { WorkflowVersionsTablePageSize } from './constants';
+import t from './strings';
 
 const useStyles = makeStyles((theme: Theme) => ({
     headerContainer: {
-        display: 'flex',
-        justifyContent: 'space-between',
-        marginLeft: theme.spacing(1),
-        marginRight: theme.spacing(1)
+        display: 'flex'
+    },
+    collapseButton: {
+        marginTop: theme.spacing(-0.5)
     },
     header: {
-        marginBottom: theme.spacing(1)
+        flexGrow: 1,
+        marginBottom: theme.spacing(1),
+        marginRight: theme.spacing(1)
     },
     viewAll: {
         color: interactiveTextColor,
         cursor: 'pointer'
+    },
+    divider: {
+        borderBottom: `1px solid ${theme.palette.divider}`,
+        marginBottom: theme.spacing(1)
     }
 }));
 
 export interface EntityVersionsProps {
     id: ResourceIdentifier;
-    versionView?: boolean;
+    showAll?: boolean;
 }
 
 /**
  * The tab/page content for viewing a workflow's versions.
  * @param id
- * @param versionView
+ * @param showAll - shows all available entity versions
  */
 export const EntityVersions: React.FC<EntityVersionsProps> = ({
     id,
-    versionView = false
+    showAll = false
 }) => {
     const { domain, project, resourceType, name } = id;
+    const [showTable, setShowTable] = useLocalCache(
+        LocalCacheItem.ShowWorkflowVersions
+    );
     const styles = useStyles();
     const sort = {
         key: executionSortFields.createdAt,
@@ -53,7 +66,7 @@ export const EntityVersions: React.FC<EntityVersionsProps> = ({
 
     const baseFilters = React.useMemo(
         () => executionFilterGenerator[resourceType](id),
-        [id]
+        [id, resourceType]
     );
 
     const versions = useWorkflowVersions(
@@ -61,10 +74,11 @@ export const EntityVersions: React.FC<EntityVersionsProps> = ({
         {
             sort,
             filter: baseFilters,
-            limit: versionView ? 100 : WorkflowVersionsTablePageSize
+            limit: showAll ? 100 : WorkflowVersionsTablePageSize
         }
     );
 
+    const preventDefault = e => e.preventDefault();
     const handleViewAll = React.useCallback(() => {
         history.push(
             Routes.WorkflowVersionDetails.makeUrl(
@@ -78,26 +92,43 @@ export const EntityVersions: React.FC<EntityVersionsProps> = ({
 
     return (
         <>
-            {!versionView && (
+            {!showAll && (
                 <div className={styles.headerContainer}>
+                    <IconButton
+                        className={styles.collapseButton}
+                        edge="start"
+                        disableRipple={true}
+                        disableTouchRipple={true}
+                        onClick={() => setShowTable(!showTable)}
+                        onMouseDown={preventDefault}
+                        size="small"
+                        aria-label=""
+                        title={t('collapseButton', showTable)}
+                    >
+                        {showTable ? <ExpandLess /> : <ExpandMore />}
+                    </IconButton>
                     <Typography className={styles.header} variant="h6">
-                        Recent Workflow Versions
+                        {t('workflowVersionsTitle')}
                     </Typography>
                     <Typography
                         className={styles.viewAll}
                         variant="body1"
                         onClick={handleViewAll}
                     >
-                        View All
+                        {t('viewAll')}
                     </Typography>
                 </div>
             )}
             <WaitForData {...versions}>
-                <WorkflowVersionsTable
-                    {...versions}
-                    isFetching={isLoadingState(versions.state)}
-                    versionView={versionView}
-                />
+                {showTable || showAll ? (
+                    <WorkflowVersionsTable
+                        {...versions}
+                        isFetching={isLoadingState(versions.state)}
+                        versionView={showAll}
+                    />
+                ) : (
+                    <div className={styles.divider} />
+                )}
             </WaitForData>
         </>
     );

--- a/src/components/Entities/constants.ts
+++ b/src/components/Entities/constants.ts
@@ -1,4 +1,3 @@
-import { mapValues, startCase } from 'lodash';
 import { ResourceType } from 'models/Common/types';
 
 type EntityStringMap = { [k in ResourceType]: string };
@@ -11,24 +10,7 @@ export const entityStrings: EntityStringMap = {
     [ResourceType.WORKFLOW]: 'workflow'
 };
 
-export const noDescriptionStrings: EntityStringMap = mapValues(
-    entityStrings,
-    typeString => `This ${typeString} has no description.`
-);
-
-export const schedulesHeader = 'Schedules';
-
-export const noSchedulesStrings: EntityStringMap = mapValues(
-    entityStrings,
-    typeString => `This ${typeString} has no schedules.`
-);
-
-export const launchStrings: EntityStringMap = mapValues(
-    entityStrings,
-    typeString => `Launch ${startCase(typeString)}`
-);
-
-export interface EntitySectionsFlags {
+interface EntitySectionsFlags {
     description?: boolean;
     executions?: boolean;
     launch?: boolean;

--- a/src/components/Entities/strings.ts
+++ b/src/components/Entities/strings.ts
@@ -1,0 +1,16 @@
+import { createLocalizedString } from 'basics/Locale';
+import { startCase } from 'lodash';
+
+const str = {
+    workflowVersionsTitle: 'Recent Workflow Versions',
+    viewAll: 'View All',
+    schedulesHeader: 'Schedules',
+    collapseButton: (showAll: boolean) => (showAll ? 'Collapse' : 'Expand'),
+    launchStrings: (typeString: string) => `Launch ${startCase(typeString)}`,
+    noDescription: (typeString: string) =>
+        `This ${typeString} has no description.`,
+    noSchedules: (typeString: string) => `This ${typeString} has no schedules.`
+};
+
+export { patternKey } from 'basics/Locale';
+export default createLocalizedString(str);

--- a/src/components/Entities/test/EntitySchedules.test.tsx
+++ b/src/components/Entities/test/EntitySchedules.test.tsx
@@ -10,8 +10,8 @@ import { ResourceIdentifier, ResourceType } from 'models/Common/types';
 import { listLaunchPlans } from 'models/Launch/api';
 import { LaunchPlan, LaunchPlanState } from 'models/Launch/types';
 import * as React from 'react';
-import { schedulesHeader } from '../constants';
 import { EntitySchedules } from '../EntitySchedules';
+import t from '../strings';
 
 jest.mock('models/Launch/api');
 
@@ -29,7 +29,7 @@ describe('EntitySchedules', () => {
 
     const renderSchedules = async () => {
         const result = render(<EntitySchedules id={id} />);
-        await waitFor(() => result.getByText(schedulesHeader));
+        await waitFor(() => result.getByText(t('schedulesHeader')));
         return result;
     };
 

--- a/src/components/Workflow/WorkflowVersionDetails.tsx
+++ b/src/components/Workflow/WorkflowVersionDetails.tsx
@@ -1,15 +1,29 @@
-import { withRouteParams } from 'components/common/withRouteParams';
-import { EntityDetails } from 'components/Entities/EntityDetails';
-import { ResourceIdentifier, ResourceType } from 'models/Common/types';
 import * as React from 'react';
+import { withRouteParams } from 'components/common/withRouteParams';
+import { ResourceIdentifier, ResourceType } from 'models/Common/types';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+import { WaitForData } from 'components/common/WaitForData';
+import { useProject } from 'components/hooks/useProjects';
+import { StaticGraphContainer } from 'components/Workflow/StaticGraphContainer';
+import { WorkflowId } from 'models/Workflow/types';
+import { entitySections } from 'components/Entities/constants';
+import { EntityDetailsHeader } from 'components/Entities/EntityDetailsHeader';
+import { EntityVersions } from 'components/Entities/EntityVersions';
 
-export interface WorkflowVersionDetailsRouteParams {
+const useStyles = makeStyles((_theme: Theme) => ({
+    versionsContainer: {
+        display: 'flex',
+        flexDirection: 'column',
+        flex: '1 1 auto'
+    }
+}));
+
+interface WorkflowVersionDetailsRouteParams {
     projectId: string;
     domainId: string;
     workflowName: string;
     workflowVersion: string;
 }
-export type WorkflowDetailsProps = WorkflowVersionDetailsRouteParams;
 
 /**
  * The view component for the Workflow Versions page
@@ -17,13 +31,13 @@ export type WorkflowDetailsProps = WorkflowVersionDetailsRouteParams;
  * @param domainId
  * @param workflowName
  */
-export const WorkflowVersionDetailsContainer: React.FC<WorkflowVersionDetailsRouteParams> = ({
+const WorkflowVersionDetailsContainer: React.FC<WorkflowVersionDetailsRouteParams> = ({
     projectId,
     domainId,
     workflowName,
     workflowVersion
 }) => {
-    const id = React.useMemo<ResourceIdentifier>(
+    const workflowId = React.useMemo<WorkflowId>(
         () => ({
             resourceType: ResourceType.WORKFLOW,
             project: projectId,
@@ -33,7 +47,26 @@ export const WorkflowVersionDetailsContainer: React.FC<WorkflowVersionDetailsRou
         }),
         [projectId, domainId, workflowName, workflowVersion]
     );
-    return <EntityDetails id={id} versionView showStaticGraph />;
+
+    const id = workflowId as ResourceIdentifier;
+    const sections = entitySections[ResourceType.WORKFLOW];
+    const project = useProject(workflowId.project);
+    const styles = useStyles();
+
+    return (
+        <WaitForData {...project}>
+            <EntityDetailsHeader
+                project={project.value}
+                id={id}
+                launchable={sections.launch}
+                backToWorkflow
+            />
+            <StaticGraphContainer workflowId={workflowId} />
+            <div className={styles.versionsContainer}>
+                <EntityVersions id={id} showAll />
+            </div>
+        </WaitForData>
+    );
 };
 
 export const WorkflowVersionDetails = withRouteParams<


### PR DESCRIPTION
In workflow view we now allow user to collapse/expand workflow versions section. User choice would be persistent between pages (by LocalStorage)

video: https://share.getcloudapp.com/kpu4e0l1

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

- Added useLocalCache hook, which uses local storage to persist user settings
-  Uncoupled EntityDetails page from WorkflowVersionDetailsContainer. Now they are independent pages
- Moved "Launch[Entity]" form into EntityDetailsHeader, so it will leave along side "Launch[Entity]" button.

## Tracking Issue
fixes https://github.com/flyteorg/flyteconsole/issues/281

Signed-off-by: Nastya Rusina <nastya@union.ai>