### PR TITLE
fix: execution view children fetch on demand refactor

### DIFF
--- a/packages/console/src/components/Executions/ExecutionDetails/ExecutionNodeViews.tsx
+++ b/packages/console/src/components/Executions/ExecutionDetails/ExecutionNodeViews.tsx
@@ -1,20 +1,12 @@
-import * as React from 'react';
+import React, { useEffect } from 'react';
 import { Tab, Tabs } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import { WaitForQuery } from 'components/common/WaitForQuery';
 import { DataError } from 'components/Errors/DataError';
 import { useTabState } from 'components/hooks/useTabState';
 import { secondaryBackgroundColor } from 'components/Theme/constants';
-import {
-  Execution,
-  ExternalResource,
-  LogsByPhase,
-  NodeExecution,
-} from 'models/Execution/types';
-import { useEffect, useMemo, useState } from 'react';
+import { Execution } from 'models/Execution/types';
 import { keyBy } from 'lodash';
-import { isMapTaskV1 } from 'models/Task/utils';
-import { useQueryClient } from 'react-query';
 import { LargeLoadingSpinner } from 'components/common/LoadingSpinner';
 import { FilterOperation } from 'models/AdminEntity/types';
 import { NodeExecutionDetailsContextProvider } from '../contextProvider/NodeExecutionDetails';
@@ -23,10 +15,8 @@ import { ExecutionFilters } from '../ExecutionFilters';
 import { useNodeExecutionFiltersState } from '../filters/useExecutionFiltersState';
 import { tabs } from './constants';
 import { useExecutionNodeViewsState } from './useExecutionNodeViewsState';
-import { fetchTaskExecutionList } from '../taskExecutionQueries';
-import { getGroupedLogs } from '../TaskExecutionsList/utils';
-import { useAllTreeNodeExecutionGroupsQuery } from '../nodeExecutionQueries';
 import { ExecutionTab } from './ExecutionTab';
