### PR TITLE
Fix Confirmation Buttons Overflow on Execution Table

### DIFF
--- a/src/components/Executions/Tables/WorkflowExecutionTable/WorkflowExecutionRow.tsx
+++ b/src/components/Executions/Tables/WorkflowExecutionTable/WorkflowExecutionRow.tsx
@@ -101,7 +101,9 @@ export const WorkflowExecutionRow: React.FC<WorkflowExecutionRowProps> = ({
     onCancel: () => setShowConfirmation(false),
     onConfirmClick: onArchiveConfirmClick,
   });
-  const columnsWithApproval = [...columns.slice(0, -2), confirmation];
+  // To hide the onHover action buttons,
+  // we take off the last column which is onHover actions buttons
+  const columnsWithApproval = [...columns.slice(0, -1), confirmation];
 
   // we show error info only on active items
   const { abortMetadata, error } = execution.closure;

--- a/src/components/Executions/Tables/WorkflowExecutionTable/styles.ts
+++ b/src/components/Executions/Tables/WorkflowExecutionTable/styles.ts
@@ -34,7 +34,8 @@ export const useStyles = makeStyles((theme: Theme) => ({
   },
   confirmationButton: {
     borderRadius: 0,
-    minWidth: '100px',
+    // make the button responsive, so the button won't overflow
+    width: '50%',
     minHeight: '53px',
     // cancel margins that are coming from table row style
     marginTop: theme.spacing(-1),


### PR DESCRIPTION
In the execution table, the cancel button is overflowing, and half of the text can't be seen. Also, the duration data is not rendered. 

what it looks like now. 
<img width="1261" alt="image" src="https://user-images.githubusercontent.com/25038146/162553793-59022574-5bf8-4c23-a438-ce45933331b2.png">


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Added back the duration data to render in the row 
Fixed the width for the Confirmation Buttons. Use % for width, so it won't overflow 

## Tracking Issue

fixes https://github.com/flyteorg/flyteconsole/issues/367

## Follow-up issue
