### PR TITLE
fix: ensure that admin version is fully shown

### DIFF
--- a/packages/zapp/console/src/components/hooks/useVersion.ts
+++ b/packages/zapp/console/src/components/hooks/useVersion.ts
@@ -16,10 +16,10 @@ function useVersion() {
 export function useAdminVersion() {
   const version = useVersion();
 
-  const controlPlaneVersion = version?.value?.controlPlaneVersion;
-  const adminVersion = controlPlaneVersion
-    ? controlPlaneVersion.Version?.slice(1, controlPlaneVersion.Version?.indexOf('-'))
-    : null;
+  const cpVersion = version?.value?.controlPlaneVersion;
+
+  // Remove letter "v" from version string, if it's in the beginning
+  const adminVersion = cpVersion?.Version?.replace(/^v/, '') ?? null;
 
   return { adminVersion };
 }


### PR DESCRIPTION
Previous version sliced out the last symbol if version didn't have `-xx` postfix. 
In real live we still want to show postfix in the version.

Fixed:
<img width="270" alt="Screen Shot 2022-05-13 at 3 55 44 PM" src="https://user-images.githubusercontent.com/55718143/168399373-329ba7c0-5dbc-41b0-92fa-facf1513a886.png">


## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

