### PR TITLE
Fix: assets path for index.js query

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ if (process.env.NODE_ENV === 'production') {
   const clientStats = require('./dist/client-stats.json');
   const distPath = path.join(__dirname, 'dist');
   app.use(
-    `${env.BASE_URL}/`,
+    `${env.BASE_URL}/assets`,
     expressStaticGzip(distPath, {
       maxAge: '1d',
     }),

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ if (process.env.NODE_ENV === 'production') {
   const clientStats = require('./dist/client-stats.json');
   const distPath = path.join(__dirname, 'dist');
   app.use(
+    // This path should be in sync with the `publicPath` from webpack config.
     `${env.BASE_URL}/assets`,
     expressStaticGzip(distPath, {
       maxAge: '1d',

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -111,7 +111,7 @@ export const favIconPlugin = new FavIconWebpackPlugin({
   logo: path.resolve(__dirname, 'src/assets/favicon.png'),
   // we can add '[fullhash:8]/' to the end of the file in future
   // if this one will be changed - ensure that OneClick will still be working
-  prefix: 'items/',
+  prefix: './',
 });
 
 /** Write client stats to a JSON file for production */

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -26,7 +26,7 @@ export const serviceName = process.env.SERVICE_NAME || 'not set';
 export const dist = path.join(__dirname, 'dist');
 
 /** Webpack public path. All emitted assets will have relative path to this path */
-export const publicPath = `${env.BASE_URL}/`;
+export const publicPath = `${env.BASE_URL}/assets/`;
 
 /** True if we are in development mode */
 export const isDev = env.NODE_ENV === 'development';

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -25,7 +25,9 @@ export const serviceName = process.env.SERVICE_NAME || 'not set';
 /** Absolute path to webpack output folder */
 export const dist = path.join(__dirname, 'dist');
 
-/** Webpack public path. All emitted assets will have relative path to this path */
+/** Webpack public path. All emitted assets will have relative path to this path
+ * every time it is changed - the index.js app.use should also be updated.
+ */
 export const publicPath = `${env.BASE_URL}/assets/`;
 
 /** True if we are in development mode */
@@ -107,7 +109,9 @@ export const htmlPlugin = new HTMLWebpackPlugin({
 
 export const favIconPlugin = new FavIconWebpackPlugin({
   logo: path.resolve(__dirname, 'src/assets/favicon.png'),
-  prefix: 'assets/', // we can add '[fullhash:8]/' to the end of the file in future
+  // we can add '[fullhash:8]/' to the end of the file in future
+  // if this one will be changed - ensure that OneClick will still be working
+  prefix: 'items/',
 });
 
 /** Write client stats to a JSON file for production */


### PR DESCRIPTION
We had an issue raised by one of our users who had different domains for console and admin api.

In his case all  Admin API request performed at `ui_domain/console` where navigated to `ui_domain/api/v1/request` instead of `admin_api/api/v1/request`. 
However if request performed from any other page , for example `domain/console/projects/flytectldemo/workflows` it will work as expect.

This change adds back `/assets` folder to hold  main.js and vendor.js and puts assets at the same  `/assets` folder

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
