### PR TITLE
chore: fix TaskType display to ensure consistency, code cleanup, add mapTaskListItem component

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -9,6 +9,11 @@ export const parameters = {
       date: /Date$/,
     },
   },
+  options: {
+    storySort: {
+      order: ['Primitives', 'Common'],
+    },
+  },
 };
 
 export const decorators = [

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,7 +24,7 @@ module.exports = {
       '<rootDir>/assetsTransformer.js',
   },
   coverageDirectory: '.coverage',
-  collectCoverageFrom: ['**/*.{ts,tsx}'],
+  collectCoverageFrom: ['**/*.{ts,tsx}', '!**/*/*.stories.tsx'],
   coveragePathIgnorePatterns: [
     '__stories__',
     '<rootDir>/.storybook',

--- a/src/components/Errors/__stories__/DataError.stories.tsx
+++ b/src/components/Errors/__stories__/DataError.stories.tsx
@@ -7,7 +7,7 @@ import { DataError } from '../DataError';
 
 const retryAction = action('retry');
 
-const stories = storiesOf('Errors/DataError', module);
+const stories = storiesOf('Common/DataError', module);
 stories.add('Title Only', () => (
   <DataError errorTitle="Something went wrong" retry={retryAction} />
 ));

--- a/src/components/Executions/ExecutionDetails/ExecutionNodeViews.tsx
+++ b/src/components/Executions/ExecutionDetails/ExecutionNodeViews.tsx
@@ -1,15 +1,11 @@
 import * as React from 'react';
 import { Tab, Tabs } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
-import { noop } from 'lodash';
-
-import { FeatureFlag, useFeatureFlag } from 'basics/FeatureFlags';
 import { WaitForQuery } from 'components/common/WaitForQuery';
 import { DataError } from 'components/Errors/DataError';
 import { useTabState } from 'components/hooks/useTabState';
 import { secondaryBackgroundColor } from 'components/Theme/constants';
 import { Execution, NodeExecution } from 'models/Execution/types';
-import { LocalCacheItem, useLocalCache } from 'basics/LocalCache';
 import { NodeExecutionDetailsContextProvider } from '../contextProvider/NodeExecutionDetails';
 import { NodeExecutionsRequestConfigContext } from '../contexts';
 import { ExecutionFilters } from '../ExecutionFilters';

--- a/src/components/Executions/Tables/__stories__/NodeExecutionsTable.stories.tsx
+++ b/src/components/Executions/Tables/__stories__/NodeExecutionsTable.stories.tsx
@@ -2,6 +2,7 @@ import { makeStyles, Theme } from '@material-ui/core/styles';
 import { storiesOf } from '@storybook/react';
 import { NodeExecutionDetailsContext } from 'components/Executions/contextProvider/NodeExecutionDetails';
 import { makeNodeExecutionListQuery } from 'components/Executions/nodeExecutionQueries';
+import { NodeExecutionDisplayType } from 'components/Executions/types';
 import { basicPythonWorkflow } from 'mocks/data/fixtures/basicPythonWorkflow';
 import * as React from 'react';
 import { useQuery, useQueryClient } from 'react-query';
@@ -26,7 +27,7 @@ const getNodeExecutionDetails = async () => {
   return {
     displayId: 'node0',
     displayName: 'basic.byton.workflow.unique.task_name',
-    displayType: 'Python-Task',
+    displayType: NodeExecutionDisplayType.PythonTask,
   };
 };
 

--- a/src/components/Executions/TaskExecutionsList/TaskExecutionLogs.tsx
+++ b/src/components/Executions/TaskExecutionsList/TaskExecutionLogs.tsx
@@ -1,10 +1,9 @@
+import * as React from 'react';
 import { Typography } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import { NewTargetLink } from 'components/common/NewTargetLink';
 import { useCommonStyles } from 'components/common/styles';
 import { TaskLog } from 'models/Common/types';
-import { TaskExecution } from 'models/Execution/types';
-import * as React from 'react';
 import { noLogsFoundString } from '../constants';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -33,19 +32,17 @@ const TaskLogList: React.FC<{ logs: TaskLog[] }> = ({ logs }) => {
   );
 };
 
-/** Renders log links from a `TaskExecution`, if they exist. Otherwise renders
- * a message indicating that no logs are available.
+/** Renders log links from a `taskLogs`(aka taskExecution.closure.logs), if they exist.
+ *  Otherwise renders a message indicating that no logs are available.
  */
-export const TaskExecutionLogs: React.FC<{ taskExecution: TaskExecution }> = ({
-  taskExecution,
-}) => {
+export const TaskExecutionLogs: React.FC<{ taskLogs: TaskLog[] }> = ({ taskLogs }) => {
   const styles = useStyles();
   return (
     <section>
       <header className={styles.sectionHeader}>
         <Typography variant="h6">Logs</Typography>
       </header>
-      <TaskLogList logs={taskExecution.closure.logs || []} />
+      <TaskLogList logs={taskLogs} />
     </section>
   );
 };

--- a/src/components/Executions/TaskExecutionsList/TaskExecutionsListItem.tsx
+++ b/src/components/Executions/TaskExecutionsList/TaskExecutionsListItem.tsx
@@ -63,7 +63,7 @@ export const TaskExecutionsListItem: React.FC<TaskExecutionsListItemProps> = ({
         {taskHasStarted && (
           <>
             <section className={styles.section}>
-              <TaskExecutionLogs taskExecution={taskExecution} />
+              <TaskExecutionLogs taskLogs={taskExecution.closure.logs || []} />
             </section>
             <section className={styles.section}>
               <TaskExecutionDetails taskExecution={taskExecution} />

--- a/src/components/Executions/constants.ts
+++ b/src/components/Executions/constants.ts
@@ -179,10 +179,10 @@ export const taskExecutionPhaseConstants: {
   },
 };
 
-export const taskTypeToNodeExecutionDisplayType: {
+const taskTypeToNodeExecutionDisplayType: {
   [k in TaskType]: NodeExecutionDisplayType;
 } = {
-  [TaskType.ARRAY]: NodeExecutionDisplayType.ArrayTask,
+  [TaskType.ARRAY]: NodeExecutionDisplayType.MapTask,
   [TaskType.BATCH_HIVE]: NodeExecutionDisplayType.BatchHiveTask,
   [TaskType.DYNAMIC]: NodeExecutionDisplayType.DynamicTask,
   [TaskType.HIVE]: NodeExecutionDisplayType.HiveTask,
@@ -192,7 +192,17 @@ export const taskTypeToNodeExecutionDisplayType: {
   [TaskType.UNKNOWN]: NodeExecutionDisplayType.UnknownTask,
   [TaskType.WAITABLE]: NodeExecutionDisplayType.WaitableTask,
   [TaskType.MPI]: NodeExecutionDisplayType.MpiTask,
+  [TaskType.ARRAY_AWS]: NodeExecutionDisplayType.ARRAY_AWS,
+  [TaskType.ARRAY_K8S]: NodeExecutionDisplayType.ARRAY_K8S,
 };
+
+export function getTaskDisplayType(taskType?: string): string {
+  if (taskType) {
+    return taskTypeToNodeExecutionDisplayType[taskType] ?? taskType;
+  }
+
+  return NodeExecutionDisplayType.Unknown;
+}
 
 export const cacheStatusMessages: { [k in Core.CatalogCacheStatus]: string } = {
   [Core.CatalogCacheStatus.CACHE_DISABLED]: 'Caching was disabled for this execution.',

--- a/src/components/Executions/constants.ts
+++ b/src/components/Executions/constants.ts
@@ -179,7 +179,7 @@ export const taskExecutionPhaseConstants: {
   },
 };
 
-const taskTypeToNodeExecutionDisplayType: {
+export const taskTypeToNodeExecutionDisplayType: {
   [k in TaskType]: NodeExecutionDisplayType;
 } = {
   [TaskType.ARRAY]: NodeExecutionDisplayType.MapTask,
@@ -195,14 +195,6 @@ const taskTypeToNodeExecutionDisplayType: {
   [TaskType.ARRAY_AWS]: NodeExecutionDisplayType.ARRAY_AWS,
   [TaskType.ARRAY_K8S]: NodeExecutionDisplayType.ARRAY_K8S,
 };
-
-export function getTaskDisplayType(taskType?: string): string {
-  if (taskType) {
-    return taskTypeToNodeExecutionDisplayType[taskType] ?? taskType;
-  }
-
-  return NodeExecutionDisplayType.Unknown;
-}
 
 export const cacheStatusMessages: { [k in Core.CatalogCacheStatus]: string } = {
   [Core.CatalogCacheStatus.CACHE_DISABLED]: 'Caching was disabled for this execution.',

--- a/src/components/Executions/contextProvider/NodeExecutionDetails/createExecutionArray.tsx
+++ b/src/components/Executions/contextProvider/NodeExecutionDetails/createExecutionArray.tsx
@@ -1,5 +1,5 @@
 import { transformerWorkflowToDag } from 'components/WorkflowGraph/transformerWorkflowToDag';
-import { getTaskDisplayType } from 'components/Executions/constants';
+import { getTaskDisplayType } from 'components/Executions/utils';
 import { NodeExecutionDetails, NodeExecutionDisplayType } from 'components/Executions/types';
 import { Workflow } from 'models/Workflow/types';
 import { Identifier } from 'models/Common/types';

--- a/src/components/Executions/contextProvider/NodeExecutionDetails/createExecutionArray.tsx
+++ b/src/components/Executions/contextProvider/NodeExecutionDetails/createExecutionArray.tsx
@@ -1,4 +1,5 @@
 import { transformerWorkflowToDag } from 'components/WorkflowGraph/transformerWorkflowToDag';
+import { getTaskDisplayType } from 'components/Executions/constants';
 import { NodeExecutionDetails, NodeExecutionDisplayType } from 'components/Executions/types';
 import { Workflow } from 'models/Workflow/types';
 import { Identifier } from 'models/Common/types';
@@ -37,11 +38,13 @@ const getNodeDetails = (node: dNode, tasks: CompiledTask[]): NodeExecutionInfo =
   if (node.value.taskNode) {
     const templateName = node.value.taskNode.referenceId.name ?? node.name;
     const task = tasks.find((t) => t.template.id.name === templateName);
+    const taskType = getTaskDisplayType(task?.template.type);
+
     return {
       scopedId: node.scopedId,
       displayId: node.value.id ?? node.id,
       displayName: templateName,
-      displayType: task?.template.type ?? NodeExecutionDisplayType.UnknownTask,
+      displayType: taskType,
       taskTemplate: task?.template,
     };
   }

--- a/src/components/Executions/contextProvider/NodeExecutionDetails/getTaskThroughExecution.ts
+++ b/src/components/Executions/contextProvider/NodeExecutionDetails/getTaskThroughExecution.ts
@@ -1,4 +1,4 @@
-import { getTaskDisplayType } from 'components/Executions/constants';
+import { getTaskDisplayType } from 'components/Executions/utils';
 import { fetchTaskExecutionList } from 'components/Executions/taskExecutionQueries';
 import { NodeExecutionDetails } from 'components/Executions/types';
 import { fetchTaskTemplate } from 'components/Task/taskQueries';

--- a/src/components/Executions/contextProvider/NodeExecutionDetails/getTaskThroughExecution.ts
+++ b/src/components/Executions/contextProvider/NodeExecutionDetails/getTaskThroughExecution.ts
@@ -1,5 +1,6 @@
+import { getTaskDisplayType } from 'components/Executions/constants';
 import { fetchTaskExecutionList } from 'components/Executions/taskExecutionQueries';
-import { NodeExecutionDetails, NodeExecutionDisplayType } from 'components/Executions/types';
+import { NodeExecutionDetails } from 'components/Executions/types';
 import { fetchTaskTemplate } from 'components/Task/taskQueries';
 import { NodeExecution } from 'models/Execution/types';
 import { TaskTemplate } from 'models/Task/types';
@@ -15,6 +16,7 @@ export const getTaskThroughExecution = async (
   if (taskExecutions && taskExecutions.length > 0) {
     taskTemplate = await fetchTaskTemplate(queryClient, taskExecutions[0].id.taskId);
     if (!taskTemplate) {
+      // eslint-disable-next-line no-console
       console.error(
         `ERROR: Unexpected missing task template while fetching NodeExecution details: ${JSON.stringify(
           taskExecutions[0].id.taskId,
@@ -26,7 +28,7 @@ export const getTaskThroughExecution = async (
   const taskDetails: NodeExecutionDetails = {
     displayId: nodeExecution.id.nodeId,
     displayName: taskExecutions?.[0]?.id.taskId.name,
-    displayType: taskTemplate?.type ?? NodeExecutionDisplayType.Unknown,
+    displayType: getTaskDisplayType(taskTemplate?.type),
     taskTemplate: taskTemplate,
   };
 

--- a/src/components/Executions/types.ts
+++ b/src/components/Executions/types.ts
@@ -13,7 +13,7 @@ export interface ExecutionPhaseConstants {
 }
 
 export enum NodeExecutionDisplayType {
-  ArrayTask = 'Array Task',
+  MapTask = 'Map Task',
   BatchHiveTask = 'Hive Batch Task',
   BranchNode = 'Branch Node',
   DynamicTask = 'Dynamic Task',
@@ -26,6 +26,9 @@ export enum NodeExecutionDisplayType {
   UnknownTask = 'Unknown Task',
   WaitableTask = 'Waitable Task',
   MpiTask = 'MPI Task',
+  // plugins
+  ARRAY_AWS = 'AWS Map Task',
+  ARRAY_K8S = 'K8S Map Task',
 }
 
 export interface ParentNodeExecution extends NodeExecution {

--- a/src/components/Executions/utils.ts
+++ b/src/components/Executions/utils.ts
@@ -21,9 +21,10 @@ import { CompiledNode } from 'models/Node/types';
 import {
   nodeExecutionPhaseConstants,
   taskExecutionPhaseConstants,
+  taskTypeToNodeExecutionDisplayType,
   workflowExecutionPhaseConstants,
 } from './constants';
-import { ExecutionPhaseConstants, ParentNodeExecution } from './types';
+import { ExecutionPhaseConstants, NodeExecutionDisplayType, ParentNodeExecution } from './types';
 
 /** Given an execution phase, returns a set of constants (i.e. color, display
  * string) used to represent it in various UI components.
@@ -53,6 +54,17 @@ export function getTaskExecutionPhaseConstants(phase: TaskExecutionPhase): Execu
   return (
     taskExecutionPhaseConstants[phase] || taskExecutionPhaseConstants[TaskExecutionPhase.UNDEFINED]
   );
+}
+
+/**
+ * Transforms taskType value to more convinient readable display Type
+ */
+export function getTaskDisplayType(taskType?: string): string {
+  if (taskType) {
+    return taskTypeToNodeExecutionDisplayType[taskType] ?? taskType;
+  }
+
+  return NodeExecutionDisplayType.Unknown;
 }
 
 /** Determines if a workflow execution can be considered finalized and will not

--- a/src/components/Notifications/__stories__/SystemStatusBanner.stories.tsx
+++ b/src/components/Notifications/__stories__/SystemStatusBanner.stories.tsx
@@ -32,7 +32,7 @@ const renderBanner = (status: SystemStatus) => (
   <RenderSystemStatusBanner systemStatus={status} onClose={action('onClose')} />
 );
 
-const stories = storiesOf('Notifications/SystemStatusBanner', module);
+const stories = storiesOf('Common/SystemStatusBanner', module);
 stories.add('Normal Status', () => renderBanner(normalStatus));
 stories.add('Degraded Status', () => renderBanner(degradedStatus));
 stories.add('Down Status', () => renderBanner(downStatus));

--- a/src/components/Theme/constants.ts
+++ b/src/components/Theme/constants.ts
@@ -58,16 +58,19 @@ export const statusColors = {
 
 export type TaskColorMap = Record<TaskType, string>;
 export const taskColors: TaskColorMap = {
+  [TaskType.PYTHON]: '#7157D9',
+  [TaskType.SPARK]: '#00B3A4',
+  [TaskType.MPI]: '#00B3A4',
   [TaskType.BATCH_HIVE]: '#E1E8ED',
   [TaskType.DYNAMIC]: '#E1E8ED',
   [TaskType.HIVE]: '#E1E8ED',
-  [TaskType.PYTHON]: '#7157D9',
-  [TaskType.SPARK]: '#00B3A4',
-  [TaskType.ARRAY]: '#E1E8ED',
   [TaskType.SIDECAR]: '#E1E8ED',
   [TaskType.UNKNOWN]: '#E1E8ED',
   [TaskType.WAITABLE]: '#E1E8ED',
-  [TaskType.MPI]: '#00B3A4',
+  [TaskType.ARRAY]: '#E1E8ED',
+  // plugins
+  [TaskType.ARRAY_AWS]: '#E1E8ED',
+  [TaskType.ARRAY_K8S]: '#E1E8ED',
 };
 
 export const bodyFontSize = '0.875rem';

--- a/src/components/WorkflowGraph/WorkflowGraph.tsx
+++ b/src/components/WorkflowGraph/WorkflowGraph.tsx
@@ -9,7 +9,7 @@ import { NodeExecutionsContext } from 'components/Executions/contexts';
 import { WaitForQuery } from 'components/common/WaitForQuery';
 import { useQuery, useQueryClient } from 'react-query';
 import { makeNodeExecutionDynamicWorkflowQuery } from 'components/Workflow/workflowQueries';
-import { createDebugLogger } from 'components/flytegraph/utils';
+import { createDebugLogger } from 'common/log';
 import { CompiledNode } from 'models/Node/types';
 import { transformerWorkflowToDag } from './transformerWorkflowToDag';
 

--- a/src/components/WorkflowGraph/transformerWorkflowToDag.tsx
+++ b/src/components/WorkflowGraph/transformerWorkflowToDag.tsx
@@ -1,5 +1,5 @@
 import { DISPLAY_NAME_END, DISPLAY_NAME_START } from 'components/flytegraph/ReactFlow/utils';
-import { createDebugLogger } from 'components/flytegraph/utils';
+import { createDebugLogger } from 'common/log';
 import { dTypes, dEdge, dNode } from 'models/Graph/types';
 import { startNodeId, endNodeId } from 'models/Node/constants';
 import { CompiledNode, ConnectionSet, TaskNode } from 'models/Node/types';

--- a/src/components/common/MapTaskExecutionsList/MapTaskStatusInfo.stories.tsx
+++ b/src/components/common/MapTaskExecutionsList/MapTaskStatusInfo.stories.tsx
@@ -18,26 +18,11 @@ export const Default = Template.bind({});
 Default.decorators = [(Story) => PanelViewDecorator(Story)];
 Default.args = {
   taskLogs: [
-    {
-      uri: '#',
-      name: 'Kubernetes Logs #0-0',
-    },
-    {
-      uri: '#',
-      name: 'Kubernetes Logs #0-1',
-    },
-    {
-      uri: '#',
-      name: 'Kubernetes Logs #0-2',
-    },
-    {
-      uri: '#',
-      name: 'Kubernetes Logs #0-3',
-    },
-    {
-      uri: '#',
-      name: 'Kubernetes Logs #0-4',
-    },
+    { uri: '#', name: 'Kubernetes Logs #0-0' },
+    { uri: '#', name: 'Kubernetes Logs #0-1' },
+    { uri: '#', name: 'Kubernetes Logs #0-2' },
+    { uri: '#', name: 'Kubernetes Logs #0-3' },
+    { uri: '#', name: 'Kubernetes Logs #0-4' },
   ],
   status: NodeExecutionPhase.QUEUED,
   expanded: true,

--- a/src/components/common/MapTaskExecutionsList/MapTaskStatusInfo.stories.tsx
+++ b/src/components/common/MapTaskExecutionsList/MapTaskStatusInfo.stories.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { NodeExecutionPhase } from 'models/Execution/enums';
+import { MapTaskStatusInfo } from './MapTaskStatusInfo';
+import { PanelViewDecorator } from '../__stories__/Decorators';
+
+export default {
+  title: 'Common/MapTaskExecutionList/MapTaskStatusInfo',
+  component: MapTaskStatusInfo,
+  parameters: { actions: { argTypesRegex: 'toggleExpanded' } },
+} as ComponentMeta<typeof MapTaskStatusInfo>;
+
+const Template: ComponentStory<typeof MapTaskStatusInfo> = (args) => (
+  <MapTaskStatusInfo {...args} />
+);
+
+export const Default = Template.bind({});
+Default.decorators = [(Story) => PanelViewDecorator(Story)];
+Default.args = {
+  taskLogs: [
+    {
+      uri: '#',
+      name: 'Kubernetes Logs #0-0',
+    },
+    {
+      uri: '#',
+      name: 'Kubernetes Logs #0-1',
+    },
+    {
+      uri: '#',
+      name: 'Kubernetes Logs #0-2',
+    },
+    {
+      uri: '#',
+      name: 'Kubernetes Logs #0-3',
+    },
+    {
+      uri: '#',
+      name: 'Kubernetes Logs #0-4',
+    },
+  ],
+  status: NodeExecutionPhase.QUEUED,
+  expanded: true,
+};
+
+export const AllSpace = Template.bind({});
+AllSpace.args = {
+  taskLogs: [],
+  status: NodeExecutionPhase.SUCCEEDED,
+};

--- a/src/components/common/MapTaskExecutionsList/MapTaskStatusInfo.test.tsx
+++ b/src/components/common/MapTaskExecutionsList/MapTaskStatusInfo.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { noLogsFoundString } from 'components/Executions/constants';
+import { getNodeExecutionPhaseConstants } from 'components/Executions/utils';
+import { NodeExecutionPhase } from 'models/Execution/enums';
+import * as React from 'react';
+
+import { MapTaskStatusInfo } from './MapTaskStatusInfo';
+
+const taskLogs = [
+  { uri: '#', name: 'Kubernetes Logs #0-0' },
+  { uri: '#', name: 'Kubernetes Logs #0-1' },
+  { uri: '#', name: 'Kubernetes Logs #0-2' },
+];
+
+describe('MapTaskStatusInfo', () => {
+  it('Phase and amount of links rendered correctly', async () => {
+    const status = NodeExecutionPhase.RUNNING;
+    const phaseData = getNodeExecutionPhaseConstants(status);
+
+    const { queryByText, getByTitle } = render(
+      <MapTaskStatusInfo taskLogs={taskLogs} status={status} expanded={false} />,
+    );
+
+    expect(queryByText(phaseData.text)).toBeInTheDocument();
+    expect(queryByText(`x${taskLogs.length}`)).toBeInTheDocument();
+    expect(queryByText('Logs')).not.toBeInTheDocument();
+
+    // Expand item - see logs section
+    const buttonEl = getByTitle('Expand row');
+    fireEvent.click(buttonEl);
+    await waitFor(() => {
+      expect(queryByText('Logs')).toBeInTheDocument();
+    });
+  });
+
+  it('Phase with no links show proper texts when opened', () => {
+    const status = NodeExecutionPhase.ABORTED;
+    const phaseData = getNodeExecutionPhaseConstants(status);
+
+    const { queryByText } = render(
+      <MapTaskStatusInfo taskLogs={[]} status={status} expanded={true} />,
+    );
+
+    expect(queryByText(phaseData.text)).toBeInTheDocument();
+    expect(queryByText(`x0`)).toBeInTheDocument();
+    expect(queryByText(noLogsFoundString)).toBeInTheDocument();
+  });
+});

--- a/src/components/common/MapTaskExecutionsList/MapTaskStatusInfo.tsx
+++ b/src/components/common/MapTaskExecutionsList/MapTaskStatusInfo.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { useState } from 'react';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+import { RowExpander } from 'components/Executions/Tables/RowExpander';
+import { NodeExecutionPhase } from 'models/Execution/enums';
+import { getNodeExecutionPhaseConstants } from 'components/Executions/utils';
+import { Typography } from '@material-ui/core';
+import { TaskExecutionLogs } from 'components/Executions/TaskExecutionsList/TaskExecutionLogs';
+import { TaskLog } from 'models/Common/types';
+
+const useStyles = makeStyles((_theme: Theme) => ({
+  mainWrapper: {
+    display: 'flex',
+    flex: 1,
+    flexDirection: 'column',
+  },
+  headerWrapper: {
+    display: 'flex',
+    flex: 'auto',
+    alignItems: 'center',
+  },
+  colorBar: {
+    height: '20px',
+    borderLeft: 'solid 4px red',
+    margin: '0 8px 0 4px',
+  },
+  title: {
+    flex: 'auto',
+  },
+  logs: {
+    marginLeft: '46px',
+  },
+  semiboldText: {
+    fontWeight: 600,
+  },
+}));
+
+interface MapTaskStatusInfoProps {
+  taskLogs: TaskLog[];
+  status: NodeExecutionPhase;
+  expanded: boolean;
+}
+
+export const MapTaskStatusInfo = (props: MapTaskStatusInfoProps) => {
+  const [expanded, setExpanded] = useState(props.expanded);
+  const styles = useStyles();
+
+  const toggleExpanded = () => {
+    setExpanded(!expanded);
+  };
+
+  const phaseData = getNodeExecutionPhaseConstants(props.status);
+  return (
+    <div className={styles.mainWrapper}>
+      <div className={styles.headerWrapper}>
+        <RowExpander expanded={expanded} onClick={toggleExpanded} />
+        <div className={styles.colorBar} style={{ borderColor: phaseData.badgeColor }} />
+        <Typography variant="body2" className={styles.title}>
+          {phaseData.text}
+        </Typography>
+        <span>{`x${props.taskLogs.length}`}</span>
+      </div>
+      {expanded && (
+        <div className={styles.logs}>
+          <TaskExecutionLogs taskLogs={props.taskLogs} />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/common/__stories__/Decorators.tsx
+++ b/src/components/common/__stories__/Decorators.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+
+const PANEL_VIEW = '320px';
+
+export function PanelViewDecorator(Story: any) {
+  return (
+    <div style={{ margin: '8px' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+        <span>Panel View</span>
+        <span>{PANEL_VIEW}</span>
+      </div>
+      <div style={{ border: 'solid 1px lightblue', width: PANEL_VIEW }}>
+        <Story />
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/__stories__/Typography.stories.tsx
+++ b/src/components/common/__stories__/Typography.stories.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { storiesOf } from '@storybook/react';
+import Typography from '@material-ui/core/Typography';
+
+const stories = storiesOf('Primitives/Material UI', module);
+stories.add('Typography', () => (
+  <div>
+    <Typography variant="h5">H5 - Biggest header, not that we use it yet</Typography>
+    <Typography variant="h6">H6 - Most used header</Typography>
+
+    <Typography variant="body1">body 1 - for regular text</Typography>
+    <Typography variant="body2">body 2 - looks like the same as body1?</Typography>
+
+    <Typography variant="subtitle1">Subtitle1 - just some text for visibility</Typography>
+    <Typography variant="overline">Overline - with some real text</Typography>
+  </div>
+));

--- a/src/components/flytegraph/ReactFlow/ReactFlowGraphComponent.tsx
+++ b/src/components/flytegraph/ReactFlow/ReactFlowGraphComponent.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { ConvertFlyteDagToReactFlows } from 'components/flytegraph/ReactFlow/transformDAGToReactFlowV2';
 import { useState, useEffect } from 'react';
+import { ConvertFlyteDagToReactFlows } from 'components/flytegraph/ReactFlow/transformDAGToReactFlowV2';
+import { createDebugLogger } from 'common/log';
 import { RFWrapperProps, RFGraphTypes, ConvertDagProps } from './types';
 import { getRFBackground } from './utils';
 import { ReactFlowWrapper } from './ReactFlowWrapper';
 import { Legend } from './NodeStatusLegend';
-import { createDebugLogger } from '../utils';
 
 const debug = createDebugLogger('@ReactFlowGraphComponent');
 

--- a/src/components/flytegraph/ReactFlow/ReactFlowWrapper.tsx
+++ b/src/components/flytegraph/ReactFlow/ReactFlowWrapper.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useState, useEffect, useCallback } from 'react';
 import ReactFlow, { Background } from 'react-flow-renderer';
+import { createDebugLogger } from 'common/log';
 import { RFWrapperProps } from './types';
 import {
   ReactFlowCustomEndNode,
@@ -13,7 +14,6 @@ import {
   ReactFlowStaticNode,
 } from './customNodeComponents';
 import { getPositionedNodes, ReactFlowIdHash } from './utils';
-import { createDebugLogger } from '../utils';
 
 const debug = createDebugLogger('@ReactFlowWrapper');
 

--- a/src/components/flytegraph/ReactFlow/transformDAGToReactFlowV2.tsx
+++ b/src/components/flytegraph/ReactFlow/transformDAGToReactFlowV2.tsx
@@ -1,9 +1,9 @@
 import { dEdge, dNode, dTypes } from 'models/Graph/types';
 import { Edge, Node, Position } from 'react-flow-renderer';
 import { NodeExecutionPhase } from 'models/Execution/enums';
+import { createDebugLogger } from 'common/log';
 import { ReactFlowGraphConfig } from './utils';
 import { ConvertDagProps } from './types';
-import { createDebugLogger } from '../utils';
 
 interface rfNode extends Node {
   isRootParentNode?: boolean;

--- a/src/components/flytegraph/constants.ts
+++ b/src/components/flytegraph/constants.ts
@@ -1,6 +1,3 @@
-import { colors } from './theme';
-import { GraphConfig } from './types';
-
 export const componentIds = {
   arrowhead: 'arrowhead',
 };
@@ -12,22 +9,3 @@ export const layoutSize = 1000;
 // Adjusts the amount of room between edges of adjacent nodes.
 // Greater values lead to more space.
 export const nodeSpacingMultiplier = 1.5;
-
-export const defaultGraphConfig: GraphConfig = {
-  node: {
-    cornerRounding: 10,
-    fillColor: colors.white,
-    fontSize: 14,
-    selectStrokeColor: colors.blue,
-    selectStrokeWidth: 4,
-    strokeColor: colors.darkGray1,
-    strokeWidth: 2,
-    textPadding: 10,
-  },
-  nodeLink: {
-    strokeColor: colors.gray4,
-    strokeWidth: 1,
-  },
-};
-
-export const logPrefix = 'flytegraph';

--- a/src/components/flytegraph/layoutUtils.ts
+++ b/src/components/flytegraph/layoutUtils.ts
@@ -1,9 +1,10 @@
 import * as d3 from 'd3-dag';
 import { cloneDeep } from 'lodash';
+import { createDebugLogger } from 'common/log';
 import { layoutSize, nodeSpacingMultiplier } from './constants';
 import { createTimer } from './timer';
 import { GraphConfig, GraphInputNode, GraphLayoutResult, RenderableNode } from './types';
-import { createDebugLogger, groupBy } from './utils';
+import { groupBy } from './utils';
 
 const log = createDebugLogger('layout');
 

--- a/src/components/flytegraph/utils.ts
+++ b/src/components/flytegraph/utils.ts
@@ -1,8 +1,4 @@
-import debug from 'debug';
-import { logPrefix } from './constants';
 import { Point } from './types';
-
-export const createDebugLogger = (namespace: string) => debug(`${logPrefix}:${namespace}`);
 
 /** Simple helper to get the midpoint between two points a & b */
 export function getMidpoint(a: Point, b: Point) {

--- a/src/models/Task/constants.ts
+++ b/src/models/Task/constants.ts
@@ -22,11 +22,3 @@ export const taskSortFields = {
   createdAt: 'created_at',
   name: 'name',
 };
-
-export function isMapTaskType(taskType?: string): boolean {
-  return (
-    taskType === TaskType.ARRAY ||
-    taskType === TaskType.ARRAY_AWS ||
-    taskType === TaskType.ARRAY_K8S
-  );
-}

--- a/src/models/Task/constants.ts
+++ b/src/models/Task/constants.ts
@@ -12,9 +12,21 @@ export enum TaskType {
   UNKNOWN = 'unknown',
   WAITABLE = 'waitable',
   MPI = 'mpi',
+
+  // plugins
+  ARRAY_AWS = 'aws-batch',
+  ARRAY_K8S = 'k8s-array',
 }
 
 export const taskSortFields = {
   createdAt: 'created_at',
   name: 'name',
 };
+
+export function isMapTaskType(taskType?: string): boolean {
+  return (
+    taskType === TaskType.ARRAY ||
+    taskType === TaskType.ARRAY_AWS ||
+    taskType === TaskType.ARRAY_K8S
+  );
+}

--- a/src/models/Task/task.test.ts
+++ b/src/models/Task/task.test.ts
@@ -1,4 +1,5 @@
-import { isMapTaskType, TaskType } from './constants';
+import { TaskType } from './constants';
+import { isMapTaskType } from './utils';
 
 describe('models/Task', () => {
   it('isMapTaskType propely identifies mapped tasks', async () => {

--- a/src/models/Task/task.test.ts
+++ b/src/models/Task/task.test.ts
@@ -1,0 +1,16 @@
+import { isMapTaskType, TaskType } from './constants';
+
+describe('models/Task', () => {
+  it('isMapTaskType propely identifies mapped tasks', async () => {
+    // when no task is provided - to be false
+    expect(isMapTaskType()).toBeFalsy();
+
+    // when mapped task is provided - to be true
+    expect(isMapTaskType(TaskType.ARRAY)).toBeTruthy();
+    expect(isMapTaskType(TaskType.ARRAY_AWS)).toBeTruthy();
+    expect(isMapTaskType(TaskType.ARRAY_K8S)).toBeTruthy();
+
+    // when regular task is provided - to be false
+    expect(isMapTaskType(TaskType.PYTHON)).toBeFalsy();
+  });
+});

--- a/src/models/Task/utils.ts
+++ b/src/models/Task/utils.ts
@@ -3,6 +3,7 @@ import { createPaginationTransformer } from 'models/AdminEntity/utils';
 import { endpointPrefixes } from 'models/Common/constants';
 import { IdentifierScope } from 'models/Common/types';
 import { makeIdentifierPath } from 'models/Common/utils';
+import { TaskType } from './constants';
 import { Task } from './types';
 
 /** Generate the correct path for retrieving a task or list of tasks based on the
@@ -14,3 +15,12 @@ export function makeTaskPath(scope: IdentifierScope) {
 
 /** Transformer to coerce an `Admin.TaskList` into a standard shape */
 export const taskListTransformer = createPaginationTransformer<Task, Admin.TaskList>('tasks');
+
+/** Returns true if tasks schema is treated as a map task */
+export function isMapTaskType(taskType?: string): boolean {
+  return (
+    taskType === TaskType.ARRAY ||
+    taskType === TaskType.ARRAY_AWS ||
+    taskType === TaskType.ARRAY_K8S
+  );
+}


### PR DESCRIPTION
This PR adds some side cleaning of our code and adds a simple component to show logs for Map tasks
The feature work would be done in separate PR and should be much easier to check with this data being out of the way.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
PR covers:
- Adding current typography preview to Storybook
<img width="762" alt="Screen Shot 2022-03-22 at 11 11 51 AM" src="https://user-images.githubusercontent.com/55718143/159549996-530d4cc9-0c73-460c-9498-771fb9a2c5b1.png">
- Ensure that storybook first will show Primitives and Common folders, and than everything else
- Remove single story folders from Storybook
- Remove duplicated debug logger "implementation" from utils file. Now it always would be imported from 'common/log';
- Added two common task types which should be always interpreted as arrays in flyteconsole: `aws-batch` and `k8s-array`
- Ensure that tasks always use proper DisplayType in Node and TaskDetailsPanel view. Graph view will always use taskType from data - as it does now.  Which means that Node will show task as "Python Task" while graph will use "python-task" string.
Before:
<img width="1157" alt="Screen Shot 2022-03-22 at 11 06 44 AM" src="https://user-images.githubusercontent.com/55718143/159550456-156ddc40-4e34-4ed7-9eda-48c4e20e115f.png">
After:
<img width="1156" alt="Screen Shot 2022-03-22 at 11 06 53 AM" src="https://user-images.githubusercontent.com/55718143/159550470-61e4d141-342a-47e5-ab58-f08af9aa31ee.png">
- Added basic MappedTaskListItem, which shows task Phase and links to the logs (Not in use currently)
<img width="597" alt="Screen Shot 2022-03-22 at 11 15 22 AM" src="https://user-images.githubusercontent.com/55718143/159550777-80b0d3da-aedc-4f80-af83-df75d7dcef9a.png">
<img width="873" alt="Screen Shot 2022-03-22 at 11 15 31 AM" src="https://user-images.githubusercontent.com/55718143/159550786-ba8e7882-7d16-4b06-a44b-fcbdb93f4bca.png">

## Tracking Issue
https://github.com/flyteorg/flyteconsole/issues/310 - prepares code to easier implementation

