### PR TITLE
fix: add eventVersion check for map tasks

### DIFF
--- a/packages/zapp/console/src/components/Executions/ExecutionDetails/ExecutionWorkflowGraph.tsx
+++ b/packages/zapp/console/src/components/Executions/ExecutionDetails/ExecutionWorkflowGraph.tsx
@@ -7,6 +7,7 @@ import { keyBy } from 'lodash';
 import { TaskExecutionPhase } from 'models/Execution/enums';
 import { ExternalResource, LogsByPhase, NodeExecution } from 'models/Execution/types';
 import { endNodeId, startNodeId } from 'models/Node/constants';
+import { isMapTaskType } from 'models/Task/utils';
 import { Workflow, WorkflowId } from 'models/Workflow/types';
 import * as React from 'react';
 import { useEffect, useMemo, useState } from 'react';
@@ -32,6 +33,14 @@ export const ExecutionWorkflowGraph: React.FC<ExecutionWorkflowGraphProps> = ({
     const taskExecutions = useTaskExecutions(nodeExecution.id);
     useTaskExecutionsRefresher(nodeExecution, taskExecutions);
 
+    const useNewMapTaskView = taskExecutions.value.every((taskExecution) => {
+      const {
+        closure: { taskType, metadata, eventVersion = 0 },
+      } = taskExecution;
+      return (
+        isMapTaskType(taskType ?? undefined) && eventVersion >= 1 && metadata?.externalResources
+      );
+    });
     const externalResources: ExternalResource[] = taskExecutions.value
       .map((taskExecution) => taskExecution.closure.metadata?.externalResources)
       .flat()
@@ -41,7 +50,7 @@ export const ExecutionWorkflowGraph: React.FC<ExecutionWorkflowGraphProps> = ({
 
     return {
       ...nodeExecution,
-      ...(logsByPhase.size > 0 && { logsByPhase }),
+      ...(useNewMapTaskView && logsByPhase.size > 0 && { logsByPhase }),
     };
   });
 

--- a/packages/zapp/console/src/components/Executions/ExecutionDetails/ExecutionWorkflowGraph.tsx
+++ b/packages/zapp/console/src/components/Executions/ExecutionDetails/ExecutionWorkflowGraph.tsx
@@ -7,7 +7,7 @@ import { keyBy } from 'lodash';
 import { TaskExecutionPhase } from 'models/Execution/enums';
 import { ExternalResource, LogsByPhase, NodeExecution } from 'models/Execution/types';
 import { endNodeId, startNodeId } from 'models/Node/constants';
-import { isMapTaskType } from 'models/Task/utils';
+import { isMapTaskV1 } from 'models/Task/utils';
 import { Workflow, WorkflowId } from 'models/Workflow/types';
 import * as React from 'react';
 import { useEffect, useMemo, useState } from 'react';
@@ -37,8 +37,10 @@ export const ExecutionWorkflowGraph: React.FC<ExecutionWorkflowGraphProps> = ({
       const {
         closure: { taskType, metadata, eventVersion = 0 },
       } = taskExecution;
-      return (
-        isMapTaskType(taskType ?? undefined) && eventVersion >= 1 && metadata?.externalResources
+      return isMapTaskV1(
+        eventVersion,
+        metadata?.externalResources?.length ?? 0,
+        taskType ?? undefined,
       );
     });
     const externalResources: ExternalResource[] = taskExecutions.value

--- a/packages/zapp/console/src/components/Executions/TaskExecutionsList/TaskExecutionsList.tsx
+++ b/packages/zapp/console/src/components/Executions/TaskExecutionsList/TaskExecutionsList.tsx
@@ -42,9 +42,11 @@ export const TaskExecutionsListContent: React.FC<{
   return (
     <>
       {taskExecutions.map((taskExecution) => {
-        const taskType = taskExecution.closure.taskType ?? undefined;
+        const {
+          closure: { taskType, metadata, eventVersion = 0 },
+        } = taskExecution;
         const useNewMapTaskView =
-          isMapTaskType(taskType) && taskExecution.closure.metadata?.externalResources;
+          isMapTaskType(taskType ?? undefined) && eventVersion >= 1 && metadata?.externalResources;
         return useNewMapTaskView ? (
           <MapTaskExecutionsListItem
             key={getUniqueTaskExecutionName(taskExecution)}

--- a/packages/zapp/console/src/components/Executions/TaskExecutionsList/TaskExecutionsList.tsx
+++ b/packages/zapp/console/src/components/Executions/TaskExecutionsList/TaskExecutionsList.tsx
@@ -4,7 +4,7 @@ import { noExecutionsFoundString } from 'common/constants';
 import { NonIdealState } from 'components/common/NonIdealState';
 import { WaitForData } from 'components/common/WaitForData';
 import { MapTaskExecution, NodeExecution, TaskExecution } from 'models/Execution/types';
-import { isMapTaskType } from 'models/Task/utils';
+import { isMapTaskV1 } from 'models/Task/utils';
 import { TaskExecutionPhase } from 'models/Execution/enums';
 import { useTaskExecutions, useTaskExecutionsRefresher } from '../useTaskExecutions';
 import { MapTaskExecutionsListItem } from './MapTaskExecutionListItem';
@@ -45,8 +45,11 @@ export const TaskExecutionsListContent: React.FC<{
         const {
           closure: { taskType, metadata, eventVersion = 0 },
         } = taskExecution;
-        const useNewMapTaskView =
-          isMapTaskType(taskType ?? undefined) && eventVersion >= 1 && metadata?.externalResources;
+        const useNewMapTaskView = isMapTaskV1(
+          eventVersion,
+          metadata?.externalResources?.length ?? 0,
+          taskType ?? undefined,
+        );
         return useNewMapTaskView ? (
           <MapTaskExecutionsListItem
             key={getUniqueTaskExecutionName(taskExecution)}

--- a/packages/zapp/console/src/components/WorkflowGraph/test/WorkflowGraph.test.tsx
+++ b/packages/zapp/console/src/components/WorkflowGraph/test/WorkflowGraph.test.tsx
@@ -28,6 +28,7 @@ describe('WorkflowGraph', () => {
             onPhaseSelectionChanged={jest.fn}
             workflow={workflow}
             nodeExecutionsById={nodeExecutionsById}
+            isDetailsTabClosed={true}
           />
         </QueryClientProvider>,
       );

--- a/packages/zapp/console/src/models/Task/task.test.ts
+++ b/packages/zapp/console/src/models/Task/task.test.ts
@@ -1,5 +1,5 @@
 import { TaskType } from './constants';
-import { isMapTaskType } from './utils';
+import { isMapTaskType, isMapTaskV1 } from './utils';
 
 describe('models/Task', () => {
   it('isMapTaskType propely identifies mapped tasks', async () => {
@@ -13,5 +13,32 @@ describe('models/Task', () => {
 
     // when regular task is provided - to be false
     expect(isMapTaskType(TaskType.PYTHON)).toBeFalsy();
+  });
+
+  it('isMapTaskV1 propely identifies mapped task events above version 1', () => {
+    const eventVersionZero = 0;
+    const eventVersionN = 3;
+    const resourcesLengthZero = 0;
+    const resourcesLengthN = 5;
+    const mapTaskTypes = [TaskType.ARRAY, TaskType.ARRAY_AWS, TaskType.ARRAY_K8S];
+    const nonMapTaskType = TaskType.PYTHON;
+
+    describe('FALSE cases:', () => {
+      // when no task is provided
+      expect(isMapTaskV1(eventVersionN, resourcesLengthN)).toBeFalsy();
+      // when regular task is provided
+      expect(isMapTaskV1(eventVersionN, resourcesLengthN, nonMapTaskType)).toBeFalsy();
+      // when eventVersion < 1
+      expect(isMapTaskV1(eventVersionZero, resourcesLengthN, mapTaskTypes[0])).toBeFalsy();
+      // when externalResources array has length of 0
+      expect(isMapTaskV1(eventVersionN, resourcesLengthZero, mapTaskTypes[0])).toBeFalsy();
+    });
+
+    describe('TRUE cases:', () => {
+      // when mapped task is provided AND eventVersion >= 1 AND externalResources array length > 0
+      for (const task of mapTaskTypes) {
+        expect(isMapTaskV1(eventVersionN, resourcesLengthN, task)).toBeTruthy();
+      }
+    });
   });
 });

--- a/packages/zapp/console/src/models/Task/utils.ts
+++ b/packages/zapp/console/src/models/Task/utils.ts
@@ -24,3 +24,12 @@ export function isMapTaskType(taskType?: string): boolean {
     taskType === TaskType.ARRAY_K8S
   );
 }
+
+/** Returns true if tasks schema is treated as a map task AND eventVersion >= 1 AND externalResources array length > 0 */
+export function isMapTaskV1(
+  eventVersion: number,
+  externalResourcesLength: number,
+  taskType?: string,
+): boolean {
+  return isMapTaskType(taskType) && eventVersion >= 1 && externalResourcesLength > 0;
+}


### PR DESCRIPTION
Signed-off-by: Olga Nad <olga@union.ai>

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Added event version check to show new map task UI (graph and details tab) only for events with version >= 1.

## Screenshots
With eventVersion
<img width="1728" alt="Screen Shot 2022-05-18 at 4 54 54 PM" src="https://user-images.githubusercontent.com/101579322/169163856-2c7a47d4-6188-47a3-a97f-1269b754e6bd.png">
Without eventVersion
<img width="1728" alt="Screen Shot 2022-05-18 at 4 58 40 PM" src="https://user-images.githubusercontent.com/101579322/169163941-984e1f37-4337-4447-98fd-beb8684792f9.png">


## Tracking Issue
fixes https://github.com/flyteorg/flyteconsole/issues/381

## Follow-up issue
_NA_
