### PR TITLE
Fix assets path for index.js query

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ if (process.env.NODE_ENV === 'production') {
   const clientStats = require('./dist/client-stats.json');
   const distPath = path.join(__dirname, 'dist');
   app.use(
-    `${env.BASE_URL}/`,
+    `${env.BASE_URL}/assets`,
     expressStaticGzip(distPath, {
       maxAge: '1d',
     }),


### PR DESCRIPTION
Signed-off-by: Alex Bain (Level 5 US)/Alex　Bain <alex.bain@woven-planet.global>

WIP do not merge yet

# TL;DR
Fix the `assets` path for `index.js` query to Flyte Admin. Without this change, my `/console` queries back to  https://avflyteconsole.scratch-alexbain.dev.l5.woven-planet.tech/api/v1/projects. With this change, `/console` queries to the Flyte Admin HTTP interface https://avflyteadminhttp.scratch-alexbain.dev.l5.woven-planet.tech/api/v1/projects instead. Other pages (e.g. `/console/projects/avexampleworkflows/workflows`) already queried to the Flyte Admin HTTP interface even without the change.

Since I am not a web developer and am not familiar with Flyte Console's codebase, it is not clear to me what is the correct behavior. At first, I thought that Flyte Console was removing its calls to Flyte Admin's HTTP interface and replacing them with its own gRPC calls. However, now I am not sure exactly what is the intended behavior. I just know this seems to fix my `/console` page for my Flyte Console.

Please see the thread https://flyte-org.slack.com/archives/CNMKCU6FR/p1650238772723579 for a full discussion of this issue.

TESTING:
- This change is made on top of `v0.52.1`. Tested successfully by deploying the fixed Flyte Console in my test EKS cluster with Flyte `v0.19.4` components. STILL WIP ACTUALLY

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?
 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue