### PR TITLE
fix: Relaunch form does not persist security context values when changed

### DIFF
--- a/packages/zapp/console/src/components/Executions/ExecutionDetails/RelaunchExecutionForm.tsx
+++ b/packages/zapp/console/src/components/Executions/ExecutionDetails/RelaunchExecutionForm.tsx
@@ -117,6 +117,7 @@ const RelaunchWorkflowForm: React.FC<RelaunchExecutionFormProps> = (props) => {
   const { initialParameters } = useRelaunchWorkflowFormState(props);
   const {
     closure: { workflowId },
+    spec: { securityContext },
   } = props.execution;
 
   return (
@@ -127,6 +128,7 @@ const RelaunchWorkflowForm: React.FC<RelaunchExecutionFormProps> = (props) => {
           onClose={props.onClose}
           referenceExecutionId={props.execution.id}
           workflowId={workflowId}
+          securityContext={securityContext}
         />
       ) : null}
     </WaitForData>

--- a/packages/zapp/console/src/components/Launch/LaunchForm/LaunchWorkflowForm.tsx
+++ b/packages/zapp/console/src/components/Launch/LaunchForm/LaunchWorkflowForm.tsx
@@ -26,6 +26,7 @@ export const LaunchWorkflowForm: React.FC<LaunchWorkflowFormProps> = (props) => 
     service,
     workflowSourceSelectorState,
   } = useLaunchWorkflowFormState(props);
+  const { securityContext } = props;
 
   const styles = useStyles();
   const baseState = state as BaseInterpretedLaunchState;
@@ -56,6 +57,15 @@ export const LaunchWorkflowForm: React.FC<LaunchWorkflowFormProps> = (props) => 
     ![LaunchState.LOADING_LAUNCH_PLANS, LaunchState.FAILED_LOADING_LAUNCH_PLANS].some(
       state.matches,
     );
+
+  const roleInitialValue = React.useMemo(() => {
+    if (securityContext) return { securityContext };
+    return (
+      state.context.defaultAuthRole ||
+      selectedLaunchPlan?.data.spec.securityContext ||
+      selectedLaunchPlan?.data.spec.authRole
+    );
+  }, [securityContext, state.context.defaultAuthRole, selectedLaunchPlan]);
 
   return (
     <>
@@ -97,11 +107,7 @@ export const LaunchWorkflowForm: React.FC<LaunchWorkflowFormProps> = (props) => 
           <AccordionDetails classes={{ root: styles.detailsWrapper }}>
             {isEnterInputsState(baseState) ? (
               <LaunchRoleInput
-                initialValue={
-                  state.context.defaultAuthRole ||
-                  selectedLaunchPlan?.data.spec.securityContext ||
-                  selectedLaunchPlan?.data.spec.authRole
-                }
+                initialValue={roleInitialValue}
                 ref={roleInputRef}
                 showErrors={state.context.showErrors}
               />

--- a/packages/zapp/console/src/components/Launch/LaunchForm/types.ts
+++ b/packages/zapp/console/src/components/Launch/LaunchForm/types.ts
@@ -65,6 +65,7 @@ export interface WorkflowInitialLaunchParameters extends BaseInitialLaunchParame
 
 export interface LaunchWorkflowFormProps extends BaseLaunchFormProps {
   workflowId: NamedEntityIdentifier;
+  securityContext?: Core.ISecurityContext;
   initialParameters?: WorkflowInitialLaunchParameters;
 }
 


### PR DESCRIPTION
Signed-off-by: James <james@union.ai>

# TL;DR
Use execution security context in Relaunch form

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Derived execution security context into Relaunch form

## Tracking Issue

fixes https://github.com/flyteorg/flyte/issues/496
