### PR TITLE
fix: make sure groups used in graph aren't undefined

### DIFF
--- a/packages/zapp/console/src/components/Executions/nodeExecutionQueries.ts
+++ b/packages/zapp/console/src/components/Executions/nodeExecutionQueries.ts
@@ -335,7 +335,7 @@ export function useAllChildNodeExecutionGroupsQuery(
       return groups.some((group) => {
         // non-empty groups are wrapped in array
         const unwrappedGroup = Array.isArray(group) ? group[0] : group;
-        if (unwrappedGroup.nodeExecutions?.length > 0) {
+        if (unwrappedGroup?.nodeExecutions?.length > 0) {
           /* Return true is any executions are not yet terminal (ie, they can change) */
           return unwrappedGroup.nodeExecutions.some((ne) => {
             return !nodeExecutionIsTerminal(ne);


### PR DESCRIPTION
Signed-off-by: Olga Nad <olga@union.ai>

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Fix to make sure graph without nested groups aren't failing to display.

Before
<img width="724" alt="Screen Shot 2022-07-19 at 12 04 04 PM" src="https://user-images.githubusercontent.com/101579322/179808380-542bc899-0ed9-437c-92a9-632709d714a6.png">
After
<img width="598" alt="Screen Shot 2022-07-19 at 12 03 36 PM" src="https://user-images.githubusercontent.com/101579322/179808414-ec2f395f-850b-4f78-9989-2fe4ec85bfa6.png">


## Follow-up issue
_NA_
