### PR TITLE
fix: Changed memo filter to scopedId from node.id

### DIFF
--- a/src/components/Executions/ExecutionDetails/ExecutionWorkflowGraph.tsx
+++ b/src/components/Executions/ExecutionDetails/ExecutionWorkflowGraph.tsx
@@ -24,7 +24,7 @@ export const ExecutionWorkflowGraph: React.FC<ExecutionWorkflowGraphProps> = ({
 }) => {
   const workflowQuery = useQuery<Workflow, Error>(makeWorkflowQuery(useQueryClient(), workflowId));
   const nodeExecutionsById = React.useMemo(
-    () => keyBy(nodeExecutions, 'id.nodeId'),
+    () => keyBy(nodeExecutions, 'scopedId'),
     [nodeExecutions],
   );
 

--- a/src/components/Executions/nodeExecutionQueries.ts
+++ b/src/components/Executions/nodeExecutionQueries.ts
@@ -244,7 +244,7 @@ async function fetchGroupsForParentNodeExecution(
      *  nodeExecution to enable mapping between graph and other components     */
     let scopedId = parentScopeId;
     if (scopedId != undefined) {
-      scopedId += `-${child.metadata?.retryGroup}-${child.metadata?.specNodeId}`;
+      scopedId += `-0-${child.metadata?.specNodeId}`;
       child['scopedId'] = scopedId;
     } else {
       child['scopedId'] = child.metadata?.specNodeId;

--- a/src/components/WorkflowGraph/WorkflowGraph.tsx
+++ b/src/components/WorkflowGraph/WorkflowGraph.tsx
@@ -38,6 +38,9 @@ function workflowToDag(workflow: Workflow): PrepareDAGResult {
     }
     const { compiledWorkflow } = workflow.closure;
     const { dag, staticExecutionIdsMap } = transformerWorkflowToDag(compiledWorkflow);
+
+    debug('workflowToDag:dag', dag);
+
     return { dag, staticExecutionIdsMap };
   } catch (e) {
     return {
@@ -70,10 +73,12 @@ export const WorkflowGraph: React.FC<WorkflowGraphProps> = (props) => {
         const dynamicExecution = allExecutions[executionId];
         const dynamicExecutionId = dynamicExecution.metadata.specNodeId || dynamicExecution.id;
         const uniqueParentId = dynamicExecution.fromUniqueParentId;
-        if (parentsToFetch[uniqueParentId]) {
-          parentsToFetch[uniqueParentId].push(dynamicExecutionId);
-        } else {
-          parentsToFetch[uniqueParentId] = [dynamicExecutionId];
+        if (uniqueParentId) {
+          if (parentsToFetch[uniqueParentId]) {
+            parentsToFetch[uniqueParentId].push(dynamicExecutionId);
+          } else {
+            parentsToFetch[uniqueParentId] = [dynamicExecutionId];
+          }
         }
       }
     }
@@ -85,7 +90,6 @@ export const WorkflowGraph: React.FC<WorkflowGraphProps> = (props) => {
   };
 
   const dynamicParents = checkForDynamicExeuctions(nodeExecutionsById, staticExecutionIdsMap);
-
   const dynamicWorkflowQuery = useQuery(
     makeNodeExecutionDynamicWorkflowQuery(useQueryClient(), dynamicParents),
   );

--- a/src/components/flytegraph/ReactFlow/ReactFlowGraphComponent.tsx
+++ b/src/components/flytegraph/ReactFlow/ReactFlowGraphComponent.tsx
@@ -40,7 +40,6 @@ const ReactFlowGraphComponent = (props) => {
   });
 
   const onAddNestedView = (view) => {
-    debug('@addNestedView:', view);
     const currentView = state.currentNestedView[view.parent] || [];
     const newView = {
       [view.parent]: [...currentView, view.view],

--- a/src/components/flytegraph/ReactFlow/transformDAGToReactFlowV2.tsx
+++ b/src/components/flytegraph/ReactFlow/transformDAGToReactFlowV2.tsx
@@ -63,6 +63,7 @@ export const buildReactFlowDataProps = (props: BuildDataProps) => {
 
   const taskType = node.value?.template ? node.value.template.type : null;
   const displayName = node.name;
+
   const mapNodeExecutionStatus = () => {
     if (nodeExecutionsById) {
       if (nodeExecutionsById[node.scopedId]) {


### PR DESCRIPTION
Signed-off-by: Jason Porter <jason@union.ai>

This fixes a bug where tasks were not correctly rendered in the graph.  The issue stems from an incorrect assumption that a `NodeExecution.nodeId` was the correct key to map against `CompiledWorkflowClosure` but in fact we must key off `scopedId`. 

Note: this is WIP pending regression testing.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
fixes https://github.com/flyteorg/flyteconsole/issues/333

## Follow-up issue
_NA_
