### PR TITLE
fix: floor seconds to int in the edge case moment returns it as float

### DIFF
--- a/packages/zapp/console/src/common/formatters.test.ts
+++ b/packages/zapp/console/src/common/formatters.test.ts
@@ -1,0 +1,40 @@
+import { millisecondsToHMS } from 'common/formatters';
+import { unknownValueString, zeroSecondsString } from './constants';
+
+describe('millisecondsToHMS', () => {
+  it('should display unknown if the value is negative', () => {
+    expect(millisecondsToHMS(-1)).toEqual(unknownValueString);
+  });
+
+  it('should display 0s if the value is 0', () => {
+    expect(millisecondsToHMS(0)).toEqual(zeroSecondsString);
+  });
+
+  it('should display in `ms` format if the value is < 1000', () => {
+    expect(millisecondsToHMS(999)).toEqual('999ms');
+  });
+
+  it('should display in `h` format if the value is >= 86400000 (24h)', () => {
+    expect(millisecondsToHMS(86400001)).toEqual('24h');
+  });
+
+  it('should display in `h m` format if the value is < 86400000 (24h)', () => {
+    expect(millisecondsToHMS(86340000)).toEqual('23h 59m');
+  });
+
+  it('should display in `h m s` format if the value is < 86400000 (24h)', () => {
+    expect(millisecondsToHMS(86399999)).toEqual('23h 59m 59s');
+  });
+
+  it('should display in `m s` format if the value is < 3600000 (1h)', () => {
+    expect(millisecondsToHMS(3599999)).toEqual('59m 59s');
+  });
+
+  it('should display in `m` format if the value is < 3600000 (1h) and seconds < 1', () => {
+    expect(millisecondsToHMS(3540000)).toEqual('59m');
+  });
+
+  it('should display in `s` format if the value is < 60000 (1m)', () => {
+    expect(millisecondsToHMS(59999)).toEqual('59s');
+  });
+});

--- a/packages/zapp/console/src/common/formatters.ts
+++ b/packages/zapp/console/src/common/formatters.ts
@@ -75,7 +75,8 @@ export function millisecondsToHMS(valueMS: number): string {
   }
 
   if (duration.seconds() >= 1) {
-    parts.push(`${duration.seconds()}s`);
+    // there may be a bug in Momemt.js that shows float number of seconds, so rounding it down to make sure it will be int
+    parts.push(`${Math.floor(duration.seconds())}s`);
   }
 
   return parts.length ? parts.join(' ') : unknownValueString;


### PR DESCRIPTION
Signed-off-by: Olga Nad <olga@union.ai>

# TL;DR
Round down number of seconds to int in the edge case moment.js returns it as float.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Tracking Issue
fixes https://github.com/flyteorg/flyteconsole/issues/568

## Follow-up issue
_NA_