### PR TITLE
fix: webmanifest missing crossorigin attribute

### DIFF
--- a/packages/zapp/console/src/assets/index.html
+++ b/packages/zapp/console/src/assets/index.html
@@ -12,6 +12,7 @@
         <link
             rel="manifest"
             href="<%= htmlWebpackPlugin.options.publicPath %>/manifest.webmanifest"
+            crossorigin="use-credentials"
         />
         <!-- 16x16, 32x32 -->
         <link


### PR DESCRIPTION
# TL;DR
Webmanifest requests result in error

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Added a crossorigin attribute

## Tracking Issue
https://github.com/flyteorg/flyteconsole/issues/565