### PR TITLE
chore: eslint cleanup - eqeqeq, unused experession, index key

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,8 +49,8 @@ module.exports = {
      * temporarily off or warn
      * */
     // some setup of eslint or prettier needed
-    'no-undef': 'off', // 1066
-    'import/no-unresolved': 'off', // 1275
+    'no-undef': 'off', // 1k+, mainly tests and globals
+    'import/no-unresolved': 'off', // 1k+
     'import/no-extraneous-dependencies': 'off', // 715 - !important
     'react/jsx-props-no-spreading': 'off', // 119
 
@@ -58,11 +58,10 @@ module.exports = {
     'no-use-before-define': 'off', // 49
     'no-shadow': 'off', // 104
     'no-param-reassign': 'off', // 28
-    'no-unused-expressions': 'warn', // 6
+    'no-unused-expressions': 'warn', // 5
     'prefer-destructuring': 'off', // 34
-    'max-classes-per-file': 'warn', // 2
     'no-empty-function': 'off',
-    'no-useless-constructor': 'warn',
+    'no-useless-constructor': 'warn', // 1
     'no-useless-computed-key': 'off',
     'no-restricted-syntax': 'off',
     'no-else-return': 'off',
@@ -96,7 +95,7 @@ module.exports = {
     'prefer-promise-reject-errors': 'off',
     'prefer-arrow-callback': 'off',
     'func-names': 'off',
-    eqeqeq: 'warn',
+    eqeqeq: 'warn', // 12
 
     // import
     'import/no-dynamic-require': 'warn', // 1
@@ -113,10 +112,10 @@ module.exports = {
     'react/no-unescaped-entities': 'off',
     'react/require-default-props': 'off',
     'react/no-unused-prop-types': 'off', // 15
-    'react/no-array-index-key': 'warn', // 5
-    'react/static-property-placement': 'off', // 1
-    'react/state-in-constructor': 'off', // 2
-    'react/no-children-prop': 'off', // 1
+    'react/no-array-index-key': 'warn', // 2
+    'react/static-property-placement': 'warn', // 1
+    'react/state-in-constructor': 'warn', // 2
+    'react/no-children-prop': 'warn', // 1
 
     // jsx-a11y
     'jsx-a11y/anchor-is-valid': 'off', // 4
@@ -127,11 +126,12 @@ module.exports = {
   overrides: [
     {
       // overrides for test files
-      files: ['*.spec.*', '*.test.*', 'src/**/test/*'],
+      files: ['*.spec.*', '*.test.*', '*.stories.*', 'src/**/test/*', 'src/**/mocks/*'],
       rules: {
         camelcase: 'off',
         '@typescript-eslint/no-explicit-any': 'off',
         'import/no-extraneous-dependencies': 'off',
+        'no-console': 'off',
 
         'jsx-a11y/aria-role': 'off',
         'jsx-a11y/control-has-associated-label': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,13 @@ module.exports = {
   env: {
     browser: true,
     es2021: true,
+    jest: true,
+  },
+  globals: {
+    // global variables, that should be assumed by eslint as defined
+    JSX: true,
+    RequiredNonNullable: true,
+    Dictionary: true,
   },
   parser: '@typescript-eslint/parser',
   parserOptions: {
@@ -28,6 +35,7 @@ module.exports = {
      */
     'arrow-body-style': 'off',
     'import/extensions': 'off',
+    'import/no-unresolved': 'off',
     'import/prefer-default-export': 'off',
     'react/jsx-boolean-value': 'off',
     'react/jsx-filename-extension': [2, { extensions: ['.jsx', '.tsx'] }],
@@ -49,8 +57,6 @@ module.exports = {
      * temporarily off or warn
      * */
     // some setup of eslint or prettier needed
-    'no-undef': 'off', // 1k+, mainly tests and globals
-    'import/no-unresolved': 'off', // 1k+
     'import/no-extraneous-dependencies': 'off', // 715 - !important
     'react/jsx-props-no-spreading': 'off', // 119
 
@@ -135,6 +141,13 @@ module.exports = {
 
         'jsx-a11y/aria-role': 'off',
         'jsx-a11y/control-has-associated-label': 'off',
+      },
+    },
+    {
+      // rules which not make sense for TS files
+      files: ['*.ts', '*.tsx'],
+      rules: {
+        'no-undef': 'off',
       },
     },
   ],

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
  * This file is NOT compiled and is run directly by Node.js. Make sure you are not using JavaScript features that
  * does not exist in Node.js runtime.
  */
+/* eslint-disable no-console */
 const morgan = require('morgan');
 const express = require('express');
 const env = require('./env');
@@ -80,7 +81,7 @@ if (process.env.NODE_ENV === 'production') {
 /* Set ADMIN_API_USE_SSL to https for CORS support */
 let server;
 const port = process.env.PORT || 3000;
-if (env.ADMIN_API_USE_SSL == 'https') {
+if (env.ADMIN_API_USE_SSL === 'https') {
   const fs = require('fs');
   const https = require('https');
   var privateKey = fs.readFileSync('script/server.key');

--- a/plugins.js
+++ b/plugins.js
@@ -1,3 +1,4 @@
+/* eslint import/no-dynamic-require: 'off', no-console: 'off' */
 const env = require('./env');
 
 const { middleware } = env.PLUGINS_MODULE ? require(env.PLUGINS_MODULE) : {};

--- a/src/basics/LocalCache/index.tsx
+++ b/src/basics/LocalCache/index.tsx
@@ -1,4 +1,5 @@
 // More info on Local storage: https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage
+import { log } from 'common/log';
 import { useState } from 'react';
 import { defaultLocalCacheConfig, LocalCacheItem } from './defaultConfig';
 
@@ -11,7 +12,7 @@ export function ClearLocalCache() {
 const getDefault = (setting: LocalCacheItem) => {
   const result = defaultLocalCacheConfig[setting];
   if (!result) {
-    console.error(
+    log.error(
       `ERROR: LocalCacheItem ${setting} doesn't have default value provided in defaultLocalCacheConfig`,
     );
     return null;

--- a/src/client.tsx
+++ b/src/client.tsx
@@ -14,7 +14,7 @@ const initializeApp = () => {
 
   const { ENABLE_GA, GA_TRACKING_ID } = env;
 
-  if (ENABLE_GA != 'false') {
+  if (ENABLE_GA !== 'false') {
     ReactGA.initialize(GA_TRACKING_ID as string);
   }
 

--- a/src/components/Entities/EntityExecutionsBarChart.tsx
+++ b/src/components/Entities/EntityExecutionsBarChart.tsx
@@ -3,7 +3,6 @@ import Typography from '@material-ui/core/Typography';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import { formatDateUTC, millisecondsToHMS } from 'common/formatters';
 import { timestampToDate } from 'common/utils';
-import { fetchStates } from 'components/hooks/types';
 import { BarChart } from 'components/common/BarChart';
 import { WaitForData } from 'components/common/WaitForData';
 import { useWorkflowExecutionFiltersState } from 'components/Executions/filters/useExecutionFiltersState';

--- a/src/components/Executions/ExecutionDetails/ExecutionMetadata.tsx
+++ b/src/components/Executions/ExecutionDetails/ExecutionMetadata.tsx
@@ -55,7 +55,7 @@ const useStyles = makeStyles((theme: Theme) => {
 
 interface DetailItem {
   className?: string;
-  label: React.ReactNode;
+  label: ExecutionMetadataLabels;
   value: React.ReactNode;
 }
 
@@ -109,8 +109,8 @@ export const ExecutionMetadata: React.FC<{
   return (
     <div className={styles.container}>
       <div className={styles.detailsContainer}>
-        {details.map(({ className, label, value }, idx) => (
-          <div className={classnames(styles.detailItem, className)} key={idx}>
+        {details.map(({ className, label, value }) => (
+          <div className={classnames(styles.detailItem, className)} key={label}>
             <Typography className={commonStyles.truncateText} variant="subtitle1">
               {label}
             </Typography>

--- a/src/components/Executions/ExecutionDetails/ExecutionMetadataExtra.tsx
+++ b/src/components/Executions/ExecutionDetails/ExecutionMetadataExtra.tsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles((theme: Theme) => {
 
 interface DetailItem {
   className?: string;
-  label: React.ReactNode;
+  label: ExecutionMetadataLabels;
   value: React.ReactNode;
 }
 
@@ -34,7 +34,12 @@ export const ExecutionMetadataExtra: React.FC<{
   const commonStyles = useCommonStyles();
   const styles = useStyles();
 
-  const { launchPlan: launchPlanId, maxParallelism, rawOutputDataConfig, authRole } = execution.spec;
+  const {
+    launchPlan: launchPlanId,
+    maxParallelism,
+    rawOutputDataConfig,
+    authRole,
+  } = execution.spec;
 
   const [launchPlanSpec, setLaunchPlanSpec] = React.useState<Partial<LaunchPlanSpec>>({});
 
@@ -53,7 +58,9 @@ export const ExecutionMetadataExtra: React.FC<{
     },
     {
       label: ExecutionMetadataLabels.rawOutputPrefix,
-      value: rawOutputDataConfig?.outputLocationPrefix || launchPlanSpec?.rawOutputDataConfig?.outputLocationPrefix,
+      value:
+        rawOutputDataConfig?.outputLocationPrefix ||
+        launchPlanSpec?.rawOutputDataConfig?.outputLocationPrefix,
     },
     {
       label: ExecutionMetadataLabels.parallelism,
@@ -63,8 +70,8 @@ export const ExecutionMetadataExtra: React.FC<{
 
   return (
     <>
-      {details.map(({ className, label, value }, idx) => (
-        <div className={classnames(styles.detailItem, className)} key={idx}>
+      {details.map(({ className, label, value }) => (
+        <div className={classnames(styles.detailItem, className)} key={label}>
           <Typography className={commonStyles.truncateText} variant="subtitle1">
             {label}
           </Typography>

--- a/src/components/Executions/ExecutionDetails/NodeExecutionDetailsPanelContent.tsx
+++ b/src/components/Executions/ExecutionDetails/NodeExecutionDetailsPanelContent.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { IconButton, Typography } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import Tab from '@material-ui/core/Tab';

--- a/src/components/Executions/ExecutionDetails/Timeline/scaleContext.tsx
+++ b/src/components/Executions/ExecutionDetails/Timeline/scaleContext.tsx
@@ -1,4 +1,5 @@
 import { Mark } from '@material-ui/core/Slider';
+import { log } from 'common/log';
 import * as React from 'react';
 import { createContext, useContext } from 'react';
 import { formatSecondsToHmsFormat } from './BarChart/utils';
@@ -27,10 +28,10 @@ export const ScaleContext = createContext<TimelineScaleState>({
   chartInterval: 20,
   marks: [],
   setMaxValue: () => {
-    console.error('ERROR: No ScaleContextProvider was found in parent components.');
+    log.error('ERROR: No ScaleContextProvider was found in parent components.');
   },
   setScaleFactor: () => {
-    console.error('ERROR: No ScaleContextProvider was found in parent components.');
+    log.error('ERROR: No ScaleContextProvider was found in parent components.');
   },
 });
 

--- a/src/components/Executions/ExecutionDetails/test/BarChart.test.tsx
+++ b/src/components/Executions/ExecutionDetails/test/BarChart.test.tsx
@@ -1,4 +1,3 @@
-import { getChartDurationData } from '../Timeline/BarChart/chartData';
 import {
   CASHED_GREEN,
   formatSecondsToHmsFormat,
@@ -6,7 +5,7 @@ import {
   getOffsetColor,
   TRANSPARENT,
 } from '../Timeline/BarChart/utils';
-import { getMockExecutionsForBarChart, mockbarItems } from './__mocks__/NodeExecution.mock';
+import { mockbarItems } from './__mocks__/NodeExecution.mock';
 
 describe('ExecutionDetails > Timeline > BarChart', () => {
   it('formatSecondsToHmsFormat works as expected', () => {
@@ -38,22 +37,6 @@ describe('ExecutionDetails > Timeline > BarChart', () => {
     // If cached - colored backfground
     expect(offsetColors[1]).toEqual(CASHED_GREEN);
   });
-
-  // Mock bars used below
-  // const mockbarItems = [
-  //   { phase: NodeExecutionPhase.FAILED, startOffsetSec: 0, durationSec: 15, isFromCache: false },
-  //   { phase: NodeExecutionPhase.SUCCEEDED, startOffsetSec: 5, durationSec: 11, isFromCache: true },
-  //   { phase: NodeExecutionPhase.RUNNING, startOffsetSec: 17, durationSec: 23, isFromCache: false },
-  //   { phase: NodeExecutionPhase.QUEUED, startOffsetSec: 39, durationSec: 0, isFromCache: false },
-  // ];
-  // it('getChartDurationData is properly generated from Node[] items', () => {
-  //   /** */
-  //   const startTime = 1642627611;
-  //   const mockData = getMockExecutionsForBarChart(startTime);
-  //   const chartItems = getChartDurationData(mockData, new Date(1642627611 * 1000));
-
-  //   expect(chartItems[0]).toEqual(mockbarItems[0]);
-  // });
 
   it('generateChartData properly generates map of data for ChartBars', () => {
     const chartData = generateChartData(mockbarItems);

--- a/src/components/Executions/ExecutionDetails/test/ExecutionDetailsAppBarContent.test.tsx
+++ b/src/components/Executions/ExecutionDetails/test/ExecutionDetailsAppBarContent.test.tsx
@@ -58,14 +58,13 @@ describe('ExecutionDetailsAppBarContent', () => {
     describe('in overflow menu', () => {
       let renderResult: RenderResult;
       let buttonEl: HTMLElement;
-      let menuEl: HTMLElement;
 
       beforeEach(async () => {
         renderResult = renderContent();
         const { getByLabelText } = renderResult;
         buttonEl = await waitFor(() => getByLabelText(commonLabels.moreOptionsButton));
         fireEvent.click(buttonEl);
-        menuEl = await waitFor(() => getByLabelText(commonLabels.moreOptionsMenu));
+        await waitFor(() => getByLabelText(commonLabels.moreOptionsMenu));
       });
 
       it('renders a clone option', () => {

--- a/src/components/Executions/Tables/WorkflowExecutionLink.tsx
+++ b/src/components/Executions/Tables/WorkflowExecutionLink.tsx
@@ -18,7 +18,7 @@ export const WorkflowExecutionLink: React.FC<{
   } = history;
   const fromExecutionNav = pathname.split('/').pop() === 'executions';
 
-  const linkColor = color == 'disabled' ? commonStyles.secondaryLink : commonStyles.primaryLink;
+  const linkColor = color === 'disabled' ? commonStyles.secondaryLink : commonStyles.primaryLink;
   return (
     <RouterLink
       className={classnames(linkColor, className)}

--- a/src/components/Executions/contextProvider/NodeExecutionDetails/index.tsx
+++ b/src/components/Executions/contextProvider/NodeExecutionDetails/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { createContext, useContext, useEffect, useRef, useState } from 'react';
+import { log } from 'common/log';
 import { Identifier } from 'models/Common/types';
 import { NodeExecution } from 'models/Execution/types';
 import { CompiledWorkflowClosure } from 'models/Workflow/types';
@@ -21,7 +22,7 @@ const NOT_AVAILABLE = 'NotAvailable';
 export const NodeExecutionDetailsContext = createContext<NodeExecutionDetailsState>({
   /** Default values used if ContextProvider wasn't initialized. */
   getNodeExecutionDetails: async () => {
-    console.error('ERROR: No NodeExecutionDetailsContextProvider was found in parent components.');
+    log.error('ERROR: No NodeExecutionDetailsContextProvider was found in parent components.');
     return UNKNOWN_DETAILS;
   },
   workflowId: {

--- a/src/components/Launch/LaunchForm/CollectionInput.tsx
+++ b/src/components/Launch/LaunchForm/CollectionInput.tsx
@@ -1,5 +1,6 @@
 import { TextField } from '@material-ui/core';
 import * as React from 'react';
+import { log } from 'common/log';
 import { makeStringChangeHandler } from './handlers';
 import { InputProps, InputType } from './types';
 import { UnsupportedInput } from './UnsupportedInput';
@@ -16,7 +17,7 @@ export const CollectionInput: React.FC<InputProps> = (props) => {
     value = '',
   } = props;
   if (!subtype) {
-    console.error('Unexpected missing subtype for collection input', props.typeDefinition);
+    log.warn('Unexpected missing subtype for collection input', props.typeDefinition);
     return <UnsupportedInput {...props} />;
   }
   const hasError = !!error;

--- a/src/components/Launch/LaunchForm/LaunchFormAdvancedInputs.tsx
+++ b/src/components/Launch/LaunchForm/LaunchFormAdvancedInputs.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Admin } from 'flyteidl';
 import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles';
 import Accordion from '@material-ui/core/Accordion';
 import AccordionSummary from '@material-ui/core/AccordionSummary';
@@ -11,7 +12,6 @@ import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import Form from '@rjsf/material-ui';
-import { flyteidl } from '@flyteorg/flyteidl/gen/pb-js/flyteidl';
 import { State } from 'xstate';
 import { LaunchAdvancedOptionsRef } from './types';
 import {
@@ -20,8 +20,6 @@ import {
   WorkflowLaunchTypestate,
 } from './launchMachine';
 import { useStyles } from './styles';
-
-import IExecutionSpec = flyteidl.admin.IExecutionSpec;
 
 const muiTheme = createMuiTheme({
   props: {
@@ -86,7 +84,7 @@ export const LaunchFormAdvancedInputs = React.forwardRef<
       }
       if (
         other?.rawOutputDataConfig?.outputLocationPrefix !== undefined &&
-          other.rawOutputDataConfig.outputLocationPrefix !== null
+        other.rawOutputDataConfig.outputLocationPrefix !== null
       ) {
         setRawOutputDataConfig(other.rawOutputDataConfig.outputLocationPrefix);
       }
@@ -100,7 +98,14 @@ export const LaunchFormAdvancedInputs = React.forwardRef<
       };
       setLabelsParamData(newLabels);
       setAnnotationsParamData(newAnnotations);
-    }, [other.disableAll, other.maxParallelism, other.rawOutputDataConfig, other.labels, other.annotations, launchPlan?.spec]);
+    }, [
+      other.disableAll,
+      other.maxParallelism,
+      other.rawOutputDataConfig,
+      other.labels,
+      other.annotations,
+      launchPlan?.spec,
+    ]);
 
     React.useImperativeHandle(
       ref,
@@ -109,7 +114,7 @@ export const LaunchFormAdvancedInputs = React.forwardRef<
           return {
             disableAll,
             rawOutputDataConfig: {
-              outputLocationPrefix: rawOutputDataConfig
+              outputLocationPrefix: rawOutputDataConfig,
             },
             maxParallelism: parseInt(maxParallelism || '', 10),
             labels: {
@@ -118,7 +123,7 @@ export const LaunchFormAdvancedInputs = React.forwardRef<
             annotations: {
               values: annotationsParamData,
             },
-          } as IExecutionSpec;
+          } as Admin.IExecutionSpec;
         },
         validate: () => {
           return true;

--- a/src/components/Launch/LaunchForm/inputHelpers/inputHelpers.ts
+++ b/src/components/Launch/LaunchForm/inputHelpers/inputHelpers.ts
@@ -1,9 +1,12 @@
+import { createDebugLogger } from 'common/log';
 import { ValueError } from 'errors/parameterErrors';
 import { Core } from 'flyteidl';
 import { InputProps, InputTypeDefinition, InputValue } from '../types';
 import { literalNone } from './constants';
 import { getHelperForInput } from './getHelperForInput';
 import { InputValidatorParams, ValidationParams } from './types';
+
+const debug = createDebugLogger('@InputHelper');
 
 type ToLiteralParams = Pick<InputProps, 'initialValue' | 'typeDefinition' | 'value'>;
 /** Converts a type/InputValue combination to a `Core.ILiteral` which can be
@@ -47,7 +50,7 @@ export function literalToInputValue(
   } catch (e) {
     // If something goes wrong (most likely malformed default value input),
     // we'll return the system default value.
-    console.debug((e as Error).message);
+    debug((e as Error).message);
     return defaultValue;
   }
 }

--- a/src/components/Literals/__stories__/literalValues.ts
+++ b/src/components/Literals/__stories__/literalValues.ts
@@ -1,4 +1,3 @@
-import { Core } from 'flyteidl';
 import { mapValues } from 'lodash';
 import { Literal } from 'models/Common/types';
 import {
@@ -14,7 +13,10 @@ import {
  * each value in a `Literal` and setting the appropriate `value` to allow
  * lookup of whichever field is populated.
  */
-function toLiterals<T>(type: 'scalar' | 'collection' | 'map', values: Dictionary<T>): Dictionary<Literal> {
+function toLiterals<T>(
+  type: 'scalar' | 'collection' | 'map',
+  values: Dictionary<T>,
+): Dictionary<Literal> {
   return mapValues(values, (value: T) => ({
     value: type,
     [type]: value,
@@ -31,5 +33,5 @@ export const schemaLiterals = toLiterals('scalar', schemaScalars);
 export const noneTypeLiteral: Literal = {
   value: 'scalar',
   scalar: noneTypeScalar,
-  hash: ''
+  hash: '',
 };

--- a/src/components/Navigation/UserInformation.tsx
+++ b/src/components/Navigation/UserInformation.tsx
@@ -31,7 +31,7 @@ export const UserInformation: React.FC<{}> = () => {
   return (
     <WaitForData spinnerVariant="none" {...profile}>
       <div className={useStyles().container}>
-        {profile.value == null ? (
+        {!profile.value ? (
           <LoginLink />
         ) : !profile.value.preferredUsername || profile.value.preferredUsername === '' ? (
           profile.value.name

--- a/src/components/Navigation/UserInformation.tsx
+++ b/src/components/Navigation/UserInformation.tsx
@@ -33,7 +33,7 @@ export const UserInformation: React.FC<{}> = () => {
       <div className={useStyles().container}>
         {profile.value == null ? (
           <LoginLink />
-        ) : profile.value.preferredUsername == null || profile.value.preferredUsername == '' ? (
+        ) : !profile.value.preferredUsername || profile.value.preferredUsername === '' ? (
           profile.value.name
         ) : (
           profile.value.preferredUsername

--- a/src/components/Project/ProjectExecutions.tsx
+++ b/src/components/Project/ProjectExecutions.tsx
@@ -1,7 +1,6 @@
 import Typography from '@material-ui/core/Typography';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import { getCacheKey } from 'components/Cache/utils';
-import { fetchStates } from 'components/hooks/types';
 import { ErrorBoundary } from 'components/common/ErrorBoundary';
 import { LargeLoadingSpinner } from 'components/common/LoadingSpinner';
 import { DataError } from 'components/Errors/DataError';

--- a/src/components/Project/test/ProjectExecutions.test.tsx
+++ b/src/components/Project/test/ProjectExecutions.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor, fireEvent, within, getByText } from '@testing-library/react';
+import { render, waitFor, fireEvent } from '@testing-library/react';
 import { basicPythonWorkflow } from 'mocks/data/fixtures/basicPythonWorkflow';
 import { oneFailedTaskWorkflow } from 'mocks/data/fixtures/oneFailedTaskWorkflow';
 import { insertFixture } from 'mocks/data/insertFixture';

--- a/src/components/Workflow/workflowQueries.ts
+++ b/src/components/Workflow/workflowQueries.ts
@@ -1,10 +1,9 @@
 import { QueryInput, QueryType } from 'components/data/types';
-import { DataError } from 'components/Errors/DataError';
 import { extractTaskTemplates } from 'components/hooks/utils';
 import { getNodeExecutionData } from 'models/Execution/api';
 import { getWorkflow } from 'models/Workflow/api';
 import { Workflow, WorkflowId } from 'models/Workflow/types';
-import { QueryClient, QueryObserverResult } from 'react-query';
+import { QueryClient } from 'react-query';
 
 export function makeWorkflowQuery(queryClient: QueryClient, id: WorkflowId): QueryInput<Workflow> {
   return {

--- a/src/components/WorkflowGraph/utils.ts
+++ b/src/components/WorkflowGraph/utils.ts
@@ -64,9 +64,9 @@ export const getDisplayName = (context: any, truncate = true): string => {
     displayName = context.id;
   }
 
-  if (displayName == startNodeId) {
+  if (displayName === startNodeId) {
     return DISPLAY_NAME_START;
-  } else if (displayName == endNodeId) {
+  } else if (displayName === endNodeId) {
     return DISPLAY_NAME_END;
   } else if (displayName.indexOf('.') > 0 && truncate) {
     /* Note: for displaying truncated task name */
@@ -85,7 +85,7 @@ export const getWorkflowId = (workflow: CompiledWorkflow): string => {
   return workflow.template.id.name;
 };
 
-export const createWorkflowNodeFromDynamic = (dw) => {
+export const createWorkflowNodeFromDynamic = () => {
   return {
     subWorkflowRef: {
       domain: 'development',

--- a/src/components/common/BarChart.tsx
+++ b/src/components/common/BarChart.tsx
@@ -77,7 +77,6 @@ export const BarChartItem: React.FC<BarChartItemProps> = ({
   onClick,
 }) => {
   const styles = useStyles();
-  const [position, setPosition] = React.useState({ x: 0, y: 0 });
 
   const content = (
     <div

--- a/src/components/common/ExpandableMonospaceText.tsx
+++ b/src/components/common/ExpandableMonospaceText.tsx
@@ -106,7 +106,7 @@ export const useExpandableMonospaceTextStyles = makeStyles((theme: Theme) => ({
 export interface ExpandableMonospaceTextProps {
   initialExpansionState?: boolean;
   text: string;
-  onExpandCollapse?(expanded: boolean): void;
+  onExpandCollapse?: (expanded: boolean) => void;
 }
 
 /** An expandable/collapsible container which renders the provided text in a
@@ -121,7 +121,9 @@ export const ExpandableMonospaceText: React.FC<ExpandableMonospaceTextProps> = (
   const styles = useExpandableMonospaceTextStyles();
   const onClickExpand = () => {
     setExpanded(!expanded);
-    typeof onExpandCollapse === 'function' && onExpandCollapse(!expanded);
+    if (onExpandCollapse) {
+      onExpandCollapse(!expanded);
+    }
   };
   const onClickCopy = () => copyToClipboard(text);
 

--- a/src/components/flytegraph/ReactFlow/NodeStatusLegend.tsx
+++ b/src/components/flytegraph/ReactFlow/NodeStatusLegend.tsx
@@ -8,7 +8,7 @@ export const LegendItem = ({ color, text }) => {
    * @TODO temporary check for nested graph until
    * nested functionality is deployed
    */
-  const isNested = text == 'Nested';
+  const isNested = text === 'Nested';
 
   const containerStyle: CSSProperties = {
     display: 'flex',

--- a/src/components/flytegraph/ReactFlow/ReactFlowGraphComponent.tsx
+++ b/src/components/flytegraph/ReactFlow/ReactFlowGraphComponent.tsx
@@ -1,19 +1,16 @@
 import * as React from 'react';
 import { useState, useEffect } from 'react';
 import { ConvertFlyteDagToReactFlows } from 'components/flytegraph/ReactFlow/transformDAGToReactFlowV2';
-import { createDebugLogger } from 'common/log';
 import { RFWrapperProps, RFGraphTypes, ConvertDagProps } from './types';
 import { getRFBackground } from './utils';
 import { ReactFlowWrapper } from './ReactFlowWrapper';
 import { Legend } from './NodeStatusLegend';
 
-const debug = createDebugLogger('@ReactFlowGraphComponent');
-
 const nodeExecutionStatusChanged = (previous, nodeExecutionsById) => {
   for (const exe in nodeExecutionsById) {
     const oldStatus = previous[exe]?.closure.phase;
     const newStatus = nodeExecutionsById[exe]?.closure.phase;
-    if (oldStatus != newStatus) {
+    if (oldStatus !== newStatus) {
       return true;
     }
   }

--- a/src/components/flytegraph/ReactFlow/ReactFlowWrapper.tsx
+++ b/src/components/flytegraph/ReactFlow/ReactFlowWrapper.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useState, useEffect, useCallback } from 'react';
 import ReactFlow, { Background } from 'react-flow-renderer';
-import { createDebugLogger } from 'common/log';
 import { RFWrapperProps } from './types';
 import {
   ReactFlowCustomEndNode,
@@ -14,8 +13,6 @@ import {
   ReactFlowStaticNode,
 } from './customNodeComponents';
 import { getPositionedNodes, ReactFlowIdHash } from './utils';
-
-const debug = createDebugLogger('@ReactFlowWrapper');
 
 /**
  * Mapping for using custom nodes inside ReactFlow
@@ -48,7 +45,7 @@ export const ReactFlowWrapper: React.FC<RFWrapperProps> = ({
   const [reactFlowInstance, setReactFlowInstance] = useState<null | any>(null);
 
   useEffect(() => {
-    if (reactFlowInstance && state.shouldUpdate == false) {
+    if (reactFlowInstance && state.shouldUpdate === false) {
       reactFlowInstance?.fitView();
     }
   }, [state.shouldUpdate, reactFlowInstance]);
@@ -68,7 +65,7 @@ export const ReactFlowWrapper: React.FC<RFWrapperProps> = ({
 
   const onNodesChange = useCallback(
     (changes) => {
-      if (changes.length == state.nodes.length && state.shouldUpdate) {
+      if (changes.length === state.nodes.length && state.shouldUpdate) {
         const nodesWithDimensions: any[] = [];
         for (let i = 0; i < changes.length; i++) {
           nodesWithDimensions.push({

--- a/src/components/flytegraph/ReactFlow/customNodeComponents.tsx
+++ b/src/components/flytegraph/ReactFlow/customNodeComponents.tsx
@@ -105,7 +105,7 @@ export const ReactFlowCustomMaxNested = ({ data }: any) => {
     );
   };
 
-  const onClick = (e) => {
+  const onClick = () => {
     data.onAddNestedView();
   };
 
@@ -208,7 +208,7 @@ export const ReactFlowCustomTaskNode = ({ data }: any) => {
   const [selectedNode, setSelectedNode] = useState(false);
 
   useEffect(() => {
-    if (selectedNode == true) {
+    if (selectedNode === true) {
       onNodeSelectionChanged(selectedNode);
       setSelectedNode(false);
     }
@@ -293,10 +293,10 @@ export const ReactFlowSubWorkflowContainer = ({ data }: any) => {
     return (
       <li
         onClick={onClick}
-        style={index == currentNestedDepth - 1 ? liStyleInactive : liStyles}
+        style={index === currentNestedDepth - 1 ? liStyleInactive : liStyles}
         id={`${data.scopedId}_${index}`}
       >
-        {index == 0 ? <span style={beforeStyle}>{'>'}</span> : null}
+        {index === 0 ? <span style={beforeStyle}>{'>'}</span> : null}
         {nestedView}
         {index < currentNestedDepth - 1 ? <span style={beforeStyle}>{'>'}</span> : null}
       </li>

--- a/src/components/flytegraph/ReactFlow/transformDAGToReactFlowV2.tsx
+++ b/src/components/flytegraph/ReactFlow/transformDAGToReactFlowV2.tsx
@@ -38,7 +38,7 @@ export const nodeHasChildren = (node: dNode) => {
 };
 
 export const isStartOrEndEdge = (edge) => {
-  return edge.sourceId == 'start-node' || edge.targetId == 'end-node';
+  return edge.sourceId === 'start-node' || edge.targetId === 'end-node';
 };
 
 interface BuildDataProps {
@@ -99,7 +99,7 @@ export const buildReactFlowDataProps = (props: BuildDataProps) => {
   };
 
   for (const rootParentId in currentNestedView) {
-    if (node.scopedId == rootParentId) {
+    if (node.scopedId === rootParentId) {
       dataProps['currentNestedView'] = currentNestedView[rootParentId];
     }
   }
@@ -136,7 +136,7 @@ export const buildReactFlowNode = ({
     output['parentNode'] = parentNode.scopedId;
   }
 
-  if (output.parentNode == node.scopedId) {
+  if (output.parentNode === node.scopedId) {
     delete output.parentNode;
   }
 
@@ -245,14 +245,14 @@ export const buildGraphMapping = (props): ReactFlowGraphMapping => {
           dataProps: nodeDataProps,
           rootParentNode: rootParentNode,
           parentNode: contextParent,
-          typeOverride: isStaticGraph == true ? dTypes.staticNode : undefined,
+          typeOverride: isStaticGraph === true ? dTypes.staticNode : undefined,
         });
         context.nodes[reactFlowNode.id] = reactFlowNode;
       } else {
         const reactFlowNode = buildReactFlowNode({
           node: node,
           dataProps: nodeDataProps,
-          typeOverride: isStaticGraph == true ? dTypes.staticNode : undefined,
+          typeOverride: isStaticGraph === true ? dTypes.staticNode : undefined,
         });
         root.nodes[reactFlowNode.id] = reactFlowNode;
       }

--- a/src/components/flytegraph/ReactFlow/utils.tsx
+++ b/src/components/flytegraph/ReactFlow/utils.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { NodeExecutionPhase } from 'models/Execution/enums';
 import { dTypes } from 'models/Graph/types';
 import { CSSProperties } from 'react';

--- a/src/components/flytegraph/ReactFlow/utils.tsx
+++ b/src/components/flytegraph/ReactFlow/utils.tsx
@@ -41,13 +41,13 @@ export const getGraphHandleStyle = (handleType: string, type?: dTypes): CSSPrope
   let marginLeft,
     marginRight = 0;
 
-  if (handleType == 'target') {
+  if (handleType === 'target') {
     marginLeft = 0;
     marginRight = -offset;
-  } else if (handleType == 'source') {
+  } else if (handleType === 'source') {
     marginRight = 0;
     marginLeft = -offset;
-  } else if (handleType == 'nestedPoint') {
+  } else if (handleType === 'nestedPoint') {
     backgroundColor = 'none';
     size = 1;
   }

--- a/src/components/flytegraph/types.ts
+++ b/src/components/flytegraph/types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { DierarchyPointNode } from 'd3-dag';
 
 /** Graph-related types */

--- a/src/components/hooks/test/useFetchableData.test.tsx
+++ b/src/components/hooks/test/useFetchableData.test.tsx
@@ -102,7 +102,7 @@ describe('useFetchableData', () => {
 
   it('should clear lastError when retrying failed initial fetch', async () => {
     const { container } = renderTester();
-    const { errorEl, fetchButton, valueEl } = await getElements(container);
+    const { errorEl, fetchButton } = await getElements(container);
 
     const error = 'something went wrong';
     rejectValue(new Error(error));

--- a/src/errors/fetchErrors.ts
+++ b/src/errors/fetchErrors.ts
@@ -1,9 +1,12 @@
+/* eslint-disable max-classes-per-file */
+
 /** Indicates failure to fetch a resource because it does not exist (404) */
 export class NotFoundError extends Error {
   constructor(public name: string, msg = 'The requested item could not be found') {
     super(msg);
   }
 }
+
 /** Indicates failure to fetch a resource because the user is not authorized (401) */
 export class NotAuthorizedError extends Error {
   constructor(msg = 'User is not authorized to view this resource') {

--- a/src/errors/parameterErrors.ts
+++ b/src/errors/parameterErrors.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-classes-per-file */
+
 /** Indicates a generic problem with a function parameter */
 export class ParameterError extends Error {
   constructor(public name: string, msg: string) {

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -1,6 +1,6 @@
 import { ensureSlashPrefixed } from 'common/utils';
-import { TaskExecutionIdentifier, WorkflowExecutionIdentifier } from 'models/Execution/types';
-import { projectBasePath, projectDomainBasePath, taskExecutionPath } from './constants';
+import { WorkflowExecutionIdentifier } from 'models/Execution/types';
+import { projectBasePath, projectDomainBasePath } from './constants';
 import { makeRoute } from './utils';
 
 /** Creates a path relative to a particular project */


### PR DESCRIPTION
Eslint related cleanup with no logic changes. 
All non-obvious fixes where skipped for now. Covered next rules:

- `eqeqeq` - When == used instead of ===  
-  `react/no-array-index-key` - it's not safe to use index as key in the arrays (it's default behaviour, so don't even have much sense) - replaced where a different unique identified already available
-  removed unused imports and some unused variables
 

## Type
 - [X] Chore
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

Signed-off-by: Nastya Rusina <nastya@union.ai>