### PR TITLE
Revert "chore: remove redundant docker build on merge to master"

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,8 +40,7 @@ jobs:
         run: make lint
 
   build_docker_image:
-    if: ${{ github.event_name == 'pull_request' }}
-    name: Build Flyteconsole Image
+    name: Build & Push Flyteconsole Image
     uses: flyteorg/flytetools/.github/workflows/publish.yml@master
     with:
       version: v1


### PR DESCRIPTION
Reverts flyteorg/flyteconsole#390

sequence of steps is
1. build image successfully
2. release flyteconsole
3. build & push image