### PR TITLE
fix: enable deeplinks in development

### DIFF
--- a/packages/zapp/console/package.json
+++ b/packages/zapp/console/package.json
@@ -11,7 +11,7 @@
         "clean": "rm -rf dist",
         "build": "TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\"}' webpack --config webpack.dev.config.ts --mode=development",
         "build:prod": "TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\"}' NODE_ENV=production webpack --config webpack.prod.config.ts --mode=production --progress",
-        "start": "webpack serve --config webpack.dev.config.ts --hot",
+        "start": "webpack serve --config webpack.dev.config.ts",
         "start:prod": "NODE_ENV=production node -r dotenv/config index.js",
         "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
         "format": "prettier --ignore-path .eslintignore --write \"**/*.+(js|jsx|ts|tsx|json)\"",

--- a/packages/zapp/console/webpack.dev.config.ts
+++ b/packages/zapp/console/webpack.dev.config.ts
@@ -41,6 +41,10 @@ export const clientConfig: webpack.Configuration = merge(common.default.clientCo
   mode: 'development',
   devtool,
   devServer: {
+    historyApiFallback: {
+      logger: console.log.bind(console),
+      disableDotRule: true,
+    },
     hot: true,
     open: [BASE_URL || '/'],
     static: {
@@ -50,7 +54,6 @@ export const clientConfig: webpack.Configuration = merge(common.default.clientCo
     compress: true,
     port: 3000,
     host: LOCAL_DEV_HOST,
-    historyApiFallback: true,
     server: {
       type: ADMIN_API_USE_SSL,
       options: {


### PR DESCRIPTION
Signed-off-by: Carina Ursu <carina@union.ai>

# TL;DR
This will allow webpack to properly render deeplinks without defaulting to 404

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin
 - [x] Chore

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The reason why deeplinks were not rendering was due to this error:

`Not rewriting GET /console/projects/flytesnacks/domains/development/workflows/core.control_flow.subworkflows.root_level_wf?duration=all because the path includes a dot (.) character.`

This PR disabled the webpack dot rule that was causing certain deeplinks to 404
