### PR TITLE
ci: ensure that webpack too doesn't include test/mock/specs files

### DIFF
--- a/packages/zapp/console/tsconfig.json
+++ b/packages/zapp/console/tsconfig.json
@@ -12,9 +12,5 @@
         "noImplicitOverride": false
     },
     "references": [{ "path": "../../plugins/components" }],
-    "include": [
-        "src/**/*",
-        // TODO: *.json could be removed when tsconfig.build.json would be properly consumed by webpack
-        "src/**/*.json"
-    ]
+    "include": ["src/**/*"]
 }


### PR DESCRIPTION
[The previous PR ](https://github.com/flyteorg/flyteconsole/pull/451) prepared a base and ensured of proper build through TSC (libs, microapp, npm packages). It made sure that tasks / mocks/ specs won't be included in final build. 

This PR finishes exclude pattern for webpack.

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [X] Chore

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Tracking Issue

part of https://github.com/flyteorg/flyteconsole/issues/431

Signed-off-by: Nastya Rusina <nastya@union.ai>