### PR TITLE
 #minor: inputHelpers InputProps

### DIFF
--- a/packages/zapp/console/src/components/Launch/LaunchForm/inputHelpers/test/inputHelpers.test.ts
+++ b/packages/zapp/console/src/components/Launch/LaunchForm/inputHelpers/test/inputHelpers.test.ts
@@ -30,6 +30,7 @@ const baseInputProps: InputProps = {
   onChange: () => {},
   required: false,
   typeDefinition: inputTypes.unknown,
+  setIsError: () => {},
 };
 
 function makeSimpleInput(typeDefinition: InputTypeDefinition, value: any): InputProps {


### PR DESCRIPTION
Signed-off-by: Carina Ursu <carina@union.ai>

# TL;DR
Fix inputHelpers test error

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
We are getting a `Property 'setIsError' is missing in type` error when running coverage

