### PR TITLE
fix(383): tasks and workflow number capped to 25 in dashboard page

### DIFF
--- a/src/components/Project/ProjectDashboard.tsx
+++ b/src/components/Project/ProjectDashboard.tsx
@@ -8,6 +8,7 @@ import { useInfiniteQuery, useQuery, useQueryClient } from 'react-query';
 import { Admin } from 'flyteidl';
 import { DomainSettingsSection } from 'components/common/DomainSettingsSection';
 import { getCacheKey } from 'components/Cache/utils';
+import { limits } from 'models/AdminEntity/constants';
 import { ErrorBoundary } from 'components/common/ErrorBoundary';
 import { LargeLoadingSpinner } from 'components/common/LoadingSpinner';
 import { DataError } from 'components/Errors/DataError';
@@ -127,9 +128,9 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = ({
 
   const fetch = React.useCallback(() => executionsQuery.fetchNextPage(), [executionsQuery]);
 
-  const { value: workflows } = useWorkflowNameList({ domain, project }, {});
+  const { value: workflows } = useWorkflowNameList({ domain, project }, { limit: limits.NONE });
   const numberOfWorkflows = workflows.length;
-  const { value: tasks } = useTaskNameList({ domain, project }, {});
+  const { value: tasks } = useTaskNameList({ domain, project }, { limit: limits.NONE });
   const numberOfTasks = tasks.length;
 
   const queryClient = useQueryClient();


### PR DESCRIPTION
Signed-off-by: Nastya Rusina <nastya@union.ai>

Now Project domain page for flytecsnacks looks like:
<img width="904" alt="Screen Shot 2022-04-13 at 3 28 15 PM" src="https://user-images.githubusercontent.com/55718143/163280443-07d2c6b7-60ba-4dfa-89ec-a89fd98727a4.png">


## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

Added NONE limit to request which is currently corresponds to 10000 items. 
We requested  a new API from backend to return total number of items, which is tracked by https://github.com/flyteorg/flyteconsole/issues/382

## Tracking Issue

fixes https://github.com/flyteorg/flyteconsole/issues/383

