### PR TITLE
fix: console showing subworkflows as unknown

### DIFF
--- a/packages/zapp/console/src/components/Executions/ExecutionDetails/Timeline/ChartHeader.tsx
+++ b/packages/zapp/console/src/components/Executions/ExecutionDetails/Timeline/ChartHeader.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import * as moment from 'moment-timezone';
+import makeStyles from '@material-ui/core/styles/makeStyles';
+import { COLOR_SPECTRUM } from 'components/Theme/colorSpectrum';
+import { useScaleContext } from './scaleContext';
+import { TimeZone } from './helpers';
+
+interface StyleProps {
+  chartWidth: number;
+  labelInterval: number;
+}
+
+const useStyles = makeStyles((_theme) => ({
+  chartHeader: (props: StyleProps) => ({
+    height: 41,
+    display: 'flex',
+    alignItems: 'center',
+    width: `${props.chartWidth}px`,
+  }),
+  taskDurationsLabelItem: (props: StyleProps) => ({
+    fontSize: 12,
+    fontFamily: 'Open Sans',
+    fontWeight: 'bold',
+    color: COLOR_SPECTRUM.gray40.color,
+    paddingLeft: 10,
+    width: `${props.labelInterval}px`,
+  }),
+}));
+
+interface HeaderProps extends StyleProps {
+  chartTimezone: string;
+  totalDurationSec: number;
+  startedAt: Date;
+}
+
+export const ChartHeader = (props: HeaderProps) => {
+  const styles = useStyles(props);
+
+  const { chartInterval: chartTimeInterval, setMaxValue } = useScaleContext();
+  const { startedAt, chartTimezone, totalDurationSec } = props;
+
+  React.useEffect(() => {
+    setMaxValue(props.totalDurationSec);
+  }, [props.totalDurationSec, setMaxValue]);
+
+  const labels = React.useMemo(() => {
+    const len = Math.ceil(totalDurationSec / chartTimeInterval);
+    const lbs = len > 0 ? new Array(len).fill('') : [];
+    return lbs.map((_, idx) => {
+      const time = moment.utc(new Date(startedAt.getTime() + idx * chartTimeInterval * 1000));
+      return chartTimezone === TimeZone.UTC
+        ? time.format('hh:mm:ss A')
+        : time.local().format('hh:mm:ss A');
+    });
+  }, [chartTimezone, startedAt, chartTimeInterval, totalDurationSec]);
+
+  return (
+    <div className={styles.chartHeader}>
+      {labels.map((label) => {
+        return (
+          <div className={styles.taskDurationsLabelItem} key={label}>
+            {label}
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/packages/zapp/console/src/components/Executions/ExecutionDetails/Timeline/ExecutionTimeline.tsx
+++ b/packages/zapp/console/src/components/Executions/ExecutionDetails/Timeline/ExecutionTimeline.tsx
@@ -15,7 +15,7 @@ import { checkForDynamicExecutions } from 'components/common/utils';
 import { convertToPlainNodes } from './helpers';
 import { ChartHeader } from './chartHeader';
 import { useScaleContext } from './scaleContext';
-import { TaskNames } from './taskNames';
+import { TaskNames } from './TaskNames';
 import { getChartDurationData } from './TimelineChart/chartData';
 import { TimelineChart } from './TimelineChart';
 

--- a/packages/zapp/console/src/components/Executions/ExecutionDetails/Timeline/ExecutionTimeline.tsx
+++ b/packages/zapp/console/src/components/Executions/ExecutionDetails/Timeline/ExecutionTimeline.tsx
@@ -13,7 +13,7 @@ import { createRef, useContext, useEffect, useRef, useState } from 'react';
 import { NodeExecutionsByIdContext } from 'components/Executions/contexts';
 import { checkForDynamicExecutions } from 'components/common/utils';
 import { convertToPlainNodes } from './helpers';
-import { ChartHeader } from './chartHeader';
+import { ChartHeader } from './ChartHeader';
 import { useScaleContext } from './scaleContext';
 import { TaskNames } from './TaskNames';
 import { getChartDurationData } from './TimelineChart/chartData';

--- a/packages/zapp/console/src/components/Executions/ExecutionDetails/Timeline/TaskNames.tsx
+++ b/packages/zapp/console/src/components/Executions/ExecutionDetails/Timeline/TaskNames.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react';
+import { makeStyles, Theme, Typography } from '@material-ui/core';
+
+import { RowExpander } from 'components/Executions/Tables/RowExpander';
+import { getNodeTemplateName } from 'components/WorkflowGraph/utils';
+import { dNode } from 'models/Graph/types';
+import { NodeExecutionName } from './NodeExecutionName';
+import { NodeExecutionsTimelineContext } from './context';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  taskNamesList: {
+    overflowY: 'scroll',
+    flex: 1,
+  },
+  namesContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'left',
+    padding: '0 10px',
+    height: 56,
+    width: 256,
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    whiteSpace: 'nowrap',
+  },
+  namesContainerExpander: {
+    display: 'flex',
+    marginTop: 'auto',
+    marginBottom: 'auto',
+  },
+  namesContainerBody: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    justifyContent: 'center',
+    whiteSpace: 'nowrap',
+    height: '100%',
+    overflow: 'hidden',
+  },
+  displayName: {
+    marginTop: 4,
+    textOverflow: 'ellipsis',
+    width: '100%',
+    overflow: 'hidden',
+  },
+  leaf: {
+    width: 30,
+  },
+}));
+
+interface TaskNamesProps {
+  nodes: dNode[];
+  onScroll: () => void;
+  onToggle: (id: string, scopeId: string, level: number) => void;
+}
+
+export const TaskNames = React.forwardRef<HTMLDivElement, TaskNamesProps>((props, ref) => {
+  const state = React.useContext(NodeExecutionsTimelineContext);
+  const { nodes, onScroll, onToggle } = props;
+  const styles = useStyles();
+
+  return (
+    <div className={styles.taskNamesList} ref={ref} onScroll={onScroll}>
+      {nodes.map((node) => {
+        const templateName = getNodeTemplateName(node);
+        const nodeLevel = node?.level ?? 0;
+        return (
+          <div
+            className={styles.namesContainer}
+            key={`level=${nodeLevel}-id=${node.id}-name=${node.scopedId}`}
+            style={{ paddingLeft: nodeLevel * 16 }}
+          >
+            <div className={styles.namesContainerExpander}>
+              {node.nodes?.length ? (
+                <RowExpander
+                  expanded={node.expanded || false}
+                  onClick={() => onToggle(node.id, node.scopedId, nodeLevel)}
+                />
+              ) : (
+                <div className={styles.leaf} />
+              )}
+            </div>
+
+            <div className={styles.namesContainerBody}>
+              <NodeExecutionName
+                name={node.name}
+                execution={node.execution!} // some nodes don't have associated execution
+                state={state}
+              />
+              <Typography variant="subtitle1" color="textSecondary" className={styles.displayName}>
+                {templateName}
+              </Typography>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+});

--- a/packages/zapp/console/src/components/Executions/Tables/nodeExecutionColumns.tsx
+++ b/packages/zapp/console/src/components/Executions/Tables/nodeExecutionColumns.tsx
@@ -3,8 +3,7 @@ import { formatDateLocalTimezone, formatDateUTC, millisecondsToHMS } from 'commo
 import { timestampToDate } from 'common/utils';
 import { useCommonStyles } from 'components/common/styles';
 import { isEqual } from 'lodash';
-import { CatalogCacheStatus, NodeExecutionPhase } from 'models/Execution/enums';
-import { TaskNodeMetadata } from 'models/Execution/types';
+import { NodeExecutionPhase } from 'models/Execution/enums';
 import * as React from 'react';
 import { useNodeExecutionContext } from '../contextProvider/NodeExecutionDetails';
 import { ExecutionStatusBadge } from '../ExecutionStatusBadge';
@@ -106,15 +105,6 @@ const DisplayType: React.FC<NodeExecutionCellRendererData> = ({ execution }) => 
 
   return <Typography color="textSecondary">{type}</Typography>;
 };
-
-const hiddenCacheStatuses = [CatalogCacheStatus.CACHE_MISS, CatalogCacheStatus.CACHE_DISABLED];
-function hasCacheStatus(taskNodeMetadata?: TaskNodeMetadata): taskNodeMetadata is TaskNodeMetadata {
-  if (!taskNodeMetadata) {
-    return false;
-  }
-  const { cacheStatus } = taskNodeMetadata;
-  return !hiddenCacheStatuses.includes(cacheStatus);
-}
 
 export function generateColumns(
   styles: ReturnType<typeof useColumnStyles>,

--- a/packages/zapp/console/src/components/WorkflowGraph/utils.ts
+++ b/packages/zapp/console/src/components/WorkflowGraph/utils.ts
@@ -4,7 +4,6 @@ import { CompiledWorkflow, Workflow } from 'models/Workflow/types';
 import { CompiledNode, TaskNode } from 'models/Node/types';
 import { CompiledTask, TaskTemplate } from 'models/Task/types';
 import { dTypes, dNode } from 'models/Graph/types';
-import _ from 'lodash';
 import { transformerWorkflowToDag } from './transformerWorkflowToDag';
 /**
  * TODO FC#393: these are dupes for testing, remove once tests fixed
@@ -27,17 +26,6 @@ export function isEndNode(node: any) {
 export function isExpanded(node: any) {
   return !!node.expanded;
 }
-
-/**
- * Utility funciton assumes (loose) parity between [a]->[b] if matching
- * keys have matching values.
- * @param a     object
- * @param b     object
- * @returns     boolean
- */
-export const checkIfObjectsAreSame = (a, b) => {
-  return _.isEqual(a, b);
-};
 
 /**
  * Returns a display name from either workflows or nodes

--- a/packages/zapp/console/src/components/WorkflowGraph/utils.ts
+++ b/packages/zapp/console/src/components/WorkflowGraph/utils.ts
@@ -35,6 +35,11 @@ export function isExpanded(node: any) {
  * @returns     boolean
  */
 export const checkIfObjectsAreSame = (a, b) => {
+  // if one of the objects is null (undefined), objects can't be the same
+  if ((!a || !b) && a != b) {
+    return false;
+  }
+
   for (const k in a) {
     if (a[k] != b[k]) {
       return false;

--- a/packages/zapp/console/src/components/WorkflowGraph/utils.ts
+++ b/packages/zapp/console/src/components/WorkflowGraph/utils.ts
@@ -4,6 +4,7 @@ import { CompiledWorkflow, Workflow } from 'models/Workflow/types';
 import { CompiledNode, TaskNode } from 'models/Node/types';
 import { CompiledTask, TaskTemplate } from 'models/Task/types';
 import { dTypes, dNode } from 'models/Graph/types';
+import _ from 'lodash';
 import { transformerWorkflowToDag } from './transformerWorkflowToDag';
 /**
  * TODO FC#393: these are dupes for testing, remove once tests fixed
@@ -35,17 +36,7 @@ export function isExpanded(node: any) {
  * @returns     boolean
  */
 export const checkIfObjectsAreSame = (a, b) => {
-  // if one of the objects is null (undefined), objects can't be the same
-  if ((!a || !b) && a != b) {
-    return false;
-  }
-
-  for (const k in a) {
-    if (a[k] != b[k]) {
-      return false;
-    }
-  }
-  return true;
+  return _.isEqual(a, b);
 };
 
 /**
@@ -115,11 +106,12 @@ export const getNodeTypeFromCompiledNode = (node: CompiledNode): dTypes => {
 };
 
 export const getSubWorkflowFromId = (id, workflow) => {
+  const _ = require('lodash');
   const { subWorkflows } = workflow;
   /* Find current matching entitity from subWorkflows */
   for (const k in subWorkflows) {
     const subWorkflowId = subWorkflows[k].template.id;
-    if (checkIfObjectsAreSame(subWorkflowId, id)) {
+    if (_.isEqual(subWorkflowId, id)) {
       return subWorkflows[k];
     }
   }
@@ -127,11 +119,12 @@ export const getSubWorkflowFromId = (id, workflow) => {
 };
 
 export const getTaskTypeFromCompiledNode = (taskNode: TaskNode, tasks: CompiledTask[]) => {
+  const _ = require('lodash');
   for (let i = 0; i < tasks.length; i++) {
     const compiledTask: CompiledTask = tasks[i];
     const taskTemplate: TaskTemplate = compiledTask.template;
     const templateId: Identifier = taskTemplate.id;
-    if (checkIfObjectsAreSame(templateId, taskNode.referenceId)) {
+    if (_.isEqual(templateId, taskNode.referenceId)) {
       return compiledTask;
     }
   }


### PR DESCRIPTION
Signed-off-by: Olga Nad <olga@union.ai>

# TL;DR
Some subworkflows compared non-empty objects with `null`, which resulted in the failure to extract fields on a `null` and the whole stack of unresolved computational steps - adding an early exit out of the comparison function, if one of the parameters is null/undefined, resolves the issue with improper populated data in the node executions table.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Demo
Before: 
<img width="1138" alt="Screen Shot 2022-08-19 at 10 33 49 AM" src="https://user-images.githubusercontent.com/101579322/185656746-be8e57a2-b675-4b31-a904-0942a2f2938c.png">

After:
<img width="1139" alt="Screen Shot 2022-08-19 at 10 34 17 AM" src="https://user-images.githubusercontent.com/101579322/185656788-2e59ff7a-8482-4339-a7b8-9c2fffae0386.png">

## Tracking Issue
fixes https://github.com/flyteorg/flyteconsole/issues/406

## Follow-up issue
_NA_