### PR TITLE
fix: on project select navigate to corresponding ProjectDashboard

### DIFF
--- a/src/components/SelectProject/ProjectList.tsx
+++ b/src/components/SelectProject/ProjectList.tsx
@@ -51,7 +51,7 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
             color="primary"
             key={domainId}
             component={ButtonLink}
-            to={Routes.ProjectDetails.sections.workflows.makeUrl(project.id, domainId)}
+            to={Routes.ProjectDetails.sections.dashboard.makeUrl(project.id, domainId)}
           >
             {name}
           </Button>


### PR DESCRIPTION
Before we introduces ProjectDashboard page, the most top level view was Workflows page, so navigating to it was a logical decision.

Now it is more logical to navigate user to ProjectDashboard page for selected peoject/domain from  project list selection `/console` section.

Video with the fix: https://share.getcloudapp.com/8LuDNkBr

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

Signed-off-by: Nastya Rusina <nastya@union.ai>
