### PR TITLE
chore: support internal/external navigsation better

### DIFF
--- a/packages/zapp/console/src/components/Navigation/NavigationDropdown.tsx
+++ b/packages/zapp/console/src/components/Navigation/NavigationDropdown.tsx
@@ -47,11 +47,11 @@ export const NavigationDropdown = (props: NavigationDropdownProps) => {
   const handleItemSelection = (item: FlyteNavItem) => {
     setSelectedPage(item.title);
 
-    if (item.url.startsWith('/')) {
-      // local navigation without BASE_URL addition
-      history.push(item.url);
+    if (item.url.startsWith('+')) {
+      // local navigation with BASE_URL addition
+      history.push(makeRoute(item.url.slice(1)));
     } else {
-      // external navigation
+      // treated as external navigation
       window.location.assign(item.url);
     }
   };

--- a/packages/zapp/console/src/components/Navigation/Readme.md
+++ b/packages/zapp/console/src/components/Navigation/Readme.md
@@ -25,8 +25,8 @@ Essentially FLYTE_NAVIGATION is a JSON object
     background:"black",  // default NavBar background color
     items:[
         {title:"Remote", url:"https://remote.site/"},
-        {title:"Dashboard", url:"/projects/flytesnacks/executions?domain=development&duration=all"},
-        {title:"Execution", url:"/projects/flytesnacks/domains/development/executions/awf2lx4g58htr8svwb7x?duration=all"}
+        {title:"Dashboard", url:"+/projects/flytesnacks/executions?domain=development&duration=all"},
+        {title:"Information", url:"/information"}
     ]
 }
 ```
@@ -35,12 +35,12 @@ If at least one item in `items` array is present the dropdown will appear in Nav
 It will contain at least two items:
 
 -   default "Console" item which navigates to ${BASE_URL}
--   all items you have provided
+-   all items you have provided:
+    -   If item's url starts with `+` sign, the navigstion would be treated as an internal one. + sign would be stripped and BASE_URL would be added to navigaiton
 
 Feel free to play around with the views in Storybook:
 
 <img width="874" alt="Screen Shot 2022-06-15 at 2 01 29 PM" src="https://user-images.githubusercontent.com/55718143/173962811-a3603d6c-3fe4-4cab-b57a-4d4806c88cfc.png">
-
 
 #### Note
 


### PR DESCRIPTION
Updated Readme

Treat all url as external - needed for proper navigation between two apps located at the same client domain, but under different paths.
User needs to add `+` sign to the url which need to be treated as internal once (to avoid full application refresh).

Signed-off-by: Nastya <55718143+anrusina@users.noreply.github.com>
