### PR TITLE
added none type in union type

### DIFF
--- a/packages/zapp/console/src/components/Launch/LaunchForm/LaunchFormInputs.tsx
+++ b/packages/zapp/console/src/components/Launch/LaunchForm/LaunchFormInputs.tsx
@@ -22,6 +22,7 @@ import { UnsupportedRequiredInputsError } from './UnsupportedRequiredInputsError
 import { useFormInputsState } from './useFormInputsState';
 import { isEnterInputsState } from './utils';
 import { getHelperForInput } from './inputHelpers/getHelperForInput';
+import { NoneInput } from './NoneInput';
 
 export function getComponentForInput(
   input: InputProps,
@@ -53,8 +54,9 @@ export function getComponentForInput(
     case InputType.Map:
       return <MapInput {...props} />;
     case InputType.Unknown:
-    case InputType.None:
       return <UnsupportedInput {...props} />;
+    case InputType.None:
+      return <NoneInput {...props} />;
     default:
       return <SimpleInput {...props} />;
   }

--- a/packages/zapp/console/src/components/Launch/LaunchForm/NoneInput.tsx
+++ b/packages/zapp/console/src/components/Launch/LaunchForm/NoneInput.tsx
@@ -1,0 +1,21 @@
+import { TextField } from '@material-ui/core';
+import * as React from 'react';
+import { noneInputTypeDescription } from './constants';
+import { InputProps } from './types';
+import { getLaunchInputId } from './utils';
+
+/** Shared renderer for any launch input type we can't accept via the UI */
+export const NoneInput: React.FC<InputProps> = (props) => {
+  const { description, label, name } = props;
+  return (
+    <TextField
+      id={getLaunchInputId(name)}
+      fullWidth={true}
+      label={label}
+      variant="outlined"
+      disabled={true}
+      helperText={description}
+      value={noneInputTypeDescription}
+    />
+  );
+};

--- a/packages/zapp/console/src/components/Launch/LaunchForm/UnionInput.tsx
+++ b/packages/zapp/console/src/components/Launch/LaunchForm/UnionInput.tsx
@@ -23,7 +23,7 @@ const generateInputTypeToValueMap = (
   listOfSubTypes: InputTypeDefinition[] | undefined,
   initialInputValue: UnionValue | undefined,
   initialType: InputTypeDefinition,
-): Record<InputType, InputValue> | {} => {
+): Record<InputType, UnionValue> | {} => {
   if (!listOfSubTypes?.length) {
     return {};
   }
@@ -95,7 +95,7 @@ export const UnionInput = (props: InputProps) => {
   }
 
   const [inputTypeToValueMap, setInputTypeToValueMap] = React.useState<
-    Record<InputType, InputValue> | {}
+    Record<InputType, UnionValue> | {}
   >(generateInputTypeToValueMap(listOfSubTypes, initialInputValue, initialInputTypeDefinition));
 
   const [selectedInputType, setSelectedInputType] = React.useState<InputType>(
@@ -105,6 +105,13 @@ export const UnionInput = (props: InputProps) => {
   const selectedInputTypeDefintion = inputTypeToInputTypeDefinition[
     selectedInputType
   ] as InputTypeDefinition;
+
+  // change the selected union input value when change the selected union input type
+  React.useEffect(() => {
+    if (inputTypeToValueMap[selectedInputType]) {
+      handleSubTypeOnChange(inputTypeToValueMap[selectedInputType].value);
+    }
+  }, [selectedInputTypeDefintion]);
 
   const handleTypeOnSelectionChanged = (value: SearchableSelectorOption<InputType>) => {
     setSelectedInputType(value.data);

--- a/packages/zapp/console/src/components/Launch/LaunchForm/constants.ts
+++ b/packages/zapp/console/src/components/Launch/LaunchForm/constants.ts
@@ -82,6 +82,7 @@ export const taskUnsupportedRequiredInputsString = `This Task version contains o
 export const blobUriHelperText = '(required) location of the data';
 export const blobFormatHelperText = '(optional) csv, parquet, etc...';
 export const correctInputErrors = 'Some inputs have errors. Please correct them before submitting.';
+export const noneInputTypeDescription = 'The value of none type is empty';
 
 export const qualityOfServiceTier = {
   UNDEFINED: 0,

--- a/packages/zapp/console/src/components/Launch/LaunchForm/inputHelpers/none.ts
+++ b/packages/zapp/console/src/components/Launch/LaunchForm/inputHelpers/none.ts
@@ -1,10 +1,6 @@
 import { Core } from 'flyteidl';
-import * as Long from 'long';
-import { literalNone } from './constants';
 import { InputValue } from '../types';
-import { primitiveLiteralPaths } from './constants';
 import { ConverterInput, InputHelper, InputValidatorParams } from './types';
-import { extractLiteralWithCheck } from './utils';
 
 function fromLiteral(literal: Core.ILiteral): InputValue {
   return {};

--- a/packages/zapp/console/src/components/Launch/LaunchForm/inputHelpers/none.ts
+++ b/packages/zapp/console/src/components/Launch/LaunchForm/inputHelpers/none.ts
@@ -1,8 +1,25 @@
+import { Core } from 'flyteidl';
+import * as Long from 'long';
 import { literalNone } from './constants';
-import { InputHelper } from './types';
+import { InputValue } from '../types';
+import { primitiveLiteralPaths } from './constants';
+import { ConverterInput, InputHelper, InputValidatorParams } from './types';
+import { extractLiteralWithCheck } from './utils';
+
+function fromLiteral(literal: Core.ILiteral): InputValue {
+  return {};
+}
+
+function toLiteral({ value }: ConverterInput): Core.ILiteral {
+  return {
+    scalar: { noneType: {} },
+  };
+}
+
+function validate({ value }: InputValidatorParams) {}
 
 export const noneHelper: InputHelper = {
-  fromLiteral: () => undefined,
-  toLiteral: literalNone,
-  validate: () => {},
+  fromLiteral,
+  toLiteral,
+  validate,
 };

--- a/packages/zapp/console/src/components/Launch/LaunchForm/inputHelpers/test/testCases.ts
+++ b/packages/zapp/console/src/components/Launch/LaunchForm/inputHelpers/test/testCases.ts
@@ -111,13 +111,10 @@ export const supportedPrimitives: InputTypeDefinition[] = [
   inputTypes.integer,
   inputTypes.schema,
   inputTypes.struct,
-];
-
-export const unsupportedTypes: InputTypeDefinition[] = [
-  inputTypes.binary,
-  inputTypes.error,
   inputTypes.none,
 ];
+
+export const unsupportedTypes: InputTypeDefinition[] = [inputTypes.binary, inputTypes.error];
 
 export const validityTestCases = {
   boolean: {

--- a/packages/zapp/console/src/components/Launch/LaunchForm/inputHelpers/utils.ts
+++ b/packages/zapp/console/src/components/Launch/LaunchForm/inputHelpers/utils.ts
@@ -32,9 +32,9 @@ export function typeIsSupported(typeDefinition: InputTypeDefinition): boolean {
   switch (type) {
     case InputType.Binary:
     case InputType.Error:
-    case InputType.None:
     case InputType.Unknown:
       return false;
+    case InputType.None:
     case InputType.Boolean:
     case InputType.Blob:
     case InputType.Datetime:

--- a/packages/zapp/console/src/components/Launch/LaunchForm/types.ts
+++ b/packages/zapp/console/src/components/Launch/LaunchForm/types.ts
@@ -181,7 +181,9 @@ export interface UnionValue {
   typeDefinition: InputTypeDefinition;
 }
 
-export type InputValue = string | number | boolean | Date | BlobValue | UnionValue;
+export interface NoneValue {}
+
+export type InputValue = string | number | boolean | Date | BlobValue | UnionValue | NoneValue;
 export type InputChangeHandler = (newValue: InputValue) => void;
 
 export interface InputProps {

--- a/packages/zapp/console/src/components/Launch/LaunchForm/utils.ts
+++ b/packages/zapp/console/src/components/Launch/LaunchForm/utils.ts
@@ -84,7 +84,6 @@ export function formatType({ type, subtype, listOfSubTypes }: InputTypeDefinitio
   }
   if (type === InputType.Union) {
     if (!listOfSubTypes) return typeLabels[type];
-
     const concatListOfSubTypes = listOfSubTypes.map((subtype) => formatType(subtype)).join(' | ');
 
     return `${typeLabels[type]} [${concatListOfSubTypes}]`;
@@ -169,6 +168,8 @@ export function getInputDefintionForLiteralType(literalType: LiteralType): Input
     result.listOfSubTypes = literalType.unionType.variants?.map((variant) =>
       getInputDefintionForLiteralType(variant as LiteralType),
     );
+  } else if (literalType.simple === 0 && literalType.structure?.tag === 'none') {
+    result.type = simpleTypeToInputType[literalType.simple];
   }
   return result;
 }


### PR DESCRIPTION
Signed-off-by: eugenejahn <eugenejahnjahn@gmail.com>

since we don't support none type, there is an bug in Union Type when using optional type. The reason is optional type will use none type. Since we added the none type support in flyteconsole, there shouldn't have any bugs on union type. 

Issue: https://github.com/flyteorg/flyteconsole/issues/571