### PR TITLE
Updated README to include instructions for OSX python support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,56 +32,53 @@
 </p>
 
 ## 📦 Install Dependencies
+
 Running flyteconsole locally requires [NodeJS](https://nodejs.org) and
 [yarn](https://yarnpkg.com). Once these are installed, you can run application locally.
 For help with installing dependencies look into
 [Installation section](CONTRIBUTING.md#-install-dependencies).
 
 ## 🚀 Quick Start
+
 1. Follow [Start a Local flyte backend](https://docs.flyte.org/en/latest/getting_started/index.html), like:
     ```bash
     docker run --rm --privileged -p 30080:30080 -p 30081:30081 -p 30082:30082 -p 30084:30084 cr.flyte.org/flyteorg/flyte-sandbox
-    ``` 
+    ```
 2. Now, export the following env variables:
 
-    ``
-    export ADMIN_API_URL=http://localhost:30080
-    export DISABLE_AUTH=1
-    ``
+    `export ADMIN_API_URL=http://localhost:30080 export DISABLE_AUTH=1`
 
-   > You can persist these environment variables either in the current shell or in a `.env` file at the root
-     of the repository. A `.env` file will persist the settings across multiple terminal
-     sessions.
+    > You can persist these environment variables either in the current shell or in a `.env` file at the root
+    > of the repository. A `.env` file will persist the settings across multiple terminal
+    > sessions.
 
 3. Start the server (uses localhost:3000)
 
-    ``bash
-    yarn start
-    ``
+    `yarn start`
 
 4. Explore your local copy at `http://localhost:3000`
 
 ### Environment Variables
 
-* `ADMIN_API_URL` (default: [window.location.origin](https://developer.mozilla.org/en-US/docs/Web/API/Window/location>))
+-   `ADMIN_API_URL` (default: [window.location.origin](https://developer.mozilla.org/en-US/docs/Web/API/Window/location>))
 
     The Flyte Console displays information fetched from the FlyteAdmin API. This
     environment variable specifies the host prefix used in constructing API requests.
 
-    *Note*: this is only the host portion of the API endpoint, consisting of the
+    _Note_: this is only the host portion of the API endpoint, consisting of the
     protocol, domain, and port (if not using the standard 80/443).
 
     This value will be combined with a suffix (such as `/api/v1`) to construct the
     final URL used in an API request.
 
-    *Default Behavior*
+    _Default Behavior_
 
     In most cases, `flyteconsole` will be hosted in the same cluster as the Admin
     API, meaning that the domain used to access the console is the same value used to
     access the API. For this reason, if no value is set for `ADMIN_API_URL`, the
     default behavior is to use the value of `window.location.origin`.
 
-* `BASE_URL` (default: `undefined`)
+-   `BASE_URL` (default: `undefined`)
 
     This allows running the console at a prefix on the target host. This is
     necessary when hosting the API and console on the same domain (with prefixes of
@@ -99,87 +96,94 @@ few environment variables in your run command to setup the appliation.
 
 `DISABLE_AUTH="1"` (optional)
 
-This example assumes building from ``v1.0.0`` on port ``8080``
+This example assumes building from `v1.0.0` on port `8080`
+
 ```bash
 docker run -p 8080:8080 -e BASE_URL="/console" -e CONFIG_DIR="/etc/flyte/config" -e DISABLE_AUTH="1" ghcr.io/flyteorg/flyteconsole:v1.0.0
-```   
-
+```
 
 ### Run the server
 
 To start the local development server run:
+
 ```bash
 yarn install    # to install node_modules
-yarn start      # to start application   
+yarn start      # to start application
 ```
-This will spin up a Webpack development server, compile all of the code into bundles, 
-and start the NodeJS server on the default port (3000). All requests to the NodeJS server 
+
+This will spin up a Webpack development server, compile all of the code into bundles,
+and start the NodeJS server on the default port (3000). All requests to the NodeJS server
 will be stalled until the bundles have finished. The application will be accessible
 at http://localhost:3000 (if using the default port).
-
 
 ## 🛠 Development
 
 For continious development we are using:
-* **[Protobuf and Debug Output](CONTRIBUTING.md#protobuf-and-debug-output)**.
-  Protobuf is a binary response/request format, which makes _Network Tab_ hardly useful.
-  To get more info on requests - use our Debug Output
-  
-* **[Storybook](CONTRIBUTING.md#storybook)**
-  \- used for component stories and base UI testing.
 
-* **[Feature flags](CONTRIBUTING.md#feature-flags)**
-  \- allows to enable/disable specific code paths. Used to simplify continious development.
+-   **[Protobuf and Debug Output](CONTRIBUTING.md#protobuf-and-debug-output)**.
+    Protobuf is a binary response/request format, which makes _Network Tab_ hardly useful.
+    To get more info on requests - use our Debug Output
+-   **[Storybook](CONTRIBUTING.md#storybook)**
+    \- used for component stories and base UI testing.
 
-* **[Google Analytics](CONTRIBUTING.md#google-analytics)**
-  \- adds tracking code to the app or website. To disable use `ENABLE_GA=false`
+-   **[Feature flags](CONTRIBUTING.md#feature-flags)**
+    \- allows to enable/disable specific code paths. Used to simplify continious development.
+
+-   **[Google Analytics](CONTRIBUTING.md#google-analytics)**
+    \- adds tracking code to the app or website. To disable use `ENABLE_GA=false`
 
 More info on each section could be found at [CONTRIBUTING.md](CONTRIBUTING.md)
 
-* Set `ADMIN_API_URL` and `ADMIN_API_USE_SSL`
-   
-   ```bash
-   export ADMIN_API_URL=https://different.admin.service.com
-   export ADMIN_API_USE_SSL="https"
-   export LOCAL_DEV_HOST=localhost.different.admin.service.com
-   ```  
-   
-   > **Hint:** Add these to your local profile (eg, `./profile`) to prevent having to do this step each time
+-   Set `ADMIN_API_URL` and `ADMIN_API_USE_SSL`
 
-* Generate SSL certificate
+    ```bash
+    export ADMIN_API_URL=https://different.admin.service.com
+    export ADMIN_API_USE_SSL="https"
+    export LOCAL_DEV_HOST=localhost.different.admin.service.com
+    ```
 
-   Run the following command from your `flyteconsole` directory
-   ```bash
-   make generate_ssl
-   ```
+    > **Hint:** Add these to your local profile (eg, `./profile`) to prevent having to do this step each time
 
-* Add new record to hosts file
+-   Generate SSL certificate
 
-   ```bash
-   sudo vim /etc/hosts
-   ```
-   
-   Add the following record
-   ```bash
-   127.0.0.1 localhost.different.admin.service.com
-   ```
-   
-* Install Chrome plugin: [Moesif Origin & CORS Changer](https://chrome.google.com/webstore/detail/moesif-origin-cors-change/digfbfaphojjndkpccljibejjbppifbc)
+    Run the following command from your `flyteconsole` directory
+
+    ```bash
+    make generate_ssl
+    ```
+
+-   Add new record to hosts file
+
+    ```bash
+    sudo vim /etc/hosts
+    ```
+
+    Add the following record
+
+    ```bash
+    127.0.0.1 localhost.different.admin.service.com
+    ```
+
+-   Install Chrome plugin: [Moesif Origin & CORS Changer](https://chrome.google.com/webstore/detail/moesif-origin-cors-change/digfbfaphojjndkpccljibejjbppifbc)
 
     > _NOTE:_
+    >
     > 1. Activate plugin (toggle to "on")
     > 1. Open 'Advanced Settings':
-    > - set `Access-Control-Allow-Credentials`: `true`
-    > - set `Domain List`: `your.localhost.com`
+    >
+    > -   set `Access-Control-Allow-Credentials`: `true`
+    > -   set `Domain List`: `your.localhost.com`
 
-* Start `flyteconsole`
+-   Start `flyteconsole`
 
-   ```bash
-   yarn start
-   ```
-   Your new localhost is [localhost.different.admin.service.com](http://localhost.different.admin.service.com)
+    ```bash
+    yarn start
+    ```
 
-   > **Hint:** Ensure you don't have `ADMIN_API_URL` set (eg, in your `/.profile`.)
+    Your new localhost is [localhost.different.admin.service.com](http://localhost.different.admin.service.com)
+
+    > **Hint:** Ensure you don't have `ADMIN_API_URL` set (eg, in your `/.profile`.)
 
 ## ⛳️ Release
+
 To release, you have to annotate the PR message to include one of the following [commit-analyzer types](https://github.com/semantic-release/commit-analyzer#rules-matching)


### PR DESCRIPTION
This PR updates the readme file to help users deal with OSX dropping python support.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
_NA_

## Tracking Issue
_NA_

## Follow-up issue
_NA_
