### PR TITLE
chore(tsc): exclude test/stories/mock files only from build

### DIFF
--- a/packages/plugins/components/package.json
+++ b/packages/plugins/components/package.json
@@ -13,8 +13,8 @@
     },
     "scripts": {
         "build": "yarn build:esm && yarn build:cjs",
-        "build:esm": "tsc --module esnext --outDir lib/esm -p ./tsconfig.build.json",
-        "build:cjs": "tsc -p ./tsconfig.build.json",
+        "build:esm": "tsc --module esnext --outDir lib/esm --project ./tsconfig.build.json",
+        "build:cjs": "tsc --project ./tsconfig.build.json",
         "test": "NODE_ENV=test jest"
     },
     "dependencies": {

--- a/packages/plugins/components/package.json
+++ b/packages/plugins/components/package.json
@@ -13,8 +13,8 @@
     },
     "scripts": {
         "build": "yarn build:esm && yarn build:cjs",
-        "build:esm": "tsc --module esnext --outDir lib/esm",
-        "build:cjs": "tsc",
+        "build:esm": "tsc --module esnext --outDir lib/esm -p ./tsconfig.build.json",
+        "build:cjs": "tsc -p ./tsconfig.build.json",
         "test": "NODE_ENV=test jest"
     },
     "dependencies": {

--- a/packages/plugins/components/src/NavBar/index.tsx
+++ b/packages/plugins/components/src/NavBar/index.tsx
@@ -7,7 +7,7 @@ import { DefaultNavBarContent } from './defaultContent';
 
 export const navBarContentId = 'nav-bar-content';
 
-interface NavBarProps {
+export interface NavBarProps {
   useCustomContent?: boolean; // rename to show that it is a backNavigation
   className?: string;
 }

--- a/packages/plugins/components/src/NavBar/navbar.stories.tsx
+++ b/packages/plugins/components/src/NavBar/navbar.stories.tsx
@@ -9,7 +9,7 @@ export default {
   component: NavBar,
 } as ComponentMeta<typeof NavBar>;
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles((_theme: Theme) => ({
   updatedOne: {
     backgroundColor: 'lightblue',
     color: 'black',

--- a/packages/plugins/components/tsconfig.build.json
+++ b/packages/plugins/components/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": [
+        // files excluded from the build, we can not put it inro default tsconfig
+        // as it will screw VSCode IntelliSence
+        "**/__mocks__",
+        "**/test",
+        "**/mocks",
+        "src/**/*.spec.*",
+        "src/**/*.test.*",
+        "src/**/*.mock.*",
+        "src/**/*.stories.*"
+    ]
+}

--- a/packages/plugins/components/tsconfig.build.json
+++ b/packages/plugins/components/tsconfig.build.json
@@ -3,9 +3,10 @@
     "exclude": [
         // files excluded from the build, we can not put it inro default tsconfig
         // as it will screw VSCode IntelliSence
-        "**/__mocks__",
         "**/test",
         "**/mocks",
+        "**/__mocks__",
+        "**/__stories__",
         "src/**/*.spec.*",
         "src/**/*.test.*",
         "src/**/*.mock.*",

--- a/packages/zapp/console/tsconfig.build.json
+++ b/packages/zapp/console/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": [
+        // files excluded from the build, we can not put it inro default tsconfig
+        // as it will screw VSCode IntelliSence
+        "**/__mocks__",
+        "**/test",
+        "**/mocks",
+        "src/**/*.spec.*",
+        "src/**/*.test.*",
+        "src/**/*.mock.*",
+        "src/**/*.stories.*"
+    ]
+}

--- a/packages/zapp/console/tsconfig.build.json
+++ b/packages/zapp/console/tsconfig.build.json
@@ -3,9 +3,10 @@
     "exclude": [
         // files excluded from the build, we can not put it inro default tsconfig
         // as it will screw VSCode IntelliSence
-        "**/__mocks__",
         "**/test",
         "**/mocks",
+        "**/__mocks__",
+        "**/__stories__",
         "src/**/*.spec.*",
         "src/**/*.test.*",
         "src/**/*.mock.*",

--- a/packages/zapp/console/tsconfig.json
+++ b/packages/zapp/console/tsconfig.json
@@ -12,5 +12,9 @@
         "noImplicitOverride": false
     },
     "references": [{ "path": "../../plugins/components" }],
-    "include": ["src/**/*"]
+    "include": [
+        "src/**/*",
+        // TODO: *.json could be removed when tsconfig.build.json would be properly consumed by webpack
+        "src/**/*.json"
+    ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -46,16 +46,5 @@
             "@flyteconsole/*": ["./packages/plugins/*/src", "./packages/zapp/*/src"]
         }
     },
-    "exclude": [
-        "**/node_modules",
-        "**/dist",
-        "**/lib",
-        "**/src/**/*.spec.*",
-        "**/src/**/*.test.*",
-        "**/src/**/*.stories.*",
-        // old code patterns
-        "**/__mocks__",
-        "**/test",
-        "**/mocks"
-    ]
+    "exclude": ["**/node_modules", "**/dist", "**/lib"]
 }


### PR DESCRIPTION
This PR separates default config used from build config to:
- ensure that VSCode IntelliSence will properly map files
- builds will still exclude test / stories / mock files.

In this PR I checked and fixed "tsc" builds - which is used for plugins (and will be used for most other packages)

It DOES NOT include proper build config usage for webpack, yet. It shouould be done separately

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Tracking Issue

part of https://github.com/flyteorg/flyteconsole/issues/431


Signed-off-by: Nastya Rusina <nastya@union.ai>
