### PR TITLE
fix: cannot read properties of undefined

### DIFF
--- a/packages/zapp/console/src/components/Executions/ExecutionDetails/ExecutionDetailsActions.tsx
+++ b/packages/zapp/console/src/components/Executions/ExecutionDetails/ExecutionDetailsActions.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@material-ui/core';
 import * as React from 'react';
-import { ResourceIdentifier, Identifier, Variable } from 'models/Common/types';
+import { ResourceIdentifier, Identifier } from 'models/Common/types';
 import { getTask } from 'models/Task/api';
 import { LaunchFormDialog } from 'components/Launch/LaunchForm/LaunchFormDialog';
 import { NodeExecutionIdentifier } from 'models/Execution/types';
@@ -20,32 +20,37 @@ export const ExecutionDetailsActions = (props: ExecutionDetailsActionsProps): JS
   const { className, details, nodeExecutionId } = props;
 
   const [showLaunchForm, setShowLaunchForm] = React.useState<boolean>(false);
-  const [taskInputsTypes, setTaskInputsTypes] = React.useState<
-    Record<string, Variable> | undefined
-  >();
+
+  const [initialParameters, setInitialParameters] = React.useState<
+    TaskInitialLaunchParameters | undefined
+  >(undefined);
 
   const executionData = useNodeExecutionData(nodeExecutionId);
-
-  const id = details.taskTemplate?.id as ResourceIdentifier | undefined;
+  const id = details.taskTemplate?.id;
 
   React.useEffect(() => {
-    const fetchTask = async () => {
-      const task = await getTask(id as Identifier);
-      setTaskInputsTypes(task.closure.compiledTask.template?.interface?.inputs?.variables);
-    };
-    if (id) fetchTask();
-  }, [id]);
+    if (!id) {
+      return;
+    }
 
-  if (!id) {
+    (async () => {
+      const task = await getTask(id!);
+
+      const literals = executionData.value.fullInputs?.literals;
+      const taskInputsTypes = task.closure.compiledTask.template?.interface?.inputs?.variables;
+
+      const tempInitialParameters: TaskInitialLaunchParameters = {
+        values: literals && taskInputsTypes && literalsToLiteralValueMap(literals, taskInputsTypes),
+        taskId: id as Identifier | undefined,
+      };
+
+      setInitialParameters(tempInitialParameters);
+    })();
+  }, [details]);
+
+  if (!id || !initialParameters) {
     return <></>;
   }
-
-  const literals = executionData.value.fullInputs?.literals;
-
-  const initialParameters: TaskInitialLaunchParameters = {
-    values: literals && taskInputsTypes && literalsToLiteralValueMap(literals, taskInputsTypes),
-    taskId: id as Identifier | undefined,
-  };
 
   const rerunOnClick = (e: React.MouseEvent<HTMLElement>) => {
     e.stopPropagation();
@@ -60,7 +65,7 @@ export const ExecutionDetailsActions = (props: ExecutionDetailsActionsProps): JS
         </Button>
       </div>
       <LaunchFormDialog
-        id={id}
+        id={id as ResourceIdentifier}
         initialParameters={initialParameters}
         showLaunchForm={showLaunchForm}
         setShowLaunchForm={setShowLaunchForm}


### PR DESCRIPTION
Null-ref when switching between node executions due to race condition.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
When clicking through node executions, a race condition happens for the current execution data, leading to us trying to access properties on the details object that do not exist.

![image](https://user-images.githubusercontent.com/6610300/172239789-13d9d990-357c-4ef3-846e-bdbd093b3e57.png)

## Tracking Issue
fixes https://github.com/flyteorg/flyteconsole/issues/505