### PR TITLE
fix: correctly coerce `defaultValue` when rendering LaunchPlan details

### DIFF
--- a/packages/zapp/console/src/components/Entities/EntityInputs.tsx
+++ b/packages/zapp/console/src/components/Entities/EntityInputs.tsx
@@ -19,6 +19,13 @@ import * as React from 'react';
 import t from './strings';
 import { transformLiterals } from '../Literals/helpers';
 
+const coerceDefaultValue = (value: string | object | undefined): string | undefined => {
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+  return value;
+};
+
 const useStyles = makeStyles((theme: Theme) => ({
   header: {
     marginBottom: theme.spacing(1),
@@ -179,7 +186,7 @@ export const EntityInputs: React.FC<{
                       <TableCell align="center">
                         {required ? <CheckIcon fontSize="small" /> : ''}
                       </TableCell>
-                      <TableCell>{defaultValue || '-'}</TableCell>
+                      <TableCell>{coerceDefaultValue(defaultValue) || '-'}</TableCell>
                     </TableRow>
                   ))}
                 </TableBody>
@@ -214,7 +221,7 @@ export const EntityInputs: React.FC<{
                   {fixedInputs.map(({ name, defaultValue }) => (
                     <TableRow key={name}>
                       <TableCell>{name}</TableCell>
-                      <TableCell>{defaultValue || '-'}</TableCell>
+                      <TableCell>{coerceDefaultValue(defaultValue) || '-'}</TableCell>
                     </TableRow>
                   ))}
                 </TableBody>


### PR DESCRIPTION
Signed-off-by: Rahul Mehta <rahul@theoremlp.com>

# TL;DR
Correctly coerce `defaultValue` to string for default & fixed inputs when rendering LaunchPlan details.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
This PR fixes a bug when rendering LaunchPlans with complex objects as fixed or default values. 
* Add  `coerceDefaultValue`, which stringifies any default values that are of type `object`
* Correctly coerce `defaultValue` when rendering fixed & default input tables

## Tracking Issue
Fixes https://github.com/flyteorg/flyte/issues/2845
Fixes #567

## Follow-up issue
N/A
