### PR TITLE
fix: Bump list launch-plans limit=50 #patch

### DIFF
--- a/src/components/Launch/LaunchForm/useLaunchWorkflowFormState.ts
+++ b/src/components/Launch/LaunchForm/useLaunchWorkflowFormState.ts
@@ -70,7 +70,7 @@ async function loadLaunchPlans(
           value: version,
         },
       ],
-      limit: 10,
+      limit: 50,
     },
   );
 


### PR DESCRIPTION
# TL;DR
Current Behavior is to fetch only 10 launch-plans per workflow . This causes issues for users who have > 10 launch-plans with no way of fetching/triggering them via the UI.

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue
