### PR TITLE
Mapped Tasks not showing cache status correctly.

### DIFF
--- a/packages/console/src/components/common/MapTaskExecutionsList/TaskNameList.tsx
+++ b/packages/console/src/components/common/MapTaskExecutionsList/TaskNameList.tsx
@@ -8,17 +8,19 @@ import { noLogsFoundString } from 'components/Executions/constants';
 import { CacheStatus } from 'components/Executions/CacheStatus';
 import { useCommonStyles } from '../styles';
 
-interface StyleProps {
-  isLink: boolean;
-}
-
 const useStyles = makeStyles((_theme: Theme) => ({
-  taskTitle: ({ isLink }: StyleProps) => ({
-    cursor: isLink ? 'pointer' : 'default',
+  taskTitle: {
+    cursor: 'default',
     '&:hover': {
-      textDecoration: isLink ? 'underline' : 'none',
+      textDecoration: 'none',
     },
-  }),
+  },
+  taskTitleLink: {
+    cursor: 'pointer',
+    '&:hover': {
+      textDecoration: 'underline',
+    },
+  },
 }));
 
 interface TaskNameListProps {
@@ -33,6 +35,7 @@ export const TaskNameList = ({
   onTaskSelected,
 }: TaskNameListProps) => {
   const commonStyles = useCommonStyles();
+  const styles = useStyles();
 
   if (logs.length === 0) {
     return <span className={commonStyles.hintText}>{noLogsFoundString}</span>;
@@ -41,16 +44,17 @@ export const TaskNameList = ({
   return (
     <>
       {logs.map((log, taskIndex) => {
-        const styles = useStyles({ isLink: !!log.uri });
         const taskLogName = getTaskLogName(
           taskExecution.id.taskId.name,
           log.name ?? '',
         );
+
         const cacheStatus =
-          taskIndex != null
-            ? taskExecution.closure?.metadata?.externalResources?.[taskIndex]
-                ?.cacheStatus
-            : null;
+          taskExecution.closure?.metadata?.externalResources?.find(
+            item =>
+              item.externalId === log.name ||
+              !!item.logs?.find(l => l.name === log.name),
+          )?.cacheStatus;
 
         const handleClick = () => {
           onTaskSelected({ ...taskExecution, taskIndex });
@@ -68,7 +72,7 @@ export const TaskNameList = ({
               color={log.uri ? 'primary' : 'textPrimary'}
               onClick={log.uri ? handleClick : undefined}
               key={taskLogName}
-              className={styles.taskTitle}
+              className={log.uri ? styles.taskTitleLink : styles.taskTitle}
               data-testid="map-task-log"
             >
               {taskLogName}

--- a/packages/console/src/components/common/MapTaskExecutionsList/TaskNameList.tsx
+++ b/packages/console/src/components/common/MapTaskExecutionsList/TaskNameList.tsx
@@ -66,12 +66,12 @@ export const TaskNameList = ({
               display: 'flex',
               alignItems: 'center',
             }}
+            key={taskLogName}
           >
             <Typography
               variant="body1"
               color={log.uri ? 'primary' : 'textPrimary'}
               onClick={log.uri ? handleClick : undefined}
-              key={taskLogName}
               className={log.uri ? styles.taskTitleLink : styles.taskTitle}
               data-testid="map-task-log"
             >


### PR DESCRIPTION
https://github.com/flyteorg/flyteconsole/issues/644

Two issues
(1) It renders cache status incorrectly because it depended on the index of the logs instead of the id. While running, the logs are not in the original order (they are in order of queued/success instead of original order). So need to find correct cache status based on id
(2) the useStyles/hooks should not be used after component is rendered. It broke the app when the execution status is updated. I managed to place it before any render

To reproduce

For this workflow,
https://development.uniondemo.run/console/projects/flytesnacks/domains/development/workflows/map-task.my_cached_map_workflow_1?duration=all

- Click `Launch Workflow` button
- For the parameter, we need to mix some cached numbers and non-cached numbers to reproduce this issue. Right now, 0 ~ 8 are cached. (This will be changed if someone run this more). So for example, if 0 ~ 8 are cached, we can set the param as `[9,1,0,12,11,3]`
- Then while running the mapped task, if you go to the Map Execution panel on the right side (by navigating to the execution details and and click the first Map task), you will see some queued & succeeded tasks. Actually the problem is the icons next to the task names. If those are already queued, then it should be the refresh icon which identifies already cached.
- To reproduce the second issue, you should wait until the Map task is completed while open this right panel. Once it is updated, the right panel will be broken.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/644
