### PR TITLE
chore: cleanup of unused variables

### DIFF
--- a/.storybook/StorybookContainer.tsx
+++ b/.storybook/StorybookContainer.tsx
@@ -1,9 +1,11 @@
+import * as React from 'react';
 import { CssBaseline } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import { ThemeProvider } from '@material-ui/styles';
-import * as React from 'react';
 import { QueryClientProvider } from 'react-query';
 import { MemoryRouter } from 'react-router-dom';
+import { SnackbarProvider } from 'notistack';
+
 import { ErrorBoundary } from '../src/components/common/ErrorBoundary';
 import { createQueryClient } from '../src/components/data/queryCache';
 import { muiTheme } from '../src/components/Theme/muiTheme';
@@ -22,9 +24,11 @@ export const StorybookContainer: React.FC = ({ children }) => {
       <CssBaseline />
       <ErrorBoundary>
         <MemoryRouter>
-          <QueryClientProvider client={queryClient}>
-            <div className={useStyles().container}>{children}</div>
-          </QueryClientProvider>
+          <SnackbarProvider maxSnack={2} anchorOrigin={{ vertical: 'top', horizontal: 'right' }}>
+            <QueryClientProvider client={queryClient}>
+              <div className={useStyles().container}>{children}</div>
+            </QueryClientProvider>
+          </SnackbarProvider>
         </MemoryRouter>
       </ErrorBoundary>
     </ThemeProvider>

--- a/src/components/Executions/ExecutionDetails/Timeline/TimelineChart/utils.ts
+++ b/src/components/Executions/ExecutionDetails/Timeline/TimelineChart/utils.ts
@@ -5,12 +5,6 @@ import { NodeExecutionPhase } from 'models/Execution/enums';
 export const CASHED_GREEN = 'rgba(74,227,174,0.25)'; // statusColors.SUCCESS (Mint20) with 25% opacity
 export const TRANSPARENT = 'rgba(0, 0, 0, 0)';
 
-export enum RelationToCache {
-  None = 'none',
-  ReadFromCaceh = 'Read from Cache',
-  WroteToCache = 'Wrote to cache',
-}
-
 export interface BarItemData {
   phase: NodeExecutionPhase;
   startOffsetSec: number;
@@ -43,11 +37,6 @@ export const formatSecondsToHmsFormat = (seconds: number) => {
     return `${minutes}m ${seconds}s`;
   }
   return `${seconds}s`;
-};
-
-export const getOffsetColor = (isCachedValue: boolean[]) => {
-  const colors = isCachedValue.map((val) => (val === true ? CASHED_GREEN : TRANSPARENT));
-  return colors;
 };
 
 /**

--- a/src/components/Executions/ExecutionDetails/test/TimelineChart.test.tsx
+++ b/src/components/Executions/ExecutionDetails/test/TimelineChart.test.tsx
@@ -2,7 +2,6 @@ import {
   CASHED_GREEN,
   formatSecondsToHmsFormat,
   generateChartData,
-  getOffsetColor,
   TRANSPARENT,
 } from '../Timeline/TimelineChart/utils';
 import { mockbarItems } from './__mocks__/NodeExecution.mock';
@@ -25,17 +24,6 @@ describe('ExecutionDetails > Timeline > BarChart', () => {
     expect(formatSecondsToHmsFormat(59)).toEqual('59s');
     expect(formatSecondsToHmsFormat(23)).toEqual('23s');
     expect(formatSecondsToHmsFormat(0)).toEqual('0s');
-  });
-
-  it('getOffsetColor returns colored background for cached items', () => {
-    const cachedArray = [false, true, false];
-    const offsetColors = getOffsetColor(cachedArray);
-
-    // If items is not cached - offset is transparent
-    expect(offsetColors[0]).toEqual(TRANSPARENT);
-    expect(offsetColors[2]).toEqual(TRANSPARENT);
-    // If cached - colored backfground
-    expect(offsetColors[1]).toEqual(CASHED_GREEN);
   });
 
   it('generateChartData properly generates map of data for ChartBars', () => {

--- a/src/components/Executions/Tables/__stories__/WorkflowExecutionsTable.stories.tsx
+++ b/src/components/Executions/Tables/__stories__/WorkflowExecutionsTable.stories.tsx
@@ -1,11 +1,9 @@
-import { Collapse } from '@material-ui/core';
+import * as React from 'react';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
 import { ExecutionState } from 'models/Execution/enums';
 import { createMockWorkflowExecutionsListResponse } from 'models/Execution/__mocks__/mockWorkflowExecutionsData';
-import { SnackbarProvider } from 'notistack';
-import * as React from 'react';
 import { WorkflowExecutionsTable, WorkflowExecutionsTableProps } from '../WorkflowExecutionsTable';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -36,38 +34,11 @@ const props: WorkflowExecutionsTableProps = {
   fetch: () => Promise.resolve(() => fetchAction() as unknown),
 };
 
-// wrapper - to ensure that error/success notification shown as expected in storybook
-const Wrapper = (props) => {
-  return (
-    <SnackbarProvider
-      maxSnack={2}
-      anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
-      TransitionComponent={Collapse}
-    >
-      {props.children}
-    </SnackbarProvider>
-  );
-};
-
 const stories = storiesOf('Tables/WorkflowExecutionsTable', module);
 stories.addDecorator((story) => <div className={useStyles().container}>{story()}</div>);
-stories.add('Basic', () => (
-  <Wrapper>
-    <WorkflowExecutionsTable {...props} />
-  </Wrapper>
-));
-stories.add('Only archived items', () => (
-  <Wrapper>
-    <WorkflowExecutionsTable {...propsArchived} />
-  </Wrapper>
-));
+stories.add('Basic', () => <WorkflowExecutionsTable {...props} />);
+stories.add('Only archived items', () => <WorkflowExecutionsTable {...propsArchived} />);
 stories.add('With more items available', () => (
-  <Wrapper>
-    <WorkflowExecutionsTable {...props} moreItemsAvailable={true} />
-  </Wrapper>
+  <WorkflowExecutionsTable {...props} moreItemsAvailable={true} />
 ));
-stories.add('With no items', () => (
-  <Wrapper>
-    <WorkflowExecutionsTable {...props} value={[]} />
-  </Wrapper>
-));
+stories.add('With no items', () => <WorkflowExecutionsTable {...props} value={[]} />);

--- a/src/components/Launch/LaunchForm/useLaunchTaskFormState.ts
+++ b/src/components/Launch/LaunchForm/useLaunchTaskFormState.ts
@@ -119,13 +119,12 @@ async function submit(
     throw new Error('Unexpected empty role input ref');
   }
 
-  const { authRole, securityContext } = roleInputRef.current?.getValue();
+  const { securityContext } = roleInputRef.current?.getValue();
   const literals = formInputsRef.current.getValues();
   const launchPlanId = taskVersion;
   const { domain, project } = taskVersion;
 
   const response = await createWorkflowExecution({
-    authRole,
     securityContext,
     domain,
     launchPlanId,

--- a/src/components/Launch/LaunchForm/useLaunchWorkflowFormState.ts
+++ b/src/components/Launch/LaunchForm/useLaunchWorkflowFormState.ts
@@ -166,7 +166,7 @@ async function submit(
     throw new Error('Unexpected empty form inputs ref');
   }
 
-  const { authRole, securityContext } = roleInputRef.current?.getValue() as LaunchRoles;
+  const { securityContext } = roleInputRef.current?.getValue() as LaunchRoles;
   const literals = formInputsRef.current.getValues();
   const { disableAll, labels, annotations, maxParallelism, rawOutputDataConfig } =
     advancedOptionsRef.current?.getValues() || {};
@@ -175,7 +175,6 @@ async function submit(
 
   const response = await createWorkflowExecution({
     annotations,
-    authRole,
     securityContext,
     disableAll,
     maxParallelism,

--- a/src/components/Workflow/__stories__/SearchableWorkflowNameList.stories.tsx
+++ b/src/components/Workflow/__stories__/SearchableWorkflowNameList.stories.tsx
@@ -1,34 +1,17 @@
-import { Collapse } from '@material-ui/core';
+import * as React from 'react';
 import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
 import { sampleWorkflowNames } from 'models/__mocks__/sampleWorkflowNames';
-import { SnackbarProvider } from 'notistack';
-import * as React from 'react';
 import { SearchableWorkflowNameList } from '../SearchableWorkflowNameList';
 
 const baseProps = { workflows: [...sampleWorkflowNames] };
 
-// wrapper - to ensure that error/success notification shown as expected in storybook
-const Wrapper = (props) => {
-  return (
-    <SnackbarProvider
-      maxSnack={2}
-      anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
-      TransitionComponent={Collapse}
-    >
-      {props.children}
-    </SnackbarProvider>
-  );
-};
-
 const stories = storiesOf('Workflow/SearchableWorkflowNameList', module);
 stories.addDecorator((story) => <div style={{ width: '650px' }}>{story()}</div>);
 stories.add('basic', () => (
-  <Wrapper>
-    <SearchableWorkflowNameList
-      showArchived={false}
-      onArchiveFilterChange={action('onArchiveFilterChange')}
-      {...baseProps}
-    />
-  </Wrapper>
+  <SearchableWorkflowNameList
+    showArchived={false}
+    onArchiveFilterChange={action('onArchiveFilterChange')}
+    {...baseProps}
+  />
 ));

--- a/src/models/Execution/api.ts
+++ b/src/models/Execution/api.ts
@@ -78,7 +78,6 @@ export const getExecutionData = (id: WorkflowExecutionIdentifier, config?: Reque
 
 export interface CreateWorkflowExecutionArguments {
   annotations?: Admin.IAnnotations | null;
-  authRole?: Admin.IAuthRole;
   securityContext?: Core.ISecurityContext;
   domain: string;
   disableAll?: boolean | null;
@@ -97,7 +96,6 @@ export interface CreateWorkflowExecutionArguments {
 export const createWorkflowExecution = (
   {
     annotations,
-    authRole,
     securityContext,
     domain,
     disableAll,


### PR DESCRIPTION
Signed-off-by: Nastya Rusina <nastya@union.ai>

Left over cleanup which wasn't connected to previous PR.
- Moved `SnackbarProvider` to default storybook wrappers
- Removed `RelationToCache` as it was never used
- Removed `getOffsetColor`, and tests for it, as we stop using it some time ago
- Removed `authRole` from `createWorkflowExecution` as we haven't really used this variable.

Tested locally by:
- Running new Workflow and Task execution
- Re-running Workflow and task execution by using "Relaunch"
- Run `yarn test`
- Ensured that storybook still can show error snackbar notification on archive/unarchive

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [X] Chore

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue
