### PR TITLE
Launch plan ref v2

### DIFF
--- a/packages/zapp/console/src/components/Executions/ExecutionDetails/ExecutionNodeViews.tsx
+++ b/packages/zapp/console/src/components/Executions/ExecutionDetails/ExecutionNodeViews.tsx
@@ -73,23 +73,6 @@ export const ExecutionNodeViews: React.FC<ExecutionNodeViewsProps> = ({ executio
     return keyBy(nodeExecutionsWithResources, 'scopedId');
   }, [nodeExecutionsWithResources]);
 
-  console.log('nodeExecutionsById:', nodeExecutionsById);
-
-  // const nodeExecutionsById = useMemo(() => {
-  //   const output = {};
-  //   for (let i = 0; i < nodeExecutionsWithResources.length; i++) {
-  //     const ne = nodeExecutionsWithResources[i];
-  //     if (ne.id.executionId.name == execution.id.name) {
-  //       output[ne.scopedId] = ne;
-  //     } else if (ne.scopedId?.includes('-0-')) {
-  //       output[ne.scopedId] = ne;
-  //     } else {
-  //       console.log('DID NOT INCLUDE:', ne);
-  //     }
-  //   }
-  //   return output;
-  // }, [nodeExecutionsWithResources]);
-
   /* We want to maintain the filter selection when switching away from the Nodes
     tab and back, but do not want to filter the nodes when viewing the graph. So,
     we will only pass filters to the execution state when on the nodes tab. */

--- a/packages/zapp/console/src/components/Executions/ExecutionDetails/ExecutionNodeViews.tsx
+++ b/packages/zapp/console/src/components/Executions/ExecutionDetails/ExecutionNodeViews.tsx
@@ -73,6 +73,23 @@ export const ExecutionNodeViews: React.FC<ExecutionNodeViewsProps> = ({ executio
     return keyBy(nodeExecutionsWithResources, 'scopedId');
   }, [nodeExecutionsWithResources]);
 
+  console.log('nodeExecutionsById:', nodeExecutionsById);
+
+  // const nodeExecutionsById = useMemo(() => {
+  //   const output = {};
+  //   for (let i = 0; i < nodeExecutionsWithResources.length; i++) {
+  //     const ne = nodeExecutionsWithResources[i];
+  //     if (ne.id.executionId.name == execution.id.name) {
+  //       output[ne.scopedId] = ne;
+  //     } else if (ne.scopedId?.includes('-0-')) {
+  //       output[ne.scopedId] = ne;
+  //     } else {
+  //       console.log('DID NOT INCLUDE:', ne);
+  //     }
+  //   }
+  //   return output;
+  // }, [nodeExecutionsWithResources]);
+
   /* We want to maintain the filter selection when switching away from the Nodes
     tab and back, but do not want to filter the nodes when viewing the graph. So,
     we will only pass filters to the execution state when on the nodes tab. */
@@ -147,15 +164,7 @@ export const ExecutionNodeViews: React.FC<ExecutionNodeViewsProps> = ({ executio
     </NodeExecutionsRequestConfigContext.Provider>
   );
 
-  const renderTab = (tabType) => (
-    <WaitForQuery
-      errorComponent={DataError}
-      query={childGroupsQuery}
-      loadingComponent={TimelineLoading}
-    >
-      {() => <ExecutionTab tabType={tabType} />}
-    </WaitForQuery>
-  );
+  const renderTab = (tabType) => <ExecutionTab tabType={tabType} />;
 
   const TimelineLoading = () => {
     return (

--- a/packages/zapp/console/src/components/Executions/nodeExecutionQueries.ts
+++ b/packages/zapp/console/src/components/Executions/nodeExecutionQueries.ts
@@ -257,29 +257,6 @@ async function fetchGroupsForParentNodeExecution(
   return Array.from(groupsByName.values());
 }
 
-// function fetchChildNodeExecutionGroups(
-//   queryClient: QueryClient,
-//   nodeExecution: NodeExecution,
-//   config: RequestConfig,
-// ) {
-//   const { workflowNodeMetadata } = nodeExecution.closure;
-//   // Newer NodeExecution structures can directly indicate their parent
-//   // status and have their children fetched in bulk.
-//   if (isParentNode(nodeExecution)) {
-//     return fetchGroupsForParentNodeExecution(queryClient, nodeExecution, config);
-//   }
-//   // Otherwise, we need to determine the type of the node and
-//   // recursively fetch NodeExecutions for the corresponding Workflow
-//   // or Task executions.
-//   if (
-//     workflowNodeMetadata &&
-//     !isEqual(workflowNodeMetadata.executionId, nodeExecution.id.executionId)
-//   ) {
-//     return fetchGroupsForWorkflowExecutionNode(queryClient, nodeExecution, config);
-//   }
-//   return fetchGroupsForTaskExecutionNode(queryClient, nodeExecution, config);
-// }
-
 function fetchChildNodeExecutionGroups(
   queryClient: QueryClient,
   nodeExecution: NodeExecution,

--- a/packages/zapp/console/src/components/Executions/nodeExecutionQueries.ts
+++ b/packages/zapp/console/src/components/Executions/nodeExecutionQueries.ts
@@ -257,6 +257,29 @@ async function fetchGroupsForParentNodeExecution(
   return Array.from(groupsByName.values());
 }
 
+// function fetchChildNodeExecutionGroups(
+//   queryClient: QueryClient,
+//   nodeExecution: NodeExecution,
+//   config: RequestConfig,
+// ) {
+//   const { workflowNodeMetadata } = nodeExecution.closure;
+//   // Newer NodeExecution structures can directly indicate their parent
+//   // status and have their children fetched in bulk.
+//   if (isParentNode(nodeExecution)) {
+//     return fetchGroupsForParentNodeExecution(queryClient, nodeExecution, config);
+//   }
+//   // Otherwise, we need to determine the type of the node and
+//   // recursively fetch NodeExecutions for the corresponding Workflow
+//   // or Task executions.
+//   if (
+//     workflowNodeMetadata &&
+//     !isEqual(workflowNodeMetadata.executionId, nodeExecution.id.executionId)
+//   ) {
+//     return fetchGroupsForWorkflowExecutionNode(queryClient, nodeExecution, config);
+//   }
+//   return fetchGroupsForTaskExecutionNode(queryClient, nodeExecution, config);
+// }
+
 function fetchChildNodeExecutionGroups(
   queryClient: QueryClient,
   nodeExecution: NodeExecution,
@@ -273,7 +296,8 @@ function fetchChildNodeExecutionGroups(
   // or Task executions.
   if (
     workflowNodeMetadata &&
-    !isEqual(workflowNodeMetadata.executionId, nodeExecution.id.executionId)
+    !isEqual(workflowNodeMetadata.executionId, nodeExecution.id.executionId) &&
+    !isEqual(nodeExecution.metadata?.specNodeId, nodeExecution.scopedId)
   ) {
     return fetchGroupsForWorkflowExecutionNode(queryClient, nodeExecution, config);
   }

--- a/packages/zapp/console/src/components/WorkflowGraph/transformerWorkflowToDag.tsx
+++ b/packages/zapp/console/src/components/WorkflowGraph/transformerWorkflowToDag.tsx
@@ -200,13 +200,20 @@ export const transformerWorkflowToDag = (
       });
       buildDAG(dNode, node, dTypes.branch);
     } else if (node.workflowNode) {
-      const id = node.workflowNode.subWorkflowRef;
-      const subworkflow = getSubWorkflowFromId(id, workflow);
-      dNode = createDNode({
-        compiledNode: node,
-        parentDNode: root,
-      });
-      buildDAG(dNode, subworkflow, dTypes.subworkflow);
+      if (node.workflowNode.launchplanRef) {
+        dNode = createDNode({
+          compiledNode: node,
+          parentDNode: root,
+        });
+      } else {
+        const id = node.workflowNode.subWorkflowRef;
+        const subworkflow = getSubWorkflowFromId(id, workflow);
+        dNode = createDNode({
+          compiledNode: node,
+          parentDNode: root,
+        });
+        buildDAG(dNode, subworkflow, dTypes.subworkflow);
+      }
     } else if (node.taskNode) {
       const taskNode = node.taskNode as TaskNode;
       const taskType: CompiledTask = getTaskTypeFromCompiledNode(

--- a/packages/zapp/console/src/components/WorkflowGraph/utils.ts
+++ b/packages/zapp/console/src/components/WorkflowGraph/utils.ts
@@ -87,7 +87,12 @@ export const getNodeTypeFromCompiledNode = (node: CompiledNode): dTypes => {
   } else if (node.branchNode) {
     return dTypes.subworkflow;
   } else if (node.workflowNode) {
-    return dTypes.subworkflow;
+    /* Workflow prop can mean either launchplanReft or subworklow */
+    if (node.workflowNode.launchplanRef) {
+      return dTypes.task;
+    } else {
+      return dTypes.subworkflow;
+    }
   } else {
     return dTypes.task;
   }


### PR DESCRIPTION
This PR fixes issues related to workflows with reference launch plans. Users reported that nodes in the graph view were not rendering these nodes correctly. The new UX will be for nodes with `launchplanRef` properties to render as standard/task nodes and the launch plan's workflow can be accessed via clicking on the node in the execution detail panel (ie, slide-out panel, "View sub-workflow") 

This fix was verified against `flytesnacks/development/core.control_flow.subworkflows.root_level_wf` and `flytesnacks/development/core.control_flow.subworkflows.other_root_level_wf`

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The issue was related to Graph and Timeline views using a map of node executions - since launch plans have independent node id values (ie, nodes aren't scoped) it was causing map collisions and values were be overwritten. This fix prevents launch plan executions from being requested from these views (preventing collisions) however users can still access these executions via the execution detail panel -- which was the intended UX. 

## Tracking Issue
fixes [https://github.com/flyteorg/flyte/issues/<number>](https://github.com/flyteorg/flyteconsole/issues/380)

## Follow-up issue
_NA_
