### PR TITLE
fix: add BASE_URL to dev startup, open deeply nested urls

### DIFF
--- a/packages/zapp/console/package.json
+++ b/packages/zapp/console/package.json
@@ -11,7 +11,7 @@
         "clean": "rm -rf dist",
         "build": "TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\"}' webpack --config webpack.dev.config.ts --mode=development",
         "build:prod": "TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\"}' NODE_ENV=production webpack --config webpack.prod.config.ts --mode=production --progress",
-        "start": "webpack serve --open --config webpack.dev.config.ts --hot",
+        "start": "webpack serve --config webpack.dev.config.ts --hot",
         "start:prod": "NODE_ENV=production node -r dotenv/config index.js",
         "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
         "format": "prettier --ignore-path .eslintignore --write \"**/*.+(js|jsx|ts|tsx|json)\"",

--- a/packages/zapp/console/webpack.dev.config.ts
+++ b/packages/zapp/console/webpack.dev.config.ts
@@ -7,6 +7,7 @@ import {
   CERTIFICATE_PATH,
   ADMIN_API_USE_SSL,
   ASSETS_PATH as publicPath,
+  BASE_URL,
 } from './env';
 
 const { merge } = require('webpack-merge');
@@ -31,6 +32,7 @@ if (
   process.exit(0);
 }
 
+console.log('publicPath', publicPath);
 /**
  * Client configuration
  *
@@ -41,7 +43,11 @@ export const clientConfig: webpack.Configuration = merge(common.default.clientCo
   devtool,
   devServer: {
     hot: true,
-    static: path.join(__dirname, 'dist'),
+    open: [BASE_URL],
+    static: {
+      directory: path.join(__dirname, 'dist'),
+      publicPath,
+    },
     compress: true,
     port: 3000,
     host: LOCAL_DEV_HOST,

--- a/packages/zapp/console/webpack.dev.config.ts
+++ b/packages/zapp/console/webpack.dev.config.ts
@@ -32,7 +32,6 @@ if (
   process.exit(0);
 }
 
-console.log('publicPath', publicPath);
 /**
  * Client configuration
  *

--- a/packages/zapp/console/webpack.dev.config.ts
+++ b/packages/zapp/console/webpack.dev.config.ts
@@ -42,7 +42,7 @@ export const clientConfig: webpack.Configuration = merge(common.default.clientCo
   devtool,
   devServer: {
     hot: true,
-    open: [BASE_URL],
+    open: [BASE_URL || '/'],
     static: {
       directory: path.join(__dirname, 'dist'),
       publicPath,


### PR DESCRIPTION
Signed-off-by: Carina Ursu <carina@union.ai>

# TL;DR
Opens the correct window in development and allows directly navigating to deeply nested routes

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Added BASE_URL to startup and correct assets path for static content

## Tracking Issue
fixes https://github.com/flyteorg/flyteconsole/issues/588 
