### PR TITLE
fix(378): ensure that undefined executions ids won't get into graph

### DIFF
--- a/src/components/Workflow/workflowQueries.ts
+++ b/src/components/Workflow/workflowQueries.ts
@@ -1,3 +1,4 @@
+import { log } from 'common/log';
 import { QueryInput, QueryType } from 'components/data/types';
 import { extractTaskTemplates } from 'components/hooks/utils';
 import { getNodeExecutionData } from 'models/Execution/api';
@@ -13,9 +14,10 @@ export function makeWorkflowQuery(queryClient: QueryClient, id: WorkflowId): Que
       // On successful workflow fetch, extract and cache all task templates
       // stored on the workflow so that we don't need to fetch them separately
       // if future queries reference them.
-      extractTaskTemplates(workflow).forEach((task) =>
-        queryClient.setQueryData([QueryType.TaskTemplate, task.id], task),
-      );
+      extractTaskTemplates(workflow).forEach((task) => {
+        return queryClient.setQueryData([QueryType.TaskTemplate, task.id], task);
+      });
+
       return workflow;
     },
     // `Workflow` objects (individual versions) are immutable and safe to
@@ -25,20 +27,26 @@ export function makeWorkflowQuery(queryClient: QueryClient, id: WorkflowId): Que
 }
 
 export function makeNodeExecutionDynamicWorkflowQuery(
-  queryClient: QueryClient,
   parentsToFetch,
 ): QueryInput<{ [key: string]: any }> {
   return {
     queryKey: [QueryType.DynamicWorkflowFromNodeExecution, parentsToFetch],
     queryFn: async () => {
       return await Promise.all(
-        Object.keys(parentsToFetch).map((id) => {
-          const executionId = parentsToFetch[id];
-          const data = getNodeExecutionData(executionId.id).then((value) => {
-            return { key: id, value: value };
-          });
-          return data;
-        }),
+        Object.keys(parentsToFetch)
+          .filter((id) => parentsToFetch[id])
+          .map((id) => {
+            const executionId = parentsToFetch[id];
+            if (!executionId) {
+              // TODO FC#377: This check and filter few lines abode need to be deleted
+              // when Branch node support would be added
+              log.error(`Graph missing info for ${id}`);
+            }
+            const data = getNodeExecutionData(executionId.id).then((value) => {
+              return { key: id, value: value };
+            });
+            return data;
+          }),
       ).then((values) => {
         const output: { [key: string]: any } = {};
         for (let i = 0; i < values.length; i++) {

--- a/src/components/Workflow/workflowQueries.ts
+++ b/src/components/Workflow/workflowQueries.ts
@@ -14,9 +14,9 @@ export function makeWorkflowQuery(queryClient: QueryClient, id: WorkflowId): Que
       // On successful workflow fetch, extract and cache all task templates
       // stored on the workflow so that we don't need to fetch them separately
       // if future queries reference them.
-      extractTaskTemplates(workflow).forEach((task) => {
-        return queryClient.setQueryData([QueryType.TaskTemplate, task.id], task);
-      });
+      extractTaskTemplates(workflow).forEach((task) =>
+        queryClient.setQueryData([QueryType.TaskTemplate, task.id], task),
+      );
 
       return workflow;
     },

--- a/src/components/WorkflowGraph/WorkflowGraph.tsx
+++ b/src/components/WorkflowGraph/WorkflowGraph.tsx
@@ -7,7 +7,7 @@ import { NonIdealState } from 'components/common/NonIdealState';
 import { DataError } from 'components/Errors/DataError';
 import { NodeExecutionsContext } from 'components/Executions/contexts';
 import { WaitForQuery } from 'components/common/WaitForQuery';
-import { useQuery, useQueryClient } from 'react-query';
+import { useQuery } from 'react-query';
 import { makeNodeExecutionDynamicWorkflowQuery } from 'components/Workflow/workflowQueries';
 import { createDebugLogger } from 'common/log';
 import { CompiledNode } from 'models/Node/types';
@@ -90,9 +90,7 @@ export const WorkflowGraph: React.FC<WorkflowGraphProps> = (props) => {
   };
 
   const dynamicParents = checkForDynamicExeuctions(nodeExecutionsById, staticExecutionIdsMap);
-  const dynamicWorkflowQuery = useQuery(
-    makeNodeExecutionDynamicWorkflowQuery(useQueryClient(), dynamicParents),
-  );
+  const dynamicWorkflowQuery = useQuery(makeNodeExecutionDynamicWorkflowQuery(dynamicParents));
   const renderReactFlowGraph = (dynamicWorkflows) => {
     debug('DynamicWorkflows:', dynamicWorkflows);
     let mergedDag = dag;


### PR DESCRIPTION
Current fix removed request for undefined executionIds, which usually happens with branch nodes.
It allows us to avoid unneeded crash. Further work is needed for proper support of Branch nodes.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Tracking Issue

fixes https://github.com/flyteorg/flyteconsole/issues/378

## Follow-up issue
This fix currently removes the crash, however it doesn't fix the branch node representation, which is still a bit off. A separate task was created to cover that work: 
https://github.com/flyteorg/flyteconsole/issues/377
`TODO` with task number was added to the code to ensure, that fix would be fully tested

Signed-off-by: Nastya Rusina <nastya@union.ai>
