### PR TITLE
fix: add default disabled state for only mine filter

### DIFF
--- a/packages/zapp/console/src/components/Executions/filters/useOnlyMyExecutionsFilterState.ts
+++ b/packages/zapp/console/src/components/Executions/filters/useOnlyMyExecutionsFilterState.ts
@@ -31,6 +31,7 @@ export function useOnlyMyExecutionsFilterState({
   const [onlyMyExecutionsValue, setOnlyMyExecutionsValue] = useState<boolean>(
     isFlagEnabled ? onlyMineExecutionsSelectedValue : initialValue ?? false, // if flag is enable let's use the value from only mine
   );
+  const defaultIsFilterDisabled = profile.value ? false : true;
 
   const getFilter = (): FilterOperation | null => {
     if (!onlyMyExecutionsValue) {
@@ -53,7 +54,7 @@ export function useOnlyMyExecutionsFilterState({
 
   return {
     onlyMyExecutionsValue,
-    isFilterDisabled: isFilterDisabled ?? false,
+    isFilterDisabled: isFilterDisabled ?? defaultIsFilterDisabled,
     onOnlyMyExecutionsFilterChange: setOnlyMyExecutionsValue,
     getFilter,
   };

--- a/packages/zapp/console/src/components/Executions/filters/useOnlyMyExecutionsFilterState.ts
+++ b/packages/zapp/console/src/components/Executions/filters/useOnlyMyExecutionsFilterState.ts
@@ -4,6 +4,7 @@ import { useUserProfile } from 'components/hooks/useUserProfile';
 import { useOnlyMineSelectedValue } from 'components/hooks/useOnlyMineSelectedValue';
 import { OnlyMyFilter } from 'basics/LocalCache/onlyMineDefaultConfig';
 import { FeatureFlag, useFeatureFlag } from 'basics/FeatureFlags';
+import { useFlyteApi } from '@flyteconsole/flyte-api';
 
 interface OnlyMyExecutionsFilterState {
   onlyMyExecutionsValue: boolean;
@@ -25,13 +26,14 @@ export function useOnlyMyExecutionsFilterState({
   initialValue,
 }: OnlyMyExecutionsFilterStateProps): OnlyMyExecutionsFilterState {
   const profile = useUserProfile();
+  const apiContext = useFlyteApi();
   const userId = profile.value?.subject ?? '';
   const isFlagEnabled = useFeatureFlag(FeatureFlag.OnlyMine);
   const onlyMineExecutionsSelectedValue = useOnlyMineSelectedValue(OnlyMyFilter.OnlyMyExecutions);
   const [onlyMyExecutionsValue, setOnlyMyExecutionsValue] = useState<boolean>(
     isFlagEnabled ? onlyMineExecutionsSelectedValue : initialValue ?? false, // if flag is enable let's use the value from only mine
   );
-  const defaultIsFilterDisabled = profile.value ? false : true;
+  const defaultIsFilterDisabled = apiContext ? false : true;
 
   const getFilter = (): FilterOperation | null => {
     if (!onlyMyExecutionsValue) {

--- a/packages/zapp/console/src/components/Executions/test/useOnlyMyExecutionsFilterState.test.ts
+++ b/packages/zapp/console/src/components/Executions/test/useOnlyMyExecutionsFilterState.test.ts
@@ -13,11 +13,11 @@ describe('useOnlyMyExecutionsFilterState', () => {
 
   describe.each`
     isFilterDisabled | initialValue | expected
-    ${undefined}     | ${undefined} | ${{ isFilterDisabled: false, onlyMyExecutionsValue: false }}
+    ${undefined}     | ${undefined} | ${{ isFilterDisabled: true, onlyMyExecutionsValue: false }}
     ${false}         | ${undefined} | ${{ isFilterDisabled: false, onlyMyExecutionsValue: false }}
     ${true}          | ${undefined} | ${{ isFilterDisabled: true, onlyMyExecutionsValue: false }}
-    ${undefined}     | ${false}     | ${{ isFilterDisabled: false, onlyMyExecutionsValue: false }}
-    ${undefined}     | ${true}      | ${{ isFilterDisabled: false, onlyMyExecutionsValue: true }}
+    ${undefined}     | ${false}     | ${{ isFilterDisabled: true, onlyMyExecutionsValue: false }}
+    ${undefined}     | ${true}      | ${{ isFilterDisabled: true, onlyMyExecutionsValue: true }}
     ${false}         | ${false}     | ${{ isFilterDisabled: false, onlyMyExecutionsValue: false }}
     ${false}         | ${true}      | ${{ isFilterDisabled: false, onlyMyExecutionsValue: true }}
     ${true}          | ${false}     | ${{ isFilterDisabled: true, onlyMyExecutionsValue: false }}

--- a/packages/zapp/console/src/components/Executions/test/useOnlyMyExecutionsFilterState.test.ts
+++ b/packages/zapp/console/src/components/Executions/test/useOnlyMyExecutionsFilterState.test.ts
@@ -13,11 +13,11 @@ describe('useOnlyMyExecutionsFilterState', () => {
 
   describe.each`
     isFilterDisabled | initialValue | expected
-    ${undefined}     | ${undefined} | ${{ isFilterDisabled: true, onlyMyExecutionsValue: false }}
+    ${undefined}     | ${undefined} | ${{ isFilterDisabled: false, onlyMyExecutionsValue: false }}
     ${false}         | ${undefined} | ${{ isFilterDisabled: false, onlyMyExecutionsValue: false }}
     ${true}          | ${undefined} | ${{ isFilterDisabled: true, onlyMyExecutionsValue: false }}
-    ${undefined}     | ${false}     | ${{ isFilterDisabled: true, onlyMyExecutionsValue: false }}
-    ${undefined}     | ${true}      | ${{ isFilterDisabled: true, onlyMyExecutionsValue: true }}
+    ${undefined}     | ${false}     | ${{ isFilterDisabled: false, onlyMyExecutionsValue: false }}
+    ${undefined}     | ${true}      | ${{ isFilterDisabled: false, onlyMyExecutionsValue: true }}
     ${false}         | ${false}     | ${{ isFilterDisabled: false, onlyMyExecutionsValue: false }}
     ${false}         | ${true}      | ${{ isFilterDisabled: false, onlyMyExecutionsValue: true }}
     ${true}          | ${false}     | ${{ isFilterDisabled: true, onlyMyExecutionsValue: false }}


### PR DESCRIPTION
# TL;DR
Added a check to set up default disabled state of the only mine filter based on the auth status - for logged in users it defaults to `enabled`, otherwise `disabled`.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Follow-up issue
_NA_