### PR TITLE
fix: stop displaying empty descriptions

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -4,7 +4,6 @@ export const navBarContentId = 'nav-bar-content';
 
 export const unknownValueString = '(unknown)';
 export const dashedValueString = '----';
-export const noDescriptionString = '(No description)';
 export const noneString = '(none)';
 export const noExecutionsFoundString = 'No executions found.';
 export const noWorkflowVersionsFoundString = 'No workflow versions found.';

--- a/src/components/Task/SearchableTaskNameList.tsx
+++ b/src/components/Task/SearchableTaskNameList.tsx
@@ -3,7 +3,6 @@ import { makeStyles, Theme } from '@material-ui/core/styles';
 import ChevronRight from '@material-ui/icons/ChevronRight';
 import ErrorOutline from '@material-ui/icons/ErrorOutline';
 import classnames from 'classnames';
-import { noDescriptionString } from 'common/constants';
 import { SearchResult } from 'components/common/SearchableList';
 import {
   SearchableNamedEntity,
@@ -79,15 +78,17 @@ const TaskNameRow: React.FC<TaskNameRowProps> = ({ label, entityName }) => {
   const styles = useStyles();
   const listStyles = useNamedEntityListStyles();
   const [inViewRef, inView] = useInView(intersectionOptions);
-  const description = entityName.metadata.description || noDescriptionString;
+  const description = entityName?.metadata?.description;
 
   return (
     <div ref={inViewRef} className={listStyles.searchResult}>
       <div className={listStyles.itemName}>
         <div className={styles.taskName}>{label}</div>
-        <Typography variant="body2" className={styles.description}>
-          {description}
-        </Typography>
+        {description && (
+          <Typography variant="body2" className={styles.description}>
+            {description}
+          </Typography>
+        )}
         {!!inView && <TaskInterface taskName={entityName} />}
       </div>
       <ChevronRight className={listStyles.itemChevron} />

--- a/src/components/Workflow/SearchableWorkflowNameList.tsx
+++ b/src/components/Workflow/SearchableWorkflowNameList.tsx
@@ -11,6 +11,7 @@ import { WorkflowExecutionPhase } from 'models/Execution/enums';
 import { Shimmer } from 'components/common/Shimmer';
 import { WorkflowExecutionIdentifier } from 'models/Execution/types';
 import { debounce } from 'lodash';
+import { Typography } from '@material-ui/core';
 import { WorkflowListStructureItem } from './types';
 import ProjectStatusBar from '../Project/ProjectStatusBar';
 import { workflowNoInputsString } from '../Launch/LaunchForm/constants';
@@ -120,9 +121,11 @@ const SearchableWorkflowNameItem: React.FC<SearchableWorkflowNameItemProps> = Re
             <DeviceHub className={styles.itemIcon} />
             <div>{id.name}</div>
           </div>
-          <div className={styles.itemDescriptionRow}>
-            {description?.length ? description : 'This workflow has no description.'}
-          </div>
+          {description && (
+            <Typography variant="body2" className={styles.itemDescriptionRow}>
+              {description}
+            </Typography>
+          )}
           <div className={styles.itemRow}>
             <div className={styles.itemLabel}>Last execution time</div>
             <div className={styles.w100}>


### PR DESCRIPTION
Signed-off-by: Olga Nad <olga@union.ai>

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Workflow and task descriptions aren't properly populating due to issues on the backend, while they are being addressed, empty description string should not be rendered.

## Demo
Workflows
<img width="711" alt="Screen Shot 2022-03-25 at 9 56 39 AM" src="https://user-images.githubusercontent.com/101579322/160146668-5388e0f8-1b4c-480e-b26b-d8a674d56cd9.png">
Tasks
<img width="402" alt="Screen Shot 2022-03-25 at 9 56 52 AM" src="https://user-images.githubusercontent.com/101579322/160146697-5d528a3c-185b-4eaf-90be-5feb068fef5e.png">

