### PR TITLE
Fixes the AppInfo window value for GA

### DIFF
--- a/packages/zapp/console/src/components/Navigation/DefaultAppBarContent.tsx
+++ b/packages/zapp/console/src/components/Navigation/DefaultAppBarContent.tsx
@@ -38,6 +38,7 @@ export const DefaultAppBarContent = (props: DefaultAppBarProps) => {
 
   const isFlagEnabled = useFeatureFlag(FeatureFlag.OnlyMine);
   const { adminVersion } = useAdminVersion();
+  const isGAEnabled = env.ENABLE_GA === 'true' && env.GA_TRACKING_ID !== '';
 
   const versions: VersionInfo[] = [
     {
@@ -52,7 +53,7 @@ export const DefaultAppBarContent = (props: DefaultAppBarProps) => {
     },
     {
       name: t('versionGoogleAnalytics'),
-      version: t(patternKey('gaDisable', env.DISABLE_GA)),
+      version: t(patternKey('gaDisable', isGAEnabled.toString())),
       url: 'https://github.com/flyteorg/flyteconsole#google-analytics',
     },
   ];


### PR DESCRIPTION
Signed-off-by: Jason Porter <jason@union.ai>

This PR fixes and issue reported by users that the value displayed in the AppInfo component would always return true for "Google Analytics" even when it was actually disabled/not-loaded.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

fixes [https://github.com/flyteorg/flyte/issues/613](https://github.com/flyteorg/flyteconsole/issues/613)

## Follow-up issue
_NA_