+import { useNodeExecutionsById } from '../useNodeExecutionsById';
 
 const useStyles = makeStyles((theme: Theme) => ({
   filters: {
@@ -55,10 +45,6 @@ const isPhaseFilter = (appliedFilters: FilterOperation[]) => {
   return false;
 };
 
-interface WorkflowNodeExecution extends NodeExecution {
-  logsByPhase?: LogsByPhase;
-}
-
 interface ExecutionNodeViewsProps {
   execution: Execution;
 }
@@ -71,21 +57,10 @@ export const ExecutionNodeViews: React.FC<ExecutionNodeViewsProps> = ({
   const styles = useStyles();
   const filterState = useNodeExecutionFiltersState();
   const tabState = useTabState(tabs, defaultTab);
-  const queryClient = useQueryClient();
-  const [nodeExecutionsLoading, setNodeExecutionsLoading] =
-    useState<boolean>(true);
 
   const {
     closure: { workflowId },
   } = execution;
-
-  const [nodeExecutions, setNodeExecutions] = useState<NodeExecution[]>([]);
-  const [nodeExecutionsWithResources, setNodeExecutionsWithResources] =
-    useState<WorkflowNodeExecution[]>([]);
-
-  const nodeExecutionsById = useMemo(() => {
-    return keyBy(nodeExecutionsWithResources, 'scopedId');
-  }, [nodeExecutionsWithResources]);
 
   // query to get all data to build Graph and Timeline
   const { nodeExecutionsQuery } = useExecutionNodeViewsState(execution);
@@ -94,73 +69,16 @@ export const ExecutionNodeViews: React.FC<ExecutionNodeViewsProps> = ({
     nodeExecutionsQuery: { data: filteredNodeExecutions },
   } = useExecutionNodeViewsState(execution, filterState.appliedFilters);
 
-  useEffect(() => {
-    let isCurrent = true;
-
-    async function fetchData(baseNodeExecutions, queryClient) {
-      setNodeExecutionsLoading(true);
-      const newValue = await Promise.all(
-        baseNodeExecutions.map(async baseNodeExecution => {
-          const taskExecutions = await fetchTaskExecutionList(
-            queryClient,
-            baseNodeExecution.id,
-          );
-
-          const useNewMapTaskView = taskExecutions.every(taskExecution => {
-            const {
-              closure: { taskType, metadata, eventVersion = 0 },
-            } = taskExecution;
-            return isMapTaskV1(
-              eventVersion,
-              metadata?.externalResources?.length ?? 0,
-              taskType ?? undefined,
-            );
-          });
-          const externalResources: ExternalResource[] = taskExecutions
-            .map(
-              taskExecution =>
-                taskExecution.closure.metadata?.externalResources,
-            )
-            .flat()
-            .filter((resource): resource is ExternalResource => !!resource);
-
-          const logsByPhase: LogsByPhase = getGroupedLogs(externalResources);
-
-          return {
-            ...baseNodeExecution,
-            ...(useNewMapTaskView && logsByPhase.size > 0 && { logsByPhase }),
-          };
-        }),
-      );
-
-      if (isCurrent) {
-        setNodeExecutionsWithResources(newValue);
-        setNodeExecutionsLoading(false);
-      }
-    }
-
-    if (nodeExecutions.length > 0) {
-      fetchData(nodeExecutions, queryClient);
-    } else {
-      if (isCurrent) {
-        setNodeExecutionsLoading(false);
-      }
-    }
-    return () => {
-      isCurrent = false;
-    };
-  }, [nodeExecutions]);
-
-  const childGroupsQuery = useAllTreeNodeExecutionGroupsQuery(
-    nodeExecutionsQuery.data ?? [],
-    {},
-  );
+  const { nodeExecutionsById, setCurrentNodeExecutionsById } =
+    useNodeExecutionsById();
 
   useEffect(() => {
-    if (!childGroupsQuery.isLoading && childGroupsQuery.data) {
-      setNodeExecutions(childGroupsQuery.data);
-    }
-  }, [childGroupsQuery.data]);
+    const currentNodeExecutionsById = keyBy(
+      nodeExecutionsQuery.data,
+      'scopedId',
+    );
+    setCurrentNodeExecutionsById(currentNodeExecutionsById);
+  }, [nodeExecutionsQuery.data]);
 
   const LoadingComponent = () => {
     return (
@@ -171,27 +89,16 @@ export const ExecutionNodeViews: React.FC<ExecutionNodeViewsProps> = ({
   };
 
   const renderTab = tabType => {
-    if (nodeExecutionsLoading) {
-      return <LoadingComponent />;
-    }
     return (
-      <WaitForQuery
-        errorComponent={DataError}
-        query={childGroupsQuery}
-        loadingComponent={LoadingComponent}
-      >
-        {() => (
-          <ExecutionTab
-            tabType={tabType}
-            // if only phase filter was applied, ignore request response, and filter out nodes via frontend filter
-            filteredNodeExecutions={
-              isPhaseFilter(filterState.appliedFilters)
-                ? undefined
-                : filteredNodeExecutions
-            }
-          />
-        )}
-      </WaitForQuery>
+      <ExecutionTab
+        tabType={tabType}
+        // if only phase filter was applied, ignore request response, and filter out nodes via frontend filter
+        filteredNodeExecutions={
+          isPhaseFilter(filterState.appliedFilters)
+            ? undefined
+            : filteredNodeExecutions
+        }
+      />
     );
   };
 
@@ -203,7 +110,9 @@ export const ExecutionNodeViews: React.FC<ExecutionNodeViewsProps> = ({
         <Tab value={tabs.timeline.id} label={tabs.timeline.label} />
       </Tabs>
       <NodeExecutionDetailsContextProvider workflowId={workflowId}>
-        <NodeExecutionsByIdContext.Provider value={nodeExecutionsById}>
+        <NodeExecutionsByIdContext.Provider
+          value={{ nodeExecutionsById, setCurrentNodeExecutionsById }}
+        >
           <div className={styles.nodesContainer}>
             {tabState.value === tabs.nodes.id && (
               <div className={styles.filters}>

--- a/packages/console/src/components/Executions/ExecutionDetails/ExecutionTabContent.tsx
+++ b/packages/console/src/components/Executions/ExecutionDetails/ExecutionTabContent.tsx
@@ -53,8 +53,8 @@ const executionMatchesPhaseFilter = (
   if (key === 'phase' && operation === FilterOperationName.VALUE_IN) {
     // default to UNKNOWN phase if the field does not exist on a closure
     const itemValue =
-      nodeExecutionPhaseConstants[nodeExecution?.closure[key]]?.value ??
-      nodeExecutionPhaseConstants[0].value;
+      nodeExecutionPhaseConstants()[nodeExecution?.closure[key]]?.value ??
+      nodeExecutionPhaseConstants()[0].value;
     // phase check filters always return values in an array
     const valuesArray = value as FilterOperationValueList;
     return valuesArray.includes(itemValue);

--- a/packages/console/src/components/Executions/ExecutionDetails/TaskExecutionNodeRenderer/TaskExecutionNode.tsx
+++ b/packages/console/src/components/Executions/ExecutionDetails/TaskExecutionNodeRenderer/TaskExecutionNode.tsx
@@ -3,8 +3,7 @@ import { NodeRendererProps, Point } from 'components/flytegraph/types';
 import { TaskNodeRenderer } from 'components/WorkflowGraph/TaskNodeRenderer';
 import { NodeExecutionPhase } from 'models/Execution/enums';
 import { DAGNode } from 'models/Graph/types';
-import * as React from 'react';
-import { useContext } from 'react';
+import React, { useContext } from 'react';
 import { NodeExecutionsByIdContext } from '../../contexts';
 import { StatusIndicator } from './StatusIndicator';
 
@@ -15,7 +14,7 @@ export const TaskExecutionNode: React.FC<
   NodeRendererProps<DAGNode>
 > = props => {
   const { node, config, selected } = props;
-  const nodeExecutionsById = useContext(NodeExecutionsByIdContext);
+  const { nodeExecutionsById } = useContext(NodeExecutionsByIdContext);
   const nodeExecution = nodeExecutionsById[node.id];
 
   const phase = nodeExecution

--- a/packages/console/src/components/Executions/ExecutionDetails/Timeline/ExecutionTimeline.tsx
+++ b/packages/console/src/components/Executions/ExecutionDetails/Timeline/ExecutionTimeline.tsx
@@ -172,7 +172,7 @@ export const ExecutionTimeline: React.FC<ExProps> = ({
   };
 
   const toggleNode = async (id: string, scopedId: string, level: number) => {
-    fetchChildrenExecutions(
+    await fetchChildrenExecutions(
       queryClient,
       scopedId,
       nodeExecutionsById,

--- a/packages/console/src/components/Executions/ExecutionDetails/Timeline/NodeExecutionName.tsx
+++ b/packages/console/src/components/Executions/ExecutionDetails/Timeline/NodeExecutionName.tsx
@@ -6,8 +6,7 @@ import { SelectNodeExecutionLink } from 'components/Executions/Tables/SelectNode
 import { isEqual } from 'lodash';
 import { NodeExecutionPhase } from 'models/Execution/enums';
 import { NodeExecution } from 'models/Execution/types';
-import * as React from 'react';
-import { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { DetailsPanelContext } from '../DetailsPanelContext';
 
 interface NodeExecutionTimelineNameData {
@@ -45,7 +44,7 @@ export const NodeExecutionName: React.FC<NodeExecutionTimelineNameData> = ({
     let isCurrent = true;
     getNodeExecutionDetails(execution).then(res => {
       if (isCurrent) {
-        setDisplayName(res.displayName);
+        setDisplayName(res?.displayName);
       }
     });
     return () => {

--- a/packages/console/src/components/Executions/ExecutionDetails/Timeline/TaskNames.tsx
+++ b/packages/console/src/components/Executions/ExecutionDetails/Timeline/TaskNames.tsx
@@ -1,7 +1,10 @@
 import React, { useContext } from 'react';
 import { IconButton, makeStyles, Theme, Tooltip } from '@material-ui/core';
 import { RowExpander } from 'components/Executions/Tables/RowExpander';
-import { getNodeTemplateName } from 'components/WorkflowGraph/utils';
+import {
+  getNodeTemplateName,
+  isExpanded,
+} from 'components/WorkflowGraph/utils';
 import { dNode } from 'models/Graph/types';
 import { PlayCircleOutline } from '@material-ui/icons';
 import { isParentNode } from 'components/Executions/utils';
@@ -87,7 +90,7 @@ export const TaskNames = React.forwardRef<HTMLDivElement, TaskNamesProps>(
                   {nodeExecution && isParentNode(nodeExecution) ? (
                     <RowExpander
                       ref={expanderRef as React.ForwardedRef<HTMLButtonElement>}
-                      expanded={node.expanded || false}
+                      expanded={isExpanded(node)}
                       onClick={() =>
                         onToggle(node.id, node.scopedId, nodeLevel)
                       }

--- a/packages/console/src/components/Executions/ExecutionDetails/Timeline/TaskNames.tsx
+++ b/packages/console/src/components/Executions/ExecutionDetails/Timeline/TaskNames.tsx
@@ -1,10 +1,11 @@
-import * as React from 'react';
+import React, { useContext } from 'react';
 import { IconButton, makeStyles, Theme, Tooltip } from '@material-ui/core';
-
 import { RowExpander } from 'components/Executions/Tables/RowExpander';
 import { getNodeTemplateName } from 'components/WorkflowGraph/utils';
 import { dNode } from 'models/Graph/types';
-import PlayCircleOutlineIcon from '@material-ui/icons/PlayCircleOutline';
+import { PlayCircleOutline } from '@material-ui/icons';
+import { isParentNode } from 'components/Executions/utils';
+import { NodeExecutionsByIdContext } from 'components/Executions/contexts';
 import { NodeExecutionName } from './NodeExecutionName';
 import t from '../strings';
 
@@ -53,11 +54,14 @@ interface TaskNamesProps {
 export const TaskNames = React.forwardRef<HTMLDivElement, TaskNamesProps>(
   ({ nodes, onScroll, onToggle, onAction }, ref) => {
     const styles = useStyles();
+    const { nodeExecutionsById } = useContext(NodeExecutionsByIdContext);
 
     return (
       <div className={styles.taskNamesList} ref={ref} onScroll={onScroll}>
         {nodes.map(node => {
           const nodeLevel = node?.level ?? 0;
+          const nodeExecution = nodeExecutionsById[node.scopedId];
+
           return (
             <div
               className={styles.namesContainer}
@@ -78,7 +82,7 @@ export const TaskNames = React.forwardRef<HTMLDivElement, TaskNamesProps>(
                 }}
               >
                 <div className={styles.namesContainerExpander}>
-                  {node.nodes?.length ? (
+                  {nodeExecution && isParentNode(nodeExecution) ? (
                     <RowExpander
                       expanded={node.expanded || false}
                       onClick={() =>
@@ -104,7 +108,7 @@ export const TaskNames = React.forwardRef<HTMLDivElement, TaskNamesProps>(
                     onClick={() => onAction(node.id)}
                     data-testid={`resume-gate-node-${node.id}`}
                   >
-                    <PlayCircleOutlineIcon />
+                    <PlayCircleOutline />
                   </IconButton>
                 </Tooltip>
               )}

--- a/packages/console/src/components/Executions/ExecutionDetails/Timeline/TaskNames.tsx
+++ b/packages/console/src/components/Executions/ExecutionDetails/Timeline/TaskNames.tsx
@@ -56,6 +56,8 @@ export const TaskNames = React.forwardRef<HTMLDivElement, TaskNamesProps>(
     const styles = useStyles();
     const { nodeExecutionsById } = useContext(NodeExecutionsByIdContext);
 
+    const expanderRef = React.useRef<HTMLButtonElement>();
+
     return (
       <div className={styles.taskNamesList} ref={ref} onScroll={onScroll}>
         {nodes.map(node => {
@@ -84,6 +86,7 @@ export const TaskNames = React.forwardRef<HTMLDivElement, TaskNamesProps>(
                 <div className={styles.namesContainerExpander}>
                   {nodeExecution && isParentNode(nodeExecution) ? (
                     <RowExpander
+                      ref={expanderRef as React.ForwardedRef<HTMLButtonElement>}
                       expanded={node.expanded || false}
                       onClick={() =>
                         onToggle(node.id, node.scopedId, nodeLevel)

--- a/packages/console/src/components/Executions/ExecutionDetails/test/TaskNames.test.tsx
+++ b/packages/console/src/components/Executions/ExecutionDetails/test/TaskNames.test.tsx
@@ -1,10 +1,26 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { dTypes } from 'models/Graph/types';
+import { NodeExecutionDetailsContextProvider } from 'components/Executions/contextProvider/NodeExecutionDetails';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { NodeExecutionsByIdContext } from 'components/Executions/contexts';
+import { mockWorkflowId } from 'mocks/data/fixtures/types';
+import { createTestQueryClient } from 'test/utils';
+import { dateToTimestamp } from 'common/utils';
+import { createMockWorkflow } from 'models/__mocks__/workflowData';
 import { TaskNames } from '../Timeline/TaskNames';
 
 const onToggle = jest.fn();
 const onAction = jest.fn();
+
+jest.mock('models/Workflow/api', () => {
+  const originalModule = jest.requireActual('models/Workflow/api');
+  return {
+    __esModule: true,
+    ...originalModule,
+    getWorkflow: jest.fn().mockResolvedValue({}),
+  };
+});
 
 const node1 = {
   id: 'n1',
@@ -25,7 +41,51 @@ const node2 = {
 };
 
 describe('ExecutionDetails > Timeline > TaskNames', () => {
-  const renderComponent = props => render(<TaskNames {...props} />);
+  let queryClient: QueryClient;
+  beforeEach(() => {
+    queryClient = createTestQueryClient();
+  });
+
+  const renderComponent = props => {
+    const nodeExecutionsById = props.nodes.reduce(
+      (accumulator, currentValue) => {
+        accumulator[currentValue.id] = {
+          closure: {
+            createdAt: dateToTimestamp(new Date()),
+            outputUri: '',
+            phase: 1,
+          },
+          metadata: currentValue.metadata,
+          id: {
+            executionId: {
+              domain: 'development',
+              name: 'MyWorkflow',
+              project: 'flytetest',
+            },
+            nodeId: currentValue.id,
+          },
+          inputUri: '',
+          scopedId: currentValue.scopedId,
+        };
+        return accumulator;
+      },
+      {},
+    );
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <NodeExecutionDetailsContextProvider workflowId={mockWorkflowId}>
+          <NodeExecutionsByIdContext.Provider
+            value={{
+              nodeExecutionsById,
+              setCurrentNodeExecutionsById: () => {},
+            }}
+          >
+            <TaskNames {...props} />
+          </NodeExecutionsByIdContext.Provider>
+        </NodeExecutionDetailsContextProvider>
+      </QueryClientProvider>,
+    );
+  };
 
   it('should render task names list', () => {
     const nodes = [node1, node2];
@@ -56,8 +116,8 @@ describe('ExecutionDetails > Timeline > TaskNames', () => {
       },
     ];
     const nodes = [
-      { ...node1, nodes: nestedNodes },
-      { ...node2, nodes: nestedNodes },
+      { ...node1, metadata: { isParentNode: true }, nodes: nestedNodes },
+      { ...node2, metadata: { isParentNode: true }, nodes: nestedNodes },
     ];
     const { getAllByTestId, getAllByTitle } = renderComponent({
       nodes,

--- a/packages/console/src/components/Executions/ExecutionDetails/utils.ts
+++ b/packages/console/src/components/Executions/ExecutionDetails/utils.ts
@@ -1,5 +1,9 @@
 import { Identifier, ResourceType } from 'models/Common/types';
-import { Execution, TaskExecution } from 'models/Execution/types';
+import {
+  Execution,
+  NodeExecution,
+  TaskExecution,
+} from 'models/Execution/types';
 import { Routes } from 'routes/routes';
 import { PaginatedEntityResponse } from 'models/AdminEntity/types';
 
@@ -28,4 +32,15 @@ export function getTaskExecutionDetailReasons(
       taskExecution => taskExecution.closure.reason,
     ) || []
   );
+}
+
+export function isChildGroupsFetched(
+  scopedId: string,
+  nodeExecutionsById: Dictionary<NodeExecution>,
+): boolean {
+  return Object.values(nodeExecutionsById).find(
+    exe => exe?.fromUniqueParentId === scopedId,
+  )
+    ? true
+    : false;
 }

--- a/packages/console/src/components/Executions/Tables/NodeExecutionRow.tsx
+++ b/packages/console/src/components/Executions/Tables/NodeExecutionRow.tsx
@@ -71,7 +71,6 @@ export const NodeExecutionRow: React.FC<NodeExecutionRowProps> = ({
     return isParentNode(nodeExecution) ? (
       <RowExpander
         ref={expanderRef as React.ForwardedRef<HTMLButtonElement>}
-        key={node.scopedId}
         expanded={isExpanded(node)}
         onClick={() => {
           onToggle(node.id, node.scopedId, nodeLevel);

--- a/packages/console/src/components/Executions/Tables/NodeExecutionRow.tsx
+++ b/packages/console/src/components/Executions/Tables/NodeExecutionRow.tsx
@@ -2,8 +2,7 @@ import classnames from 'classnames';
 import { NodeExecution } from 'models/Execution/types';
 import { dNode } from 'models/Graph/types';
 import { NodeExecutionPhase } from 'models/Execution/enums';
-import * as React from 'react';
-import { useContext } from 'react';
+import React, { useContext } from 'react';
 import { isExpanded } from 'components/WorkflowGraph/utils';
 import { isEqual } from 'lodash';
 import { useTheme } from 'components/Theme/useTheme';
@@ -13,6 +12,7 @@ import { NodeExecutionColumnDefinition } from './types';
 import { DetailsPanelContext } from '../ExecutionDetails/DetailsPanelContext';
 import { RowExpander } from './RowExpander';
 import { calculateNodeExecutionRowLeftSpacing } from './utils';
+import { isParentNode } from '../utils';
 
 const useStyles = makeStyles(() => ({
   namesContainerExpander: {
@@ -68,7 +68,7 @@ export const NodeExecutionRow: React.FC<NodeExecutionRowProps> = ({
 
   const expanderContent = (
     <div className={styles.namesContainerExpander}>
-      {node.nodes?.length ? (
+      {isParentNode(nodeExecution) ? (
         <RowExpander
           expanded={expanded}
           onClick={() => onToggle(node.id, node.scopedId, nodeLevel)}

--- a/packages/console/src/components/Executions/Tables/NodeExecutionRow.tsx
+++ b/packages/console/src/components/Executions/Tables/NodeExecutionRow.tsx
@@ -44,12 +44,13 @@ export const NodeExecutionRow: React.FC<NodeExecutionRowProps> = ({
 }) => {
   const styles = useStyles();
   const theme = useTheme();
+  const expanderRef = React.useRef<HTMLButtonElement>();
+
   const tableStyles = useExecutionTableStyles();
   const { selectedExecution, setSelectedExecution } =
     useContext(DetailsPanelContext);
 
   const nodeLevel = node?.level ?? 0;
-  const expanded = isExpanded(node);
 
   // For the first level, we want the borders to span the entire table,
   // so we'll use padding to space the content. For nested rows, we want the
@@ -66,18 +67,20 @@ export const NodeExecutionRow: React.FC<NodeExecutionRowProps> = ({
     ? isEqual(selectedExecution, nodeExecution)
     : false;
 
-  const expanderContent = (
-    <div className={styles.namesContainerExpander}>
-      {isParentNode(nodeExecution) ? (
-        <RowExpander
-          expanded={expanded}
-          onClick={() => onToggle(node.id, node.scopedId, nodeLevel)}
-        />
-      ) : (
-        <div className={styles.leaf} />
-      )}
-    </div>
-  );
+  const expanderContent = React.useMemo(() => {
+    return isParentNode(nodeExecution) ? (
+      <RowExpander
+        ref={expanderRef as React.ForwardedRef<HTMLButtonElement>}
+        key={node.scopedId}
+        expanded={isExpanded(node)}
+        onClick={() => {
+          onToggle(node.id, node.scopedId, nodeLevel);
+        }}
+      />
+    ) : (
+      <div className={styles.leaf} />
+    );
+  }, [node, nodeLevel]);
 
   // open the side panel for selected execution's detail
   // use null in case if there is no execution provided - when it is null, will close side panel
@@ -99,7 +102,9 @@ export const NodeExecutionRow: React.FC<NodeExecutionRowProps> = ({
           <div
             className={classnames(tableStyles.rowColumn, tableStyles.expander)}
           >
-            {expanderContent}
+            <div className={styles.namesContainerExpander}>
+              {expanderContent}
+            </div>
           </div>
           {columns.map(({ className, key: columnKey, cellRenderer }) => (
             <div

--- a/packages/console/src/components/Executions/Tables/NodeExecutionsTable.tsx
+++ b/packages/console/src/components/Executions/Tables/NodeExecutionsTable.tsx
@@ -13,6 +13,7 @@ import {
   isStartNode,
 } from 'components/WorkflowGraph/utils';
 import { useQueryClient } from 'react-query';
+import { merge, eq } from 'lodash';
 import { ExecutionsTableHeader } from './ExecutionsTableHeader';
 import { generateColumns } from './nodeExecutionColumns';
 import { NoExecutionsContent } from './NoExecutionsContent';
@@ -72,9 +73,19 @@ export const NodeExecutionsTable: React.FC<NodeExecutionsTableProps> = ({
   );
 
   useEffect(() => {
-    setOriginalNodes(
-      appliedFilters.length > 0 && filteredNodes ? filteredNodes : initialNodes,
-    );
+    setOriginalNodes(ogn => {
+      const newNodes =
+        appliedFilters.length > 0 && filteredNodes
+          ? filteredNodes
+          : merge(initialNodes, ogn);
+
+      if (!eq(newNodes, ogn)) {
+        return newNodes;
+      }
+
+      return ogn;
+    });
+
     const plainNodes = convertToPlainNodes(originalNodes);
     const updatedShownNodesMap = plainNodes.map(node => {
       const execution = nodeExecutionsById[node.scopedId];
@@ -88,7 +99,7 @@ export const NodeExecutionsTable: React.FC<NodeExecutionsTableProps> = ({
   }, [initialNodes, filteredNodes, originalNodes, nodeExecutionsById]);
 
   const toggleNode = async (id: string, scopedId: string, level: number) => {
-    fetchChildrenExecutions(
+    await fetchChildrenExecutions(
       queryClient,
       scopedId,
       nodeExecutionsById,

--- a/packages/console/src/components/Executions/Tables/NodeExecutionsTable.tsx
+++ b/packages/console/src/components/Executions/Tables/NodeExecutionsTable.tsx
@@ -7,11 +7,6 @@ import { dNode } from 'models/Graph/types';
 import { NodeExecutionPhase } from 'models/Execution/enums';
 import { dateToTimestamp } from 'common/utils';
 import React, { useMemo, useEffect, useState, useContext } from 'react';
-import {
-  isEndNode,
-  isExpanded,
-  isStartNode,
-} from 'components/WorkflowGraph/utils';
 import { useQueryClient } from 'react-query';
 import { merge, eq } from 'lodash';
 import { ExecutionsTableHeader } from './ExecutionsTableHeader';
@@ -23,7 +18,7 @@ import { convertToPlainNodes } from '../ExecutionDetails/Timeline/helpers';
 import { useNodeExecutionContext } from '../contextProvider/NodeExecutionDetails';
 import { NodeExecutionRow } from './NodeExecutionRow';
 import { useNodeExecutionFiltersState } from '../filters/useExecutionFiltersState';
-import { fetchChildrenExecutions } from '../utils';
+import { fetchChildrenExecutions, searchNode } from '../utils';
 
 interface NodeExecutionsTableProps {
   initialNodes: dNode[];
@@ -106,30 +101,7 @@ export const NodeExecutionsTable: React.FC<NodeExecutionsTableProps> = ({
       setCurrentNodeExecutionsById,
       setShouldUpdate,
     );
-
-    const searchNode = (nodes: dNode[], nodeLevel: number) => {
-      if (!nodes || nodes.length === 0) {
-        return;
-      }
-      for (let i = 0; i < nodes.length; i++) {
-        const node = nodes[i];
-        if (isStartNode(node) || isEndNode(node)) {
-          continue;
-        }
-        if (
-          node.id === id &&
-          node.scopedId === scopedId &&
-          nodeLevel === level
-        ) {
-          nodes[i].expanded = !nodes[i].expanded;
-          return;
-        }
-        if (node.nodes.length > 0 && isExpanded(node)) {
-          searchNode(node.nodes, nodeLevel + 1);
-        }
-      }
-    };
-    searchNode(originalNodes, 0);
+    searchNode(originalNodes, 0, id, scopedId, level);
     setOriginalNodes([...originalNodes]);
   };
 

--- a/packages/console/src/components/Executions/Tables/RowExpander.tsx
+++ b/packages/console/src/components/Executions/Tables/RowExpander.tsx
@@ -1,25 +1,34 @@
+import * as React from 'react';
 import { IconButton } from '@material-ui/core';
 import ChevronRight from '@material-ui/icons/ChevronRight';
 import ExpandMore from '@material-ui/icons/ExpandMore';
-import * as React from 'react';
 import t from './strings';
 
-/** A simple expand/collapse arrow to be rendered next to row items. */
-export const RowExpander: React.FC<{
+interface RowExpanderProps {
   expanded: boolean;
+  key?: string;
   onClick: () => void;
-}> = ({ expanded, onClick }) => (
-  <IconButton
-    disableRipple={true}
-    disableTouchRipple={true}
-    size="small"
-    title={t('expanderTitle', expanded)}
-    onClick={(e: React.MouseEvent<HTMLElement>) => {
-      // prevent the parent row body onClick event trigger
-      e.stopPropagation();
-      onClick();
-    }}
-  >
-    {expanded ? <ExpandMore /> : <ChevronRight />}
-  </IconButton>
-);
+}
+/** A simple expand/collapse arrow to be rendered next to row items. */
+export const RowExpander = React.forwardRef<
+  HTMLButtonElement,
+  RowExpanderProps
+>(({ expanded, key, onClick }, ref) => {
+  return (
+    <IconButton
+      key={key}
+      ref={ref}
+      disableRipple={true}
+      disableTouchRipple={true}
+      size="small"
+      title={t('expanderTitle', expanded)}
+      onClick={(e: React.MouseEvent<HTMLElement>) => {
+        // prevent the parent row body onClick event trigger
+        e.stopPropagation();
+        onClick();
+      }}
+    >
+      {expanded ? <ExpandMore /> : <ChevronRight />}
+    </IconButton>
+  );
+});

--- a/packages/console/src/components/Executions/Tables/nodeExecutionColumns.tsx
+++ b/packages/console/src/components/Executions/Tables/nodeExecutionColumns.tsx
@@ -37,7 +37,7 @@ const DisplayId: React.FC<NodeExecutionCellRendererData> = ({ execution }) => {
     let isCurrent = true;
     getNodeExecutionDetails(execution).then(res => {
       if (isCurrent) {
-        setDisplayId(res.displayId);
+        setDisplayId(res?.displayId);
       }
     });
     return () => {
@@ -63,7 +63,7 @@ const DisplayType: React.FC<NodeExecutionCellRendererData> = ({
     let isCurrent = true;
     getNodeExecutionDetails(execution).then(res => {
       if (isCurrent) {
-        setType(res.displayType);
+        setType(res?.displayType);
       }
     });
     return () => {

--- a/packages/console/src/components/Executions/Tables/test/NodeExecutionRow.test.tsx
+++ b/packages/console/src/components/Executions/Tables/test/NodeExecutionRow.test.tsx
@@ -14,10 +14,6 @@ import { NodeExecutionRow } from '../NodeExecutionRow';
 jest.mock('components/Workflow/workflowQueries');
 const { fetchWorkflow } = require('components/Workflow/workflowQueries');
 
-jest.mock('components/Executions/Tables/RowExpander', () => ({
-  RowExpander: jest.fn(() => <div data-testid="expander"></div>),
-}));
-
 const columns = [];
 const node = {
   id: 'n1',
@@ -44,15 +40,15 @@ describe('Executions > Tables > NodeExecutionRow', () => {
     );
   });
 
-  const renderComponent = props =>
-    render(
+  const renderComponent = props => {
+    return render(
       <QueryClientProvider client={queryClient}>
         <NodeExecutionDetailsContextProvider workflowId={mockWorkflowId}>
           <NodeExecutionRow {...props} />
         </NodeExecutionDetailsContextProvider>
       </QueryClientProvider>,
     );
-
+  };
   it('should not render expander if node is a leaf', async () => {
     const { queryByRole, queryByTestId } = renderComponent({
       columns,
@@ -67,8 +63,14 @@ describe('Executions > Tables > NodeExecutionRow', () => {
   });
 
   it('should render expander if node contains list of nodes', async () => {
-    const mockNode = { ...node, nodes: [node, node] };
-    const { queryByRole, queryByTestId } = renderComponent({
+    const mockNode = {
+      ...node,
+      nodes: [node, node],
+    };
+
+    (execution.metadata as any).isParentNode = true;
+
+    const { queryByRole, queryByTitle } = renderComponent({
       columns,
       node: mockNode,
       nodeExecution: execution,
@@ -77,6 +79,6 @@ describe('Executions > Tables > NodeExecutionRow', () => {
     await waitFor(() => queryByRole('listitem'));
 
     expect(queryByRole('listitem')).toBeInTheDocument();
-    expect(queryByTestId('expander')).toBeInTheDocument();
+    expect(queryByTitle('Expand row')).toBeInTheDocument();
   });
 });

--- a/packages/console/src/components/Executions/Tables/test/NodeExecutionsTable.test.tsx
+++ b/packages/console/src/components/Executions/Tables/test/NodeExecutionsTable.test.tsx
@@ -91,7 +91,12 @@ describe('NodeExecutionsTableExecutions > Tables > NodeExecutionsTable', () => {
     render(
       <QueryClientProvider client={queryClient}>
         <NodeExecutionDetailsContextProvider workflowId={mockWorkflowId}>
-          <NodeExecutionsByIdContext.Provider value={nodeExecutionsById}>
+          <NodeExecutionsByIdContext.Provider
+            value={{
+              nodeExecutionsById,
+              setCurrentNodeExecutionsById: () => {},
+            }}
+          >
             <NodeExecutionsTable
               initialNodes={initialNodes}
               filteredNodes={filteredNodes}

--- a/packages/console/src/components/Executions/contextProvider/NodeExecutionDetails/index.tsx
+++ b/packages/console/src/components/Executions/contextProvider/NodeExecutionDetails/index.tsx
@@ -1,5 +1,10 @@
-import * as React from 'react';
-import { createContext, useContext, useEffect, useRef, useState } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { log } from 'common/log';
 import { Identifier } from 'models/Common/types';
 import { NodeExecution } from 'models/Execution/types';
@@ -17,7 +22,7 @@ import { getTaskThroughExecution } from './getTaskThroughExecution';
 interface NodeExecutionDetailsState {
   getNodeExecutionDetails: (
     nodeExecution?: NodeExecution,
-  ) => Promise<NodeExecutionDetails>;
+  ) => Promise<NodeExecutionDetails | undefined>;
   workflowId: Identifier;
   compiledWorkflowClosure: CompiledWorkflowClosure | null;
 }
@@ -113,7 +118,7 @@ export const NodeExecutionDetailsContextProvider = (props: ProviderProps) => {
     };
   }, [queryClient, resourceType, project, domain, name, version]);
 
-  const checkForDynamicTasks = async (nodeExecution: NodeExecution) => {
+  const getDynamicTasks = async (nodeExecution: NodeExecution) => {
     const taskDetails = await getTaskThroughExecution(
       queryClient,
       nodeExecution,
@@ -130,7 +135,7 @@ export const NodeExecutionDetailsContextProvider = (props: ProviderProps) => {
 
   const getDetails = async (
     nodeExecution?: NodeExecution,
-  ): Promise<NodeExecutionDetails> => {
+  ): Promise<NodeExecutionDetails | undefined> => {
     if (!executionTree || !nodeExecution) {
       return UNKNOWN_DETAILS;
     }
@@ -148,7 +153,9 @@ export const NodeExecutionDetailsContextProvider = (props: ProviderProps) => {
       }
 
       // look for specific task by nodeId in current execution
-      details = await checkForDynamicTasks(nodeExecution);
+      if (nodeExecution.metadata?.isDynamic) {
+        details = await getDynamicTasks(nodeExecution);
+      }
       return details;
     }
 

--- a/packages/console/src/components/Executions/contexts.ts
+++ b/packages/console/src/components/Executions/contexts.ts
@@ -1,14 +1,28 @@
-import { Execution, NodeExecution } from 'models/Execution/types';
+import { Execution, LogsByPhase, NodeExecution } from 'models/Execution/types';
 import { createContext } from 'react';
 
 export interface ExecutionContextData {
   execution: Execution;
 }
 
+export interface WorkflowNodeExecution extends NodeExecution {
+  tasksFetched?: boolean;
+  logsByPhase?: LogsByPhase;
+}
+
 export const ExecutionContext = createContext<ExecutionContextData>(
   {} as ExecutionContextData,
 );
 
-export const NodeExecutionsByIdContext = createContext<
-  Dictionary<NodeExecution>
->({});
+export interface INodeExecutionsByIdContext {
+  nodeExecutionsById: Dictionary<WorkflowNodeExecution>;
+  setCurrentNodeExecutionsById: (
+    currentNodeExecutionsById: Dictionary<NodeExecution>,
+  ) => void;
+}
+
+export const NodeExecutionsByIdContext =
+  createContext<INodeExecutionsByIdContext>({
+    nodeExecutionsById: {},
+    setCurrentNodeExecutionsById: () => {},
+  });

--- a/packages/console/src/components/Executions/useNodeExecutionsById.ts
+++ b/packages/console/src/components/Executions/useNodeExecutionsById.ts
@@ -1,0 +1,23 @@
+import { NodeExecution } from 'models/Execution/types';
+import { useCallback, useState } from 'react';
+import { INodeExecutionsByIdContext } from './contexts';
+
+export const useNodeExecutionsById = (
+  initialNodeExecutionsById?: Dictionary<NodeExecution>,
+): INodeExecutionsByIdContext => {
+  const [nodeExecutionsById, setNodeExecutionsById] = useState(
+    initialNodeExecutionsById ?? {},
+  );
+
+  const setCurrentNodeExecutionsById = useCallback(
+    (currentNodeExecutionsById: Dictionary<NodeExecution>): void => {
+      setNodeExecutionsById(currentNodeExecutionsById);
+    },
+    [],
+  );
+
+  return {
+    nodeExecutionsById,
+    setCurrentNodeExecutionsById,
+  };
+};

--- a/packages/console/src/components/Launch/LaunchForm/ResumeSignalForm.tsx
+++ b/packages/console/src/components/Launch/LaunchForm/ResumeSignalForm.tsx
@@ -1,7 +1,6 @@
 import { DialogContent, Typography } from '@material-ui/core';
 import { getCacheKey } from 'components/Cache/utils';
-import * as React from 'react';
-import { useState, useContext, useEffect, useMemo } from 'react';
+import React, { useState, useContext, useEffect, useMemo } from 'react';
 import { NodeExecution } from 'models/Execution/types';
 import { NodeExecutionsByIdContext } from 'components/Executions/contexts';
 import { useNodeExecutionData } from 'components/hooks/useNodeExecution';
@@ -39,7 +38,7 @@ export const ResumeSignalForm: React.FC<ResumeSignalFormProps> = ({
     nodeId,
     onClose,
   });
-  const nodeExecutionsById = useContext(NodeExecutionsByIdContext);
+  const { nodeExecutionsById } = useContext(NodeExecutionsByIdContext);
   const [nodeExecution, setNodeExecution] = useState<NodeExecution>(
     nodeExecutionsById[nodeId],
   );

--- a/packages/console/src/components/Launch/LaunchForm/test/ResumeSignalForm.test.tsx
+++ b/packages/console/src/components/Launch/LaunchForm/test/ResumeSignalForm.test.tsx
@@ -107,7 +107,7 @@ describe('ResumeSignalForm', () => {
               }}
             >
               <NodeExecutionsByIdContext.Provider
-                value={mockNodeExecutionsById}
+                value={{ nodeExecutionsById: mockNodeExecutionsById }}
               >
                 <ResumeSignalForm
                   onClose={onClose}

--- a/packages/console/src/components/WorkflowGraph/WorkflowGraph.tsx
+++ b/packages/console/src/components/WorkflowGraph/WorkflowGraph.tsx
@@ -54,7 +54,6 @@ export const WorkflowGraph: React.FC<WorkflowGraphProps> = ({
 
   return (
     <ReactFlowGraphComponent
-      dynamicWorkflows={dynamicWorkflows}
       data={mergedDag}
       onNodeSelectionChanged={onNodeSelectionChanged}
       onPhaseSelectionChanged={onPhaseSelectionChanged}

--- a/packages/console/src/components/WorkflowGraph/WorkflowGraph.tsx
+++ b/packages/console/src/components/WorkflowGraph/WorkflowGraph.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import ReactFlowGraphComponent from 'components/flytegraph/ReactFlow/ReactFlowGraphComponent';
+import React from 'react';
+import { ReactFlowGraphComponent } from 'components/flytegraph/ReactFlow/ReactFlowGraphComponent';
 import { Error } from 'models/Common/types';
 import { NonIdealState } from 'components/common/NonIdealState';
 import { CompiledNode } from 'models/Node/types';
@@ -16,6 +16,8 @@ export interface WorkflowGraphProps {
   error: Error | null;
   dynamicWorkflows: any;
   initialNodes: dNode[];
+  shouldUpdate: boolean;
+  setShouldUpdate: (val: boolean) => void;
 }
 export interface DynamicWorkflowMapping {
   rootGraphNodeId: CompiledNode;
@@ -31,6 +33,8 @@ export const WorkflowGraph: React.FC<WorkflowGraphProps> = ({
   error,
   dynamicWorkflows,
   initialNodes,
+  shouldUpdate,
+  setShouldUpdate,
 }) => {
   if (error) {
     return (
@@ -57,6 +61,8 @@ export const WorkflowGraph: React.FC<WorkflowGraphProps> = ({
       selectedPhase={selectedPhase}
       isDetailsTabClosed={isDetailsTabClosed}
       initialNodes={initialNodes}
+      shouldUpdate={shouldUpdate}
+      setShouldUpdate={setShouldUpdate}
     />
   );
 };

--- a/packages/console/src/components/WorkflowGraph/transformerWorkflowToDag.tsx
+++ b/packages/console/src/components/WorkflowGraph/transformerWorkflowToDag.tsx
@@ -11,6 +11,7 @@ import {
   CompiledWorkflow,
   CompiledWorkflowClosure,
 } from 'models/Workflow/types';
+import { isParentNode } from 'components/Executions/utils';
 import {
   isStartOrEndNode,
   getDisplayName,
@@ -33,6 +34,7 @@ const debug = createDebugLogger('@transformerWorkflowToDag');
 export const transformerWorkflowToDag = (
   workflow: CompiledWorkflowClosure,
   dynamicToMerge: any | null = null,
+  nodeExecutionsById = {},
 ): any => {
   const { primary } = workflow;
   const staticExecutionIdsMap = {};
@@ -57,8 +59,12 @@ export const transformerWorkflowToDag = (
     taskTemplate?: CompiledTask;
     typeOverride?: dTypes;
   }
-  const createDNode = (props: CreateDNodeProps): dNode => {
-    const { compiledNode, parentDNode, taskTemplate, typeOverride } = props;
+  const createDNode = ({
+    compiledNode,
+    parentDNode,
+    taskTemplate,
+    typeOverride,
+  }: CreateDNodeProps): dNode => {
     const nodeValue =
       taskTemplate == null
         ? compiledNode
@@ -99,6 +105,9 @@ export const transformerWorkflowToDag = (
         ? getNodeTypeFromCompiledNode(compiledNode)
         : typeOverride;
 
+    const nodeExecution = nodeExecutionsById[scopedId];
+    const isParent = nodeExecution && isParentNode(nodeExecution);
+
     const output = {
       id: compiledNode.id,
       scopedId: scopedId,
@@ -108,6 +117,7 @@ export const transformerWorkflowToDag = (
       nodes: [],
       edges: [],
       gateNode: compiledNode.gateNode,
+      isParentNode: isParent,
     } as dNode;
 
     staticExecutionIdsMap[output.scopedId] = compiledNode;

--- a/packages/console/src/components/common/utils.ts
+++ b/packages/console/src/components/common/utils.ts
@@ -30,14 +30,16 @@ export const checkForDynamicExecutions = (allExecutions, staticExecutions) => {
   for (const executionId in allExecutions) {
     if (!staticExecutions[executionId]) {
       const dynamicExecution = allExecutions[executionId];
-      const dynamicExecutionId =
-        dynamicExecution.metadata.specNodeId || dynamicExecution.id;
-      const uniqueParentId = dynamicExecution.fromUniqueParentId;
-      if (uniqueParentId) {
-        if (parentsToFetch[uniqueParentId]) {
-          parentsToFetch[uniqueParentId].push(dynamicExecutionId);
-        } else {
-          parentsToFetch[uniqueParentId] = [dynamicExecutionId];
+      if (dynamicExecution) {
+        const dynamicExecutionId =
+          dynamicExecution.metadata?.specNodeId || dynamicExecution.id;
+        const uniqueParentId = dynamicExecution.fromUniqueParentId;
+        if (uniqueParentId) {
+          if (parentsToFetch[uniqueParentId]) {
+            parentsToFetch[uniqueParentId].push(dynamicExecutionId);
+          } else {
+            parentsToFetch[uniqueParentId] = [dynamicExecutionId];
+          }
         }
       }
     }

--- a/packages/console/src/components/common/utils.ts
+++ b/packages/console/src/components/common/utils.ts
@@ -27,15 +27,13 @@ export function measureText(fontDefinition: string, text: string) {
  */
 export const checkForDynamicExecutions = (allExecutions, staticExecutions) => {
   const parentsToFetch = {};
-  const executionsByNodeId = {};
   for (const executionId in allExecutions) {
-    const execution = allExecutions[executionId];
-    executionsByNodeId[execution.id.nodeId] = execution;
     if (!staticExecutions[executionId]) {
-      if (execution) {
+      const dynamicExecution = allExecutions[executionId];
+      if (dynamicExecution) {
         const dynamicExecutionId =
-          execution.metadata?.specNodeId || execution.id;
-        const uniqueParentId = execution.fromUniqueParentId;
+          dynamicExecution.metadata?.specNodeId || dynamicExecution.id;
+        const uniqueParentId = dynamicExecution.fromUniqueParentId;
         if (uniqueParentId) {
           if (parentsToFetch[uniqueParentId]) {
             parentsToFetch[uniqueParentId].push(dynamicExecutionId);
@@ -48,8 +46,7 @@ export const checkForDynamicExecutions = (allExecutions, staticExecutions) => {
   }
   const result = {};
   for (const parentId in parentsToFetch) {
-    const execution = executionsByNodeId[parentId];
-    result[execution.scopedId] = execution;
+    result[parentId] = allExecutions[parentId];
   }
   return result;
 };

--- a/packages/console/src/components/common/utils.ts
+++ b/packages/console/src/components/common/utils.ts
@@ -27,13 +27,15 @@ export function measureText(fontDefinition: string, text: string) {
  */
 export const checkForDynamicExecutions = (allExecutions, staticExecutions) => {
   const parentsToFetch = {};
+  const executionsByNodeId = {};
   for (const executionId in allExecutions) {
+    const execution = allExecutions[executionId];
+    executionsByNodeId[execution.id.nodeId] = execution;
     if (!staticExecutions[executionId]) {
-      const dynamicExecution = allExecutions[executionId];
-      if (dynamicExecution) {
+      if (execution) {
         const dynamicExecutionId =
-          dynamicExecution.metadata?.specNodeId || dynamicExecution.id;
-        const uniqueParentId = dynamicExecution.fromUniqueParentId;
+          execution.metadata?.specNodeId || execution.id;
+        const uniqueParentId = execution.fromUniqueParentId;
         if (uniqueParentId) {
           if (parentsToFetch[uniqueParentId]) {
             parentsToFetch[uniqueParentId].push(dynamicExecutionId);
@@ -46,7 +48,8 @@ export const checkForDynamicExecutions = (allExecutions, staticExecutions) => {
   }
   const result = {};
   for (const parentId in parentsToFetch) {
-    result[parentId] = allExecutions[parentId];
+    const execution = executionsByNodeId[parentId];
+    result[execution.scopedId] = execution;
   }
   return result;
 };

--- a/packages/console/src/components/common/utils.ts
+++ b/packages/console/src/components/common/utils.ts
@@ -30,7 +30,7 @@ export const checkForDynamicExecutions = (allExecutions, staticExecutions) => {
   const executionsByNodeId = {};
   for (const executionId in allExecutions) {
     const execution = allExecutions[executionId];
-    executionsByNodeId[execution.id.nodeId] = execution;
+    executionsByNodeId[execution?.id.nodeId] = execution;
     if (!staticExecutions[executionId]) {
       if (execution) {
         const dynamicExecutionId =

--- a/packages/console/src/components/flytegraph/ReactFlow/ReactFlowGraphComponent.tsx
+++ b/packages/console/src/components/flytegraph/ReactFlow/ReactFlowGraphComponent.tsx
@@ -50,13 +50,13 @@ export const ReactFlowGraphComponent = ({
         setCurrentNodeExecutionsById,
         setShouldUpdate,
       );
-    } else {
-      const currentView = currentNestedView[view.parent] || [];
-      const newView = {
-        [view.parent]: [...currentView, view.view],
-      };
-      setcurrentNestedView(newView);
     }
+
+    const currentView = currentNestedView[view.parent] || [];
+    const newView = {
+      [view.parent]: [...currentView, view.view],
+    };
+    setcurrentNestedView(newView);
   };
 
   const onRemoveNestedView = (viewParent, viewIndex) => {

--- a/packages/console/src/components/flytegraph/ReactFlow/ReactFlowWrapper.tsx
+++ b/packages/console/src/components/flytegraph/ReactFlow/ReactFlowWrapper.tsx
@@ -114,7 +114,7 @@ export const ReactFlowWrapper: React.FC<RFWrapperProps> = ({
   const onNodeClick = async (_event, node) => {
     const scopedId = node.data.scopedId;
     if (node.data.isParentNode) {
-      fetchChildrenExecutions(
+      await fetchChildrenExecutions(
         queryClient,
         scopedId,
         nodeExecutionsById,

--- a/packages/console/src/components/flytegraph/ReactFlow/ReactFlowWrapper.tsx
+++ b/packages/console/src/components/flytegraph/ReactFlow/ReactFlowWrapper.tsx
@@ -38,12 +38,7 @@ export const ReactFlowWrapper: React.FC<RFWrapperProps> = ({
   backgroundStyle,
   currentNestedView,
   version,
-  setShouldUpdate,
 }) => {
-  const queryClient = useQueryClient();
-  const { nodeExecutionsById, setCurrentNodeExecutionsById } = useContext(
-    NodeExecutionsByIdContext,
-  );
   const [state, setState] = useState({
     shouldUpdate: true,
     nodes: rfGraphJson?.nodes,
@@ -111,17 +106,7 @@ export const ReactFlowWrapper: React.FC<RFWrapperProps> = ({
     flexDirection: 'column',
   };
 
-  const onNodeClick = async (_event, node) => {
-    const scopedId = node.data.scopedId;
-    if (node.data.isParentNode) {
-      await fetchChildrenExecutions(
-        queryClient,
-        scopedId,
-        nodeExecutionsById,
-        setCurrentNodeExecutionsById,
-        setShouldUpdate,
-      );
-    }
+  const onNodeClick = async _event => {
     setState(state => ({ ...state, needFitView: false }));
   };
 

--- a/packages/console/src/components/flytegraph/ReactFlow/ReactFlowWrapper.tsx
+++ b/packages/console/src/components/flytegraph/ReactFlow/ReactFlowWrapper.tsx
@@ -46,8 +46,8 @@ export const ReactFlowWrapper: React.FC<RFWrapperProps> = ({
   );
   const [state, setState] = useState({
     shouldUpdate: true,
-    nodes: rfGraphJson.nodes,
-    edges: rfGraphJson.edges,
+    nodes: rfGraphJson?.nodes,
+    edges: rfGraphJson?.edges,
     version: version,
     reactFlowInstance: null,
     needFitView: false,
@@ -57,8 +57,8 @@ export const ReactFlowWrapper: React.FC<RFWrapperProps> = ({
     setState(state => ({
       ...state,
       shouldUpdate: true,
-      nodes: rfGraphJson.nodes,
-      edges: rfGraphJson.edges.map(edge => ({ ...edge, zIndex: 0 })),
+      nodes: rfGraphJson?.nodes,
+      edges: rfGraphJson?.edges?.map(edge => ({ ...edge, zIndex: 0 })),
     }));
   }, [rfGraphJson]);
 

--- a/packages/console/src/components/flytegraph/ReactFlow/customNodeComponents.tsx
+++ b/packages/console/src/components/flytegraph/ReactFlow/customNodeComponents.tsx
@@ -1,11 +1,10 @@
-import * as React from 'react';
-import { useState, useEffect, useContext } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { Handle, Position } from 'react-flow-renderer';
 import { dTypes } from 'models/Graph/types';
 import { NodeExecutionPhase, TaskExecutionPhase } from 'models/Execution/enums';
 import { RENDER_ORDER } from 'components/Executions/TaskExecutionsList/constants';
 import { whiteColor } from 'components/Theme/constants';
-import PlayCircleOutlineIcon from '@material-ui/icons/PlayCircleOutline';
+import { PlayCircleOutline } from '@material-ui/icons';
 import { Tooltip } from '@material-ui/core';
 import { COLOR_SPECTRUM } from 'components/Theme/colorSpectrum';
 import { getNodeFrontendPhase } from 'components/Executions/utils';
@@ -223,7 +222,7 @@ const TaskPhaseItem = ({
 
 export const ReactFlowGateNode = ({ data }: RFNode) => {
   const { compiledWorkflowClosure } = useNodeExecutionContext();
-  const nodeExecutionsById = useContext(NodeExecutionsByIdContext);
+  const { nodeExecutionsById } = useContext(NodeExecutionsByIdContext);
   const {
     nodeType,
     nodeExecutionStatus,
@@ -263,7 +262,7 @@ export const ReactFlowGateNode = ({ data }: RFNode) => {
         {text}
         {phase === NodeExecutionPhase.PAUSED && (
           <Tooltip title={t('resumeTooltip')}>
-            <PlayCircleOutlineIcon onClick={onResumeClick} style={iconStyles} />
+            <PlayCircleOutline onClick={onResumeClick} style={iconStyles} />
           </Tooltip>
         )}
       </div>

--- a/packages/console/src/components/flytegraph/ReactFlow/transformDAGToReactFlowV2.tsx
+++ b/packages/console/src/components/flytegraph/ReactFlow/transformDAGToReactFlowV2.tsx
@@ -8,7 +8,7 @@ import {
 import { createDebugLogger } from 'common/log';
 import { LogsByPhase } from 'models/Execution/types';
 import { isMapTaskType } from 'models/Task/utils';
-import { ReactFlowGraphConfig } from './utils';
+import { isUnFetchedDynamicNode, ReactFlowGraphConfig } from './utils';
 import { ConvertDagProps } from './types';
 
 interface rfNode extends Node {
@@ -276,6 +276,18 @@ export const buildGraphMapping = (props): ReactFlowGraphMapping => {
             });
           }
         }
+
+        /*
+         * Because dyanmic nodes are now fetched on demand we need to check
+         * for nodes that are parents without children; in which case we want
+         * to override the type to mimic unopened subworkflow (nestedMaxDepth)
+         */
+        const type =
+          isStaticGraph === true
+            ? dTypes.staticNode
+            : isUnFetchedDynamicNode(node)
+            ? dTypes.nestedMaxDepth
+            : undefined;
 
         if (rootParentNode) {
           const rootParentId = rootParentNode.scopedId;

--- a/packages/console/src/components/flytegraph/ReactFlow/transformDAGToReactFlowV2.tsx
+++ b/packages/console/src/components/flytegraph/ReactFlow/transformDAGToReactFlowV2.tsx
@@ -124,10 +124,13 @@ const buildReactFlowDataProps = ({
       }
     },
     onAddNestedView: () => {
-      onAddNestedView({
-        parent: rootParentNode.scopedId,
-        view: scopedId,
-      });
+      onAddNestedView(
+        {
+          parent: rootParentNode ? rootParentNode.scopedId : scopedId,
+          view: scopedId,
+        },
+        node,
+      );
     },
     onRemoveNestedView,
   };
@@ -278,11 +281,14 @@ export const buildGraphMapping = (props): ReactFlowGraphMapping => {
         }
 
         /*
-         * Because dyanmic nodes are now fetched on demand we need to check
-         * for nodes that are parents without children; in which case we want
-         * to override the type to mimic unopened subworkflow (nestedMaxDepth)
+         * case: isUnfetcedDyanmic
+         * dyanmic nodes are now fetched on demand; thse will be nodes that are
+         * parents without children; in which case we override the type nestedMaxDepth
+         *
+         * case dTypes.nestedMaxDepth
+         * for nodes that subworkflows; this is the unexpanded view
          */
-        const type =
+        const typeOVerride =
           isStaticGraph === true
             ? dTypes.staticNode
             : isUnFetchedDynamicNode(node)
@@ -307,16 +313,14 @@ export const buildGraphMapping = (props): ReactFlowGraphMapping => {
             dataProps: nodeDataProps,
             rootParentNode: rootParentNode,
             parentNode: contextParent,
-            typeOverride:
-              isStaticGraph === true ? dTypes.staticNode : undefined,
+            typeOverride: typeOVerride,
           });
           context.nodes[reactFlowNode.id] = reactFlowNode;
         } else {
           const reactFlowNode = buildReactFlowNode({
             node: node,
             dataProps: nodeDataProps,
-            typeOverride:
-              isStaticGraph === true ? dTypes.staticNode : undefined,
+            typeOverride: typeOVerride,
           });
           root.nodes[reactFlowNode.id] = reactFlowNode;
         }

--- a/packages/console/src/components/flytegraph/ReactFlow/transformDAGToReactFlowV2.tsx
+++ b/packages/console/src/components/flytegraph/ReactFlow/transformDAGToReactFlowV2.tsx
@@ -58,24 +58,23 @@ interface BuildDataProps {
   rootParentNode: dNode;
   currentNestedView: string[];
 }
-const buildReactFlowDataProps = (props: BuildDataProps) => {
-  const {
-    node,
-    nodeExecutionsById,
-    onNodeSelectionChanged,
-    onPhaseSelectionChanged,
-    selectedPhase,
-    onAddNestedView,
-    onRemoveNestedView,
-    rootParentNode,
-    currentNestedView,
-  } = props;
-
+const buildReactFlowDataProps = ({
+  node,
+  nodeExecutionsById,
+  onNodeSelectionChanged,
+  onPhaseSelectionChanged,
+  selectedPhase,
+  onAddNestedView,
+  onRemoveNestedView,
+  rootParentNode,
+  currentNestedView,
+}: BuildDataProps) => {
   const {
     value: nodeValue,
     name: displayName,
     scopedId,
     type: nodeType,
+    isParentNode,
   } = node;
   const taskType = nodeValue?.template?.type ?? null;
 
@@ -111,6 +110,7 @@ const buildReactFlowDataProps = (props: BuildDataProps) => {
     scopedId,
     taskType,
     nodeLogsByPhase,
+    isParentNode,
     cacheStatus,
     selectedPhase,
     onNodeSelectionChanged: () => {

--- a/packages/console/src/components/flytegraph/ReactFlow/types.ts
+++ b/packages/console/src/components/flytegraph/ReactFlow/types.ts
@@ -15,12 +15,12 @@ export interface RFWrapperProps {
   onNodeSelectionChanged?: any;
   nodeExecutionsById?: any;
   version?: string;
+  setShouldUpdate?: (val: boolean) => void;
 }
 
 /* Note: extending to allow applying styles directly to handle */
 export interface RFHandleProps extends HandleProps {
   style: any;
-  id?: string;
 }
 
 export enum RFGraphTypes {
@@ -79,6 +79,7 @@ interface RFCustomData {
   dag: any;
   taskType: dTypes;
   cacheStatus: CatalogCacheStatus;
+  isParentNode: boolean;
   nodeLogsByPhase: LogsByPhase;
   selectedPhase: TaskExecutionPhase;
   currentNestedView: string[];

--- a/packages/console/src/components/flytegraph/ReactFlow/utils.tsx
+++ b/packages/console/src/components/flytegraph/ReactFlow/utils.tsx
@@ -123,6 +123,10 @@ export const getStatusColor: (
   }
 };
 
+export const isUnFetchedDynamicNode = node => {
+  return node.isParentNode && node.nodes.length === 0;
+};
+
 export const getNestedGraphContainerStyle = overwrite => {
   let width = overwrite.width;
   let height = overwrite.height;

--- a/packages/console/src/models/Graph/types.ts
+++ b/packages/console/src/models/Graph/types.ts
@@ -60,4 +60,5 @@ export interface dNode {
   expanded?: boolean;
   level?: number;
   execution?: NodeExecution;
+  isParentNode?: boolean;
 }

--- a/website/webpack.utilities.ts
+++ b/website/webpack.utilities.ts
@@ -76,7 +76,7 @@ export const getConfigFile = (mode: Mode): string =>
 // Determines whether to use CDN based on current development mode.
 export const getShouldLoadReactFromCDN = (mode: Mode) =>
   mode === 'production' ||
-  fs.existsSync(path.resolve(__dirname, '../node_modules/react'));
+  !fs.existsSync(path.resolve(__dirname, '../node_modules/react'));
 
 // Report current configuration
 export const logWebpackStats = (mode: Mode) => {


### PR DESCRIPTION
Signed-off-by: Olga Nad <olga@union.ai>

This fixes a previous refactor on node details UX by placing execution data into a single shared context between List, Graph and Timeline views (to avoid each view re-fetching already fetched data). However, the previous solution would front load the data b recursively fetching each execution's children which we found caused major issues for larger dynamic workflows.

To fix this issue this PR will implement an on-demand fetch for dynamic workflows.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin
 - [ ] Chore

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

- Removed childGroups fetch (recursive) from `ExecutionNodeViews` page
- Moved childGroups fetch to `onToggle` in Table and Timeline components - requests trigger when user clicked on expander
- Moved map tasks fetch to details page to back fill one-off nodeExecutions data, and to `ReactFlowGraphComponent` to batch them for all known nodeExecutions, so the graph is rendered properly (this will slow down the graph tab, but based on user's feedback, it's ok, if graph tab takes some time to load).
- Updated Graph nesting logic to support unexpanded subworkflows at level 0

## Known issues
- [ ] some unit tests are broken
- [x] add childGroups fetch in graph on node click
- [x] fix rerender of graph on childGroups fetch
- [x] fix `compiledWorkflowClosure` to check for `is_dynamic` field (available in node execution's metadata) instead of pulling multiple requests on repeat
- [ ] test filters in Table tab
- [x] display parent node as `nested` in graph to indicate it has children
- [ ] child task type stays in Loading state in the Details Sidebar

## Follow-up issue
_NA_

## Test workflows
- normal `core.control_flow.subworkflows.parent_wf`
- dynamic `core.control_flow.dynamics.wf`
- nested parent `core.control_flow.subworkflows.nested_parent_wf`
- map task `flyte.workflows.example_map_task.wf`
- small fan-out dynamic `workflows.branching_dynamic_example.wf`