### PR TITLE
fix: on resize Header and body of the tables are mismatched

### DIFF
--- a/src/components/Executions/Tables/styles.ts
+++ b/src/components/Executions/Tables/styles.ts
@@ -105,8 +105,6 @@ export const useExecutionTableStyles = makeStyles((theme: Theme) => ({
     flexDirection: 'row',
   },
   rowColumn: {
-    flexGrow: 0,
-    flexShrink: 0,
     marginRight: theme.spacing(1),
     minWidth: 0,
     paddingBottom: theme.spacing(1),

--- a/src/components/Tables/DataList.tsx
+++ b/src/components/Tables/DataList.tsx
@@ -12,7 +12,7 @@ import {
   List,
   ListRowRenderer,
 } from 'react-virtualized';
-import { headerGridHeight, tableGridPadding } from './constants';
+import { headerGridHeight, tableGridPadding, minListContainerHeight } from './constants';
 import { LoadMoreRowContent } from './LoadMoreRowContent';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -24,6 +24,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   listContainer: {
     display: 'flex',
     flexDirection: 'column',
+    // set minHeight to avoid AutoResizer setting height to 0
+    minHeight: theme.spacing(minListContainerHeight),
   },
   noRowsContent: {
     color: tablePlaceholderColor,

--- a/src/components/Tables/constants.ts
+++ b/src/components/Tables/constants.ts
@@ -1,3 +1,4 @@
 export const loadMoreRowGridHeight = 6;
 export const headerGridHeight = 6;
 export const tableGridPadding = 1;
+export const minListContainerHeight = 24;


### PR DESCRIPTION
Signed-off-by: Eugene Jahn <eugenejahnjahn@gmail.com>

fixed this issue https://github.com/flyteorg/flyteconsole/issues/318
btw. I have updated the issue to address another responsive bug for the table. It's also fixed. 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
removed `flex-grow: 0` and `flex-shrink:0` on the table column. We don't need it because we want the table to be responsive. Otherwise, can't show data in the smaller width window. 

also, set a minHeight for the table rows container. Otherwise, the height of the row container will be set to 0 due to auto resizer.  

## Tracking Issue

fixes: https://github.com/flyteorg/flyteconsole/issues/318

## Follow-up issue
_NA_

