### PR TITLE
fix: resolve minimist package to v1.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
         "@babel/plugin-proposal-object-rest-spread": "~7.16.7",
         "@babel/preset-env": "~7.16.11",
         "@babel/preset-react": "~7.16.7",
-        "@babel/preset-typescript": "~7.16.7"
+        "@babel/preset-typescript": "~7.16.7",
+        "minimist": "1.2.6"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13619,15 +13619,10 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
-minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+minimist@0.0.8, minimist@1.2.6, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass-collect@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
We currently using favicon package to genereate icons and put them into assets folder.

    "favicons": "^6.2.0",
    "favicons-webpack-plugin": "^5.0.2",
Favicon v. 6.2.2 was release more than a year ago and leads to hardcoded mkdirp@0.5.1 which leads to minimist@0.0.8 with severe vulnerability.

Newer favicon version 7.0.0-beta is not compattible with favicons-webpack-plugin.

We need to investigate (https://github.com/flyteorg/flyteconsole/issues/491):

- if better package is available for this need.
- if we can minimize amount of generated icons, as currently we have a lot of sizes we don't really need.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Follow-up issue
https://github.com/flyteorg/flyteconsole/issues/491
