### PR TITLE
fix: flyteconsole tag in ci pipeline 

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -107,12 +107,14 @@ jobs:
         # a tag, update our target
         run: |
           CURRENT_TAG=$(git tag --sort=-refname --points-at ${{ github.ref }} | head -n 1)
+          echo $CURRENT_TAG
           echo "::set-output name=currentTag::$CURRENT_TAG"
 
   push_docker_image:
     name: Push to Github Registry
     needs: [check_for_tag]
     runs-on: ubuntu-latest
+    if: ${{ needs.check_for_tag.outputs.currentTag != '' }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/upgrade_automation.yml
+++ b/.github/workflows/upgrade_automation.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   trigger-upgrade:
     name: ${{ github.event.inputs.component }} Upgrade
-    if: ${{ github.event.inputs.component  == "boilerplate" }}
+    if: ${{ github.event.inputs.component  == 'boilerplate' }}
     uses: flyteorg/flytetools/.github/workflows/flyte_automation.yml@master
     with:
       component: ${{ github.event.inputs.component }}
@@ -24,7 +24,7 @@ jobs:
   upgrade_flyteidl:
     name: Upgrade Flyteidl
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.component  == "flyteidl" }}
+    if: ${{ github.event.inputs.component  == 'flyteidl' }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/boilerplate/update.cfg
+++ b/boilerplate/update.cfg
@@ -1,4 +1,3 @@
 flyte/docker_build
 flyte/pull_request_template
-flyte/welcome_bot
 flyte/code_of_conduct


### PR DESCRIPTION
# TL;DR
The root cause of CI pipeline failure:
- In flyteconsole, we are not creating a release for each merge, Release will depend on the PR title. Meaning in our CI [this step](https://github.com/flyteorg/flyteconsole/blob/28a224e7ef800f33ecc754835aceb90f8c0cff0b/.github/workflows/checks.yml#L109) will always run but will not produce any output because each master merge doesn't have a tag. 

Empty tags are responsible for the CI pipeline failure https://github.com/flyteorg/flyteconsole/runs/7434395445?check_suite_focus=true

Test: 
For a release: https://github.com/evalsocket/flyteconsole/runs/7464756361?check_suite_focus=true#step:4:9
for a normal commit: https://github.com/evalsocket/flyteconsole/actions/runs/2717297519

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
