### PR TITLE
chore: cleaning up eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,10 @@ module.exports = {
     },
   },
   rules: {
-    // "off" or 0: turn off the rule completely; "warn" or 1;  "error" or 2
+    /**
+     * Rules we don't want to be enabled
+     * "off" or 0: turn off the rule completely; "warn" or 1;  "error" or 2
+     */
     'arrow-body-style': 'off',
     'import/extensions': 'off',
     'import/prefer-default-export': 'off',
@@ -30,7 +33,15 @@ module.exports = {
     'react/jsx-filename-extension': [2, { extensions: ['.jsx', '.tsx'] }],
     'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
 
-    // up for discussion
+    // disabled to let "@typescript-eslint/*" rules do it's job
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    'no-redeclare': 'off',
+    '@typescript-eslint/no-redeclare': ['warn', { ignoreDeclarationMerge: true }], // still will warn on exporting enums :(
+
+    /**
+     * Up for discussion
+     * */
     'react/function-component-definition': 'off',
     'react/destructuring-assignment': 'off',
 
@@ -44,10 +55,8 @@ module.exports = {
     'react/jsx-props-no-spreading': 'off', // 119
 
     // classic
-    'no-unused-vars': 'off', // 364
-    'no-use-before-define': 'warn', // 49
+    'no-use-before-define': 'off', // 49
     'no-shadow': 'off', // 104
-    'no-redeclare': 'warn', // 16
     'no-param-reassign': 'off', // 28
     'no-unused-expressions': 'warn', // 6
     'prefer-destructuring': 'off', // 34
@@ -57,7 +66,6 @@ module.exports = {
     'no-useless-computed-key': 'off',
     'no-restricted-syntax': 'off',
     'no-else-return': 'off',
-    'no-console': 'warn',
     'no-plusplus': 'off',
     'no-var': 'off',
     'no-continue': 'off',
@@ -89,7 +97,6 @@ module.exports = {
     'prefer-arrow-callback': 'off',
     'func-names': 'off',
     eqeqeq: 'warn',
-    camelcase: 'warn',
 
     // import
     'import/no-dynamic-require': 'warn', // 1
@@ -99,36 +106,35 @@ module.exports = {
     'react/jsx-no-useless-fragment': 'off', // 15
     'react/no-access-state-in-setstate': 'warn', // 2
     'react/jsx-no-bind': 'warn', // 3
-    'react/prop-types': 'off',
-    'react/jsx-curly-brace-presence': 'off',
+    'react/prop-types': 'off', // 69
     'react/self-closing-comp': 'off',
     'react/jsx-no-constructed-context-values': 'off',
     'react/no-unstable-nested-components': 'off',
     'react/no-unescaped-entities': 'off',
     'react/require-default-props': 'off',
-    'react/no-unused-prop-types': 'off',
-    'react/no-array-index-key': 'off',
-    'react/no-unused-state': 'off',
-    'react/static-property-placement': 'off',
-    'react/state-in-constructor': 'off',
-    'react/no-children-prop': 'off',
-    'react/sort-comp': 'off',
+    'react/no-unused-prop-types': 'off', // 15
+    'react/no-array-index-key': 'warn', // 5
+    'react/static-property-placement': 'off', // 1
+    'react/state-in-constructor': 'off', // 2
+    'react/no-children-prop': 'off', // 1
 
     // jsx-a11y
-    'jsx-a11y/aria-role': 'off',
-    'jsx-a11y/anchor-is-valid': 'off',
-    'jsx-a11y/click-events-have-key-events': 'off',
-    'jsx-a11y/no-noninteractive-element-interactions': 'off',
-    'jsx-a11y/no-static-element-interactions': 'off',
-    'jsx-a11y/control-has-associated-label': 'off',
+    'jsx-a11y/anchor-is-valid': 'off', // 4
+    'jsx-a11y/no-noninteractive-element-interactions': 'off', // 1
+    'jsx-a11y/click-events-have-key-events': 'off', // 7
+    'jsx-a11y/no-static-element-interactions': 'off', // 6
   },
   overrides: [
     {
       // overrides for test files
       files: ['*.spec.*', '*.test.*', 'src/**/test/*'],
       rules: {
+        camelcase: 'off',
         '@typescript-eslint/no-explicit-any': 'off',
         'import/no-extraneous-dependencies': 'off',
+
+        'jsx-a11y/aria-role': 'off',
+        'jsx-a11y/control-has-associated-label': 'off',
       },
     },
   ],

--- a/src/components/Entities/EntitySchedules.tsx
+++ b/src/components/Entities/EntitySchedules.tsx
@@ -5,6 +5,7 @@ import { useCommonStyles } from 'components/common/styles';
 import { WaitForData } from 'components/common/WaitForData';
 import { useWorkflowSchedules } from 'components/hooks/useWorkflowSchedules';
 import { ResourceIdentifier } from 'models/Common/types';
+import { identifierToString } from 'models/Common/utils';
 import { LaunchPlan } from 'models/Launch/types';
 import * as React from 'react';
 import { entityStrings } from './constants';
@@ -22,14 +23,14 @@ const RenderSchedules: React.FC<{
   const commonStyles = useCommonStyles();
   return (
     <ul className={commonStyles.listUnstyled}>
-      {launchPlans.map((launchPlan, idx) => {
+      {launchPlans.map((launchPlan) => {
         const { schedule } = launchPlan.spec.entityMetadata;
         const frequencyString = getScheduleFrequencyString(schedule);
         const offsetString = getScheduleOffsetString(schedule);
         const scheduleString = offsetString
           ? `${frequencyString} (offset by ${offsetString})`
           : frequencyString;
-        return <li key={idx}>{scheduleString}</li>;
+        return <li key={identifierToString(launchPlan.id)}>{scheduleString}</li>;
       })}
     </ul>
   );

--- a/src/components/Executions/ExecutionDetails/NodeExecutionDetailsPanelContent.tsx
+++ b/src/components/Executions/ExecutionDetails/NodeExecutionDetailsPanelContent.tsx
@@ -171,7 +171,7 @@ const ExecutionTypeDetails: React.FC<{
         <div className={classnames(commonStyles.microHeader, commonStyles.textMuted)}>Type</div>
         <div>{details ? details.displayType : <Skeleton />}</div>
       </div>
-      {<NodeExecutionLinkContent execution={execution} />}
+      <NodeExecutionLinkContent execution={execution} />
     </div>
   );
 };

--- a/src/components/Navigation/VersionDisplayModal.tsx
+++ b/src/components/Navigation/VersionDisplayModal.tsx
@@ -112,7 +112,7 @@ export const VersionDisplayModal: React.FC<VersionDisplayModalProps> = ({ onClos
         <div className={styles.versionWrapper}>
           <span>Google Analytics</span>
           <Link
-            href={`https://github.com/flyteorg/flyteconsole#google-analytics`}
+            href="https://github.com/flyteorg/flyteconsole#google-analytics"
             className={styles.version}
             target="_blank"
           >

--- a/src/components/Project/ProjectExecutions.tsx
+++ b/src/components/Project/ProjectExecutions.tsx
@@ -134,7 +134,7 @@ export const ProjectExecutions: React.FC<ProjectExecutionsProps> = ({
       moreItemsAvailable={!!query.hasNextPage}
       showWorkflowName={true}
       isFetching={query.isFetching}
-      data-testid={'workflow-table'}
+      data-testid="workflow-table"
     />
   );
 

--- a/src/components/SelectProject/ProjectList.tsx
+++ b/src/components/SelectProject/ProjectList.tsx
@@ -22,8 +22,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-export interface ProjectListProps {
-  error?: string;
+interface ProjectListProps {
   projects: Project[];
 }
 

--- a/src/components/Tables/LoadMoreRowContent.tsx
+++ b/src/components/Tables/LoadMoreRowContent.tsx
@@ -5,7 +5,7 @@ import { useCommonStyles } from 'components/common/styles';
 import * as React from 'react';
 import { loadMoreRowGridHeight } from './constants';
 
-export const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles((theme: Theme) => ({
   loadMoreRowContainer: {
     alignItems: ' center',
     display: ' flex',
@@ -20,8 +20,7 @@ export const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-export interface LoadMoreRowContentProps {
-  className?: string;
+interface LoadMoreRowContentProps {
   lastError: string | Error | null;
   isFetching: boolean;
   style?: any;

--- a/src/components/common/DetailsPanel.tsx
+++ b/src/components/common/DetailsPanel.tsx
@@ -21,11 +21,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   spacer: theme.mixins.toolbar as CSSProperties,
 }));
 
-interface DetailsPanelProps extends React.Props<{}> {
+interface DetailsPanelProps {
   onClose?: () => void;
   open?: boolean;
-  /** Width of this container, accepts any valid CSS width value */
-  width?: string | number;
 }
 
 /** A shared panel rendered along the right side of the UI. Content can be

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -37,7 +37,6 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 interface ErrorBoundaryState {
   error?: Error;
-  hasError: boolean;
 }
 
 const RenderError: React.FC<{ error: Error; fixed: boolean }> = ({ error, fixed }) => {
@@ -70,10 +69,7 @@ const RenderError: React.FC<{ error: Error; fixed: boolean }> = ({ error, fixed 
 export class ErrorBoundary extends React.Component<{ fixed?: boolean }, ErrorBoundaryState> {
   constructor(props: object) {
     super(props);
-    this.state = {
-      error: undefined,
-      hasError: false,
-    };
+    this.state = { error: undefined };
   }
 
   componentDidCatch(error: Error, info: unknown) {

--- a/src/components/common/ExpandableContentLink.tsx
+++ b/src/components/common/ExpandableContentLink.tsx
@@ -1,7 +1,7 @@
 import { Button, Link } from '@material-ui/core';
 import * as React from 'react';
 
-export interface ExpandableContentLinkProps {
+interface ExpandableContentLinkProps {
   /** Set to true to allow hiding the content after it is initially expanded */
   allowCollapse?: boolean;
   /** Use a button instead of a link */
@@ -37,10 +37,6 @@ export class ExpandableContentLink extends React.Component<ExpandableContentLink
   state = {
     showContent: false,
   };
-
-  public render() {
-    return this.state.showContent ? this.renderExpanded() : this.renderCollapsed();
-  }
 
   private renderToggleComponent = () => {
     const { button, collapsedText, expandedText, toggleClassName } = this.props;
@@ -95,4 +91,8 @@ export class ExpandableContentLink extends React.Component<ExpandableContentLink
       onExpand();
     }
   };
+
+  public render() {
+    return this.state.showContent ? this.renderExpanded() : this.renderCollapsed();
+  }
 }

--- a/src/components/common/__stories__/BarChart.stories.tsx
+++ b/src/components/common/__stories__/BarChart.stories.tsx
@@ -28,10 +28,10 @@ stories.add('BarChartItem', () => {
   const styles = useStyles();
   return (
     <div className={styles.body} style={{ width: '150px' }}>
-      <BarChartItem isSelected={false} value={50} color={'green'} />
-      <BarChartItem isSelected={true} value={100} color={'green'} tooltip={tooltipMock} />
-      <BarChartItem isSelected={false} value={75} color={'red'} tooltip={tooltipMock} />
-      <BarChartItem isSelected={false} value={12} color={'red'} tooltip={tooltipMock} />
+      <BarChartItem isSelected={false} value={50} color="green" />
+      <BarChartItem isSelected={true} value={100} color="green" tooltip={tooltipMock} />
+      <BarChartItem isSelected={false} value={75} color="red" tooltip={tooltipMock} />
+      <BarChartItem isSelected={false} value={12} color="red" tooltip={tooltipMock} />
     </div>
   );
 });

--- a/src/components/flytegraph/InteractiveViewBox.tsx
+++ b/src/components/flytegraph/InteractiveViewBox.tsx
@@ -203,5 +203,3 @@ export const InteractiveViewBox: React.FC<InteractiveViewBoxProps> = (props) => 
   // changed.
   <InteractiveViewBoxImpl {...props} key={`${props.width}_${props.height}`} />
 );
-
-// narusina - is it in use?

--- a/src/components/flytegraph/InteractiveViewBox.tsx
+++ b/src/components/flytegraph/InteractiveViewBox.tsx
@@ -6,12 +6,12 @@ const viewBoxStyles = {
   width: '100%',
 };
 
-export interface InteractiveViewBoxChildrenProps {
+interface InteractiveViewBoxChildrenProps {
   /** An SVG viewbox string, suitable for use in a `<svg />` element */
   viewBox: string;
 }
 
-export interface InteractiveViewBoxProps {
+interface InteractiveViewBoxProps {
   /** A single function component which will accept the current viewBox
    * string and render arbitrary content
    */
@@ -111,17 +111,6 @@ class InteractiveViewBoxImpl extends React.Component<InteractiveViewBoxProps> {
     }
   }
 
-  private updateViewBox(viewBox: ViewBoxRect) {
-    this.viewBox = viewBox;
-    if (!this.updating) {
-      this.updating = true;
-      window.requestAnimationFrame(() => {
-        this.forceUpdate();
-        this.updating = false;
-      });
-    }
-  }
-
   private onWheel = (event: WheelEvent) => {
     event.preventDefault();
     // Make the zooming less twitchy
@@ -181,6 +170,17 @@ class InteractiveViewBoxImpl extends React.Component<InteractiveViewBoxProps> {
     this.updateViewBox(translateViewBox(this.viewBox, deltaX, deltaY));
   };
 
+  private updateViewBox(viewBox: ViewBoxRect) {
+    this.viewBox = viewBox;
+    if (!this.updating) {
+      this.updating = true;
+      window.requestAnimationFrame(() => {
+        this.forceUpdate();
+        this.updating = false;
+      });
+    }
+  }
+
   public render() {
     const { x, y, width, height } = this.viewBox;
     const viewBox = `${x},${y},${width},${height}`;
@@ -203,3 +203,5 @@ export const InteractiveViewBox: React.FC<InteractiveViewBoxProps> = (props) => 
   // changed.
   <InteractiveViewBoxImpl {...props} key={`${props.width}_${props.height}`} />
 );
+
+// narusina - is it in use?

--- a/src/components/flytegraph/ReactFlow/NodeStatusLegend.tsx
+++ b/src/components/flytegraph/ReactFlow/NodeStatusLegend.tsx
@@ -80,7 +80,7 @@ export const Legend = () => {
             />
           );
         })}
-        <LegendItem color={'#aaa'} text={'Nested'} />
+        <LegendItem color="#aaa" text="Nested" />
       </div>
     );
   };

--- a/src/components/flytegraph/RenderedGraph.tsx
+++ b/src/components/flytegraph/RenderedGraph.tsx
@@ -26,6 +26,52 @@ export class RenderedGraph<T> extends React.Component<RenderedGraphProps<T>, Ren
     this.containerClickHandler = new DragFilteringClickHandler(this.onContainerClick);
   }
 
+  private clearSelection = () => {
+    // Don't need to trigger a re-render if selection is already empty
+    if (!this.props.selectedNodes || this.props.selectedNodes.length === 0) {
+      return;
+    }
+    this.props.onNodeSelectionChanged && this.props.onNodeSelectionChanged([]);
+  };
+
+  private onNodeEnter = (id: string) => {
+    const hoveredNodes: Dictionary<boolean> = {
+      ...this.state.hoveredNodes,
+      [id]: true,
+    };
+    this.setState({ hoveredNodes });
+    this.props.onNodeEnter && this.props.onNodeEnter(id);
+  };
+
+  private onNodeLeave = (id: string) => {
+    const hoveredNodes: Dictionary<boolean> = {
+      ...this.state.hoveredNodes,
+    };
+    delete hoveredNodes[id];
+    this.setState({ hoveredNodes });
+    this.props.onNodeLeave && this.props.onNodeLeave(id);
+  };
+
+  private onNodeSelect = (id: string) => {
+    // Only supporting single-select at the moment. So if we clicked
+    // a selected node, reset it. Otherwise, the clicked node is the
+    // new selection
+    if (this.props.selectedNodes && this.props.selectedNodes.includes(id)) {
+      return this.clearSelection();
+    }
+
+    this.props.onNodeSelectionChanged && this.props.onNodeSelectionChanged([id]);
+  };
+
+  private onNodeClick = (id: string) => {
+    this.props.onNodeClick && this.props.onNodeClick(id);
+    this.onNodeSelect(id);
+  };
+
+  private onContainerClick = () => {
+    this.clearSelection();
+  };
+
   public render() {
     const {
       config,
@@ -104,50 +150,4 @@ export class RenderedGraph<T> extends React.Component<RenderedGraphProps<T>, Ren
       </svg>
     );
   }
-
-  private clearSelection = () => {
-    // Don't need to trigger a re-render if selection is already empty
-    if (!this.props.selectedNodes || this.props.selectedNodes.length === 0) {
-      return;
-    }
-    this.props.onNodeSelectionChanged && this.props.onNodeSelectionChanged([]);
-  };
-
-  private onNodeEnter = (id: string) => {
-    const hoveredNodes: Dictionary<boolean> = {
-      ...this.state.hoveredNodes,
-      [id]: true,
-    };
-    this.setState({ hoveredNodes });
-    this.props.onNodeEnter && this.props.onNodeEnter(id);
-  };
-
-  private onNodeLeave = (id: string) => {
-    const hoveredNodes: Dictionary<boolean> = {
-      ...this.state.hoveredNodes,
-    };
-    delete hoveredNodes[id];
-    this.setState({ hoveredNodes });
-    this.props.onNodeLeave && this.props.onNodeLeave(id);
-  };
-
-  private onNodeSelect = (id: string) => {
-    // Only supporting single-select at the moment. So if we clicked
-    // a selected node, reset it. Otherwise, the clicked node is the
-    // new selection
-    if (this.props.selectedNodes && this.props.selectedNodes.includes(id)) {
-      return this.clearSelection();
-    }
-
-    this.props.onNodeSelectionChanged && this.props.onNodeSelectionChanged([id]);
-  };
-
-  private onNodeClick = (id: string) => {
-    this.props.onNodeClick && this.props.onNodeClick(id);
-    this.onNodeSelect(id);
-  };
-
-  private onContainerClick = () => {
-    this.clearSelection();
-  };
 }

--- a/src/models/AdminEntity/types.ts
+++ b/src/models/AdminEntity/types.ts
@@ -13,10 +13,15 @@ export enum FilterOperationName {
   VALUE_IN = 'value_in',
 }
 
+/* It's an ENUM exports, and as such need to be exported as both type and const value */
+/* eslint-disable @typescript-eslint/no-redeclare */
+export type SortDirection = Admin.Sort.Direction;
+export const SortDirection = Admin.Sort.Direction;
+/* eslint-enable @typescript-eslint/no-redeclare */
+
 /** Represents a query filter for collection endpoints. Multiple filters can be combined into a single
  * query string.
  */
-
 export type FilterOperationValue = string | number;
 export type FilterOperationValueList = FilterOperationValue[];
 export type FilterOperationValueGenerator = () => FilterOperationValue | FilterOperationValueList;
@@ -27,9 +32,6 @@ export interface FilterOperation {
 }
 
 export type FilterOperationList = FilterOperation[];
-
-export type SortDirection = Admin.Sort.Direction;
-export const SortDirection = Admin.Sort.Direction;
 export type Sort = RequiredNonNullable<Admin.ISort>;
 
 /** Generic interface for any class which can be used to decode a protobuf message. */

--- a/src/models/Common/types.ts
+++ b/src/models/Common/types.ts
@@ -4,11 +4,27 @@ import { Admin, Core, Protobuf } from 'flyteidl';
 /** These are types shared across multiple sections of the data model. Most of
  * map to types found in `flyteidl.core`.
  */
+
+/* It's an ENUM exports, and as such need to be exported as both type and const value */
+/* eslint-disable @typescript-eslint/no-redeclare */
+export type SimpleType = Core.SimpleType;
+export const SimpleType = Core.SimpleType;
+export type EnumType = Core.EnumType;
+export const EnumType = Core.EnumType;
+export type FixedRateUnit = Admin.FixedRateUnit;
+export const FixedRateUnit = Admin.FixedRateUnit;
+export type ResourceType = Core.ResourceType;
+export const ResourceType = Core.ResourceType;
+export type BlobDimensionality = Core.BlobType.BlobDimensionality;
+export const BlobDimensionality = Core.BlobType.BlobDimensionality;
+export type SchemaColumnType = Core.SchemaType.SchemaColumn.SchemaColumnType;
+export const SchemaColumnType = Core.SchemaType.SchemaColumn.SchemaColumnType;
+/* eslint-enable @typescript-eslint/no-redeclare */
+
 export type Alias = Core.IAlias;
 export type Binding = Core.IBinding;
 export type Container = Core.IContainer;
-export type FixedRateUnit = Admin.FixedRateUnit;
-export const FixedRateUnit = Admin.FixedRateUnit;
+
 export interface Identifier extends Core.IIdentifier {
   resourceType?: ResourceType;
   project: string;
@@ -30,8 +46,6 @@ export interface NamedEntity extends Admin.INamedEntity {
   metadata: NamedEntityMetadata;
 }
 export type Notification = Admin.INotification;
-export type ResourceType = Core.ResourceType;
-export const ResourceType = Core.ResourceType;
 export type RetryStrategy = Core.IRetryStrategy;
 export type RuntimeMetadata = Core.IRuntimeMetadata;
 export type Schedule = Admin.ISchedule;
@@ -48,8 +62,6 @@ export interface Blob extends Core.IBlob {
   metadata: BlobMetadata;
   uri: string;
 }
-export type BlobDimensionality = Core.BlobType.BlobDimensionality;
-export const BlobDimensionality = Core.BlobType.BlobDimensionality;
 
 export interface BlobMetadata extends Core.IBlobMetadata {
   type: BlobType;
@@ -103,9 +115,6 @@ export interface SchemaColumn extends Core.SchemaType.ISchemaColumn {
   type: SchemaColumnType;
 }
 
-export type SchemaColumnType = Core.SchemaType.SchemaColumn.SchemaColumnType;
-export const SchemaColumnType = Core.SchemaType.SchemaColumn.SchemaColumnType;
-
 export interface SchemaType extends Core.ISchemaType {
   columns: SchemaColumn[];
 }
@@ -140,11 +149,6 @@ export interface LiteralType extends Core.ILiteralType {
   simple?: SimpleType;
   enumType?: EnumType;
 }
-
-export type SimpleType = Core.SimpleType;
-export const SimpleType = Core.SimpleType;
-export type EnumType = Core.EnumType;
-export const EnumType = Core.EnumType;
 
 export interface Variable extends Core.IVariable {
   type: LiteralType;

--- a/src/models/Execution/enums.ts
+++ b/src/models/Execution/enums.ts
@@ -5,6 +5,8 @@ import { Admin, Core } from 'flyteidl';
  * modules individually (such as when running with ts-jest)
  */
 
+/* It's an ENUM exports, and as such need to be exported as both type and const value */
+/* eslint-disable @typescript-eslint/no-redeclare */
 export type ExecutionState = Admin.ExecutionState;
 export const ExecutionState = Admin.ExecutionState;
 export type ExecutionMode = Admin.ExecutionMetadata.ExecutionMode;
@@ -15,3 +17,4 @@ export type NodeExecutionPhase = Core.NodeExecution.Phase;
 export const NodeExecutionPhase = Core.NodeExecution.Phase;
 export type TaskExecutionPhase = Core.TaskExecution.Phase;
 export const TaskExecutionPhase = Core.TaskExecution.Phase;
+/* eslint-enable @typescript-eslint/no-redeclare */

--- a/src/models/Launch/types.ts
+++ b/src/models/Launch/types.ts
@@ -34,5 +34,9 @@ export interface LaunchPlan extends Admin.ILaunchPlan {
 }
 
 export type LaunchPlanId = Identifier;
+
+/* It's an ENUM exports, and as such need to be exported as both type and const value */
+/* eslint-disable @typescript-eslint/no-redeclare */
 export type LaunchPlanState = Admin.LaunchPlanState;
 export const LaunchPlanState = Admin.LaunchPlanState;
+/* eslint-enable @typescript-eslint/no-redeclare */


### PR DESCRIPTION
Signed-off-by: Nastya Rusina <nastya@union.ai>

Updated some eslint rules settings, to ensure more accurate erroring. 
Fixed errors which were not required more detailed testing:

- Updated `no-unused-vars` and `no-redeclare` to typescript versions
- Allowed to break `camelcase` and `jsx-a11y/*` rules in **test** and **storybook** files
- removed some unused variables, which was obviously not in use (left in place those which require some investigation)
- removed unused exports for Props interfaces (we should limit export usage only if type is needed to be reused - it minimizes release package size)
- moved render functions to the end of class ( in two places) - no code change
- disabled `no-redeclare` rule for enum declarations

## Type
 - [X] Chore
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?
 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

