### PR TITLE
chore: remove redundant docker build on merge to master

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,7 +40,8 @@ jobs:
         run: make lint
 
   build_docker_image:
-    name: Build & Push Flyteconsole Image
+    if: ${{ github.event_name == 'pull_request' }}
+    name: Build Flyteconsole Image
     uses: flyteorg/flytetools/.github/workflows/publish.yml@master
     with:
       version: v1


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
Currently on merge to master we run the ` Build & Push Flyteconsole Image` github action twice: one instance only builds the docker image and the second instance builds and pushes it.

This change makes it so we build the image on open PRs and build and push the image on merges.

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin
 - [x] Housekeeping

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_NA_

## Follow-up issue
_NA_
