### PR TITLE
fix: dimensionality per data type blob and be disabled in UI

### DIFF
--- a/src/components/Launch/LaunchForm/BlobInput.tsx
+++ b/src/components/Launch/LaunchForm/BlobInput.tsx
@@ -37,8 +37,14 @@ const useStyles = makeStyles((theme: Theme) => ({
 /** A micro form for entering the values related to a Blob Literal */
 export const BlobInput: React.FC<InputProps> = (props) => {
   const styles = useStyles();
-  const { error, label, name, onChange, value: propValue } = props;
-  const blobValue = isBlobValue(propValue) ? propValue : defaultBlobValue;
+  const { error, label, name, onChange, value: propValue, typeDefinition } = props;
+  const dimensionality = typeDefinition?.literalType?.blob?.dimensionality;
+  const blobValue = isBlobValue(propValue)
+    ? propValue
+    : {
+        uri: '',
+        dimensionality: dimensionality ?? BlobDimensionality.SINGLE,
+      };
   const hasError = !!error;
   const helperText = hasError ? error : props.helperText;
 
@@ -102,6 +108,7 @@ export const BlobInput: React.FC<InputProps> = (props) => {
               id={selectId}
               value={blobValue.dimensionality}
               onChange={handleDimensionalityChange}
+              disabled
             >
               <MenuItem value={BlobDimensionality.SINGLE}>Single (File)</MenuItem>
               <MenuItem value={BlobDimensionality.MULTIPART}>Multipart (Directory)</MenuItem>


### PR DESCRIPTION
Signed-off-by: Eugene Jahn <eugenejahnjahn@gmail.com>

fix dimensionality per data type blob and be disabled in UI. For the blob input, we will set the dimensionality based on the blob type(if dimensionality from blob type is empty, we set to BlobDimensionality.SINGLE)

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
add the dimensionality from typeDefinition?.literalType?.blob?.dimensionality
disable the select component 

## Tracking Issue

fixes https://github.com/flyteorg/flyteconsole/issues/336

