### PR TITLE
Fix the activation of Google Analytics

### DIFF
--- a/packages/zapp/console/env.js
+++ b/packages/zapp/console/env.js
@@ -36,7 +36,7 @@ const PLUGINS_MODULE = process.env.PLUGINS_MODULE;
 const STATUS_URL = process.env.STATUS_URL;
 
 // Configure Google Analytics
-const ENABLE_GA = process.env.ENABLE_GA || false;
+const ENABLE_GA = process.env.ENABLE_GA || 'false';
 const GA_TRACKING_ID = process.env.GA_TRACKING_ID || '';
 
 const FLYTE_NAVIGATION = process.env.FLYTE_NAVIGATION || '';

--- a/packages/zapp/console/src/components/Navigation/DefaultAppBarContent.tsx
+++ b/packages/zapp/console/src/components/Navigation/DefaultAppBarContent.tsx
@@ -9,6 +9,7 @@ import { Routes } from 'routes/routes';
 import { FeatureFlag, useFeatureFlag } from 'basics/FeatureFlags';
 import { useAdminVersion } from 'components/hooks/useVersion';
 import { env } from 'common/env';
+import ReactGA from 'react-ga4';
 import { NavigationDropdown } from './NavigationDropdown';
 import { UserInformation } from './UserInformation';
 import { OnlyMine } from './OnlyMine';
@@ -52,7 +53,7 @@ export const DefaultAppBarContent = (props: DefaultAppBarProps) => {
     },
     {
       name: t('versionGoogleAnalytics'),
-      version: t(patternKey('gaDisable', env.DISABLE_GA)),
+      version: t(patternKey('gaEnable', ReactGA.isInitialized.toString())),
       url: 'https://github.com/flyteorg/flyteconsole#google-analytics',
     },
   ];

--- a/packages/zapp/console/src/components/Navigation/DefaultAppBarContent.tsx
+++ b/packages/zapp/console/src/components/Navigation/DefaultAppBarContent.tsx
@@ -53,7 +53,7 @@ export const DefaultAppBarContent = (props: DefaultAppBarProps) => {
     },
     {
       name: t('versionGoogleAnalytics'),
-      version: t(patternKey('gaEnable', ReactGA.isInitialized.toString())),
+      version: t(patternKey('gaActive', ReactGA.isInitialized.toString())),
       url: 'https://github.com/flyteorg/flyteconsole#google-analytics',
     },
   ];

--- a/packages/zapp/console/src/components/Navigation/DefaultAppBarContent.tsx
+++ b/packages/zapp/console/src/components/Navigation/DefaultAppBarContent.tsx
@@ -9,7 +9,6 @@ import { Routes } from 'routes/routes';
 import { FeatureFlag, useFeatureFlag } from 'basics/FeatureFlags';
 import { useAdminVersion } from 'components/hooks/useVersion';
 import { env } from 'common/env';
-import ReactGA from 'react-ga4';
 import { NavigationDropdown } from './NavigationDropdown';
 import { UserInformation } from './UserInformation';
 import { OnlyMine } from './OnlyMine';

--- a/packages/zapp/console/src/components/Navigation/strings.ts
+++ b/packages/zapp/console/src/components/Navigation/strings.ts
@@ -5,9 +5,9 @@ const str = {
   versionConsoleUi: 'UI Version',
   versionAdmin: 'Admin Version',
   versionGoogleAnalytics: 'Google Analytics',
-  gaEnable_: 'Active',
-  gaEnable_true: 'Active',
-  gaEnable_false: 'Inactive',
+  gaActive_: 'Active',
+  gaActive_true: 'Active',
+  gaActive_false: 'Inactive',
 };
 
 export { patternKey } from '@flyteconsole/locale';

--- a/packages/zapp/console/src/components/Navigation/strings.ts
+++ b/packages/zapp/console/src/components/Navigation/strings.ts
@@ -5,9 +5,9 @@ const str = {
   versionConsoleUi: 'UI Version',
   versionAdmin: 'Admin Version',
   versionGoogleAnalytics: 'Google Analytics',
-  gaDisable_: 'Active',
-  gaDisable_true: 'Active',
-  gaDisable_false: 'Inactive',
+  gaEnable_: 'Active',
+  gaEnable_true: 'Active',
+  gaEnable_false: 'Inactive',
 };
 
 export { patternKey } from '@flyteconsole/locale';


### PR DESCRIPTION
# TL;DR
This PR fixes the activation of Google Analytics using string 'false' instead of boolean false as the default value of `ENABLE_GA` to align with others
Note that this PR renames `gaDisable` to `gaActive` for consistency.

## Type
 - [x] Bug Fix

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Based on the root cause described in https://github.com/flyteorg/flyteconsole/issues/614, there is a discrepancy in data type between the environment variable, the local variable, and where it is used. This PR fixes the data type at the local variable definition to align with the other two.

## Tracking Issue
fixes https://github.com/flyteorg/flyteconsole/issues/614

## Follow-up issue
NA