### PR TITLE
Make whole row clickable to open TaskExecutionDetails panel

### DIFF
--- a/packages/zapp/console/src/components/Executions/Tables/NodeExecutionRow.tsx
+++ b/packages/zapp/console/src/components/Executions/Tables/NodeExecutionRow.tsx
@@ -14,7 +14,7 @@ import { ExpandableExecutionError } from './ExpandableExecutionError';
 import { NodeExecutionChildren } from './NodeExecutionChildren';
 import { RowExpander } from './RowExpander';
 import { selectedClassName, useExecutionTableStyles } from './styles';
-import { calculateNodeExecutionRowLeftSpacing } from './utils';
+import { calculateNodeExecutionRowLeftSpacing, selectExecution } from './utils';
 
 interface NodeExecutionRowProps {
   abortMetadata?: Admin.IAbortMetadata;
@@ -102,13 +102,16 @@ export const NodeExecutionRow: React.FC<NodeExecutionRowProps> = ({
     </div>
   ) : null;
 
+  const onClick = () => selectExecution(state, nodeExecution);
+
   return (
     <div
       role="listitem"
-      className={classnames(tableStyles.row, {
+      className={classnames(tableStyles.row, tableStyles.clickableRow, {
         [selectedClassName]: selected,
       })}
       style={style}
+      onClick={onClick}
     >
       <div
         className={classnames(tableStyles.rowContent, {

--- a/packages/zapp/console/src/components/Executions/Tables/SelectNodeExecutionLink.tsx
+++ b/packages/zapp/console/src/components/Executions/Tables/SelectNodeExecutionLink.tsx
@@ -2,6 +2,7 @@ import { Link } from '@material-ui/core';
 import { NodeExecution } from 'models/Execution/types';
 import * as React from 'react';
 import { NodeExecutionsTableState } from './types';
+import { selectExecution } from './utils';
 
 /** Renders a link that, when clicked, will trigger selection of the
  * given NodeExecution.
@@ -12,8 +13,8 @@ export const SelectNodeExecutionLink: React.FC<{
   linkText: string;
   state: NodeExecutionsTableState;
 }> = ({ className, execution, linkText, state }) => {
-  // use null in case if there is no execution provied - to close panel
-  const onClick = () => state.setSelectedExecution(execution?.id ?? null);
+  const onClick = () => selectExecution(state, execution);
+
   return (
     <Link component="button" className={className} onClick={onClick} variant="body1">
       {linkText}

--- a/packages/zapp/console/src/components/Executions/Tables/styles.ts
+++ b/packages/zapp/console/src/components/Executions/Tables/styles.ts
@@ -98,6 +98,9 @@ export const useExecutionTableStyles = makeStyles((theme: Theme) => ({
       backgroundColor: listhoverColor,
     },
   },
+  clickableRow: {
+    cursor: 'pointer',
+  },
   rowContent: {},
   rowColumns: {
     alignItems: 'center',

--- a/packages/zapp/console/src/components/Executions/Tables/utils.ts
+++ b/packages/zapp/console/src/components/Executions/Tables/utils.ts
@@ -4,3 +4,8 @@ import { nameColumnLeftMarginGridWidth } from './styles';
 export function calculateNodeExecutionRowLeftSpacing(level: number, spacing: Spacing) {
   return spacing(nameColumnLeftMarginGridWidth + 3 * level);
 }
+
+export function selectExecution(state, nodeExecution) {
+  // use null in case if there is no execution provied - to close panel
+  state.setSelectedExecution(nodeExecution?.id ?? null);
+}


### PR DESCRIPTION
# TL;DR
make the row clickable and will open the sidebar

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixeshttps://github.com/flyteorg/flyteconsole/issues/398

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
