### PR TITLE
fix: left nav doesn't accurately update on  workflow version page

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyteorg/console",
-  "version": "0.0.10",
+  "version": "0.0.13",
   "description": "Flyteconsole main app module",
   "main": "./dist/index.js",
   "module": "./lib/index.js",

--- a/packages/console/src/components/Tables/PaginatedDataList.tsx
+++ b/packages/console/src/components/Tables/PaginatedDataList.tsx
@@ -115,7 +115,7 @@ const PaginatedDataListHeader = <C,>(
             className={column.className}
             key={column.key}
             align="left"
-            padding="default"
+            padding="normal"
             sortDirection={orderBy === column.key ? order : false}
           >
             <TableSortLabel
@@ -154,13 +154,12 @@ const PaginatedDataList = <T,>({
   totalRows,
   showRadioButton,
   fillEmptyRows = true,
-  noDataString,
 }: PropsWithChildren<PaginatedDataListProps<T>>) => {
   const classes = useStyles();
   const [order, setOrder] = React.useState<Order>('asc');
   const [orderBy, setOrderBy] = React.useState('calories');
-  const [page, setPage] = React.useState(0);
-  const [rowsPerPage, setRowsPerPage] = React.useState(5);
+  const [page] = React.useState(0);
+  const [rowsPerPage] = React.useState(5);
 
   const handleRequestSort = (
     event: React.MouseEvent<unknown>,
@@ -198,7 +197,7 @@ const PaginatedDataList = <T,>({
               showRadioButton={showRadioButton}
             />
             <TableBody>
-              {data.map((row, index) => {
+              {data.map((row, _index) => {
                 return rowRenderer(row);
               })}
               {fillEmptyRows && !showRadioButton && emptyRows > 0 && (

--- a/packages/console/src/routes/routes.ts
+++ b/packages/console/src/routes/routes.ts
@@ -81,7 +81,7 @@ export class Routes {
   static WorkflowDetails = {
     makeUrl: (project: string, domain: string, workflowName: string) =>
       makeProjectDomainBoundPath(project, domain, `/workflows/${workflowName}`),
-    path: `${projectDomainBasePath}/workflows/:workflowName`,
+    path: `${projectDomainBasePath}/(workflows|workflow)/:workflowName`,
   };
 
   // LaunchPlans

--- a/website/package.json
+++ b/website/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@flyteorg/common": "^0.0.3",
-    "@flyteorg/console": "^0.0.10",
+    "@flyteorg/console": "^0.0.13",
     "long": "^4.0.0",
     "protobufjs": "~6.11.3",
     "react-ga4": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1995,7 +1995,7 @@ __metadata:
   resolution: "@flyteconsole/client-app@workspace:website"
   dependencies:
     "@flyteorg/common": ^0.0.3
-    "@flyteorg/console": ^0.0.10
+    "@flyteorg/console": ^0.0.13
     "@types/long": ^3.0.32
     long: ^4.0.0
     protobufjs: ~6.11.3
@@ -2034,7 +2034,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@flyteorg/console@^0.0.10, @flyteorg/console@workspace:packages/console":
+"@flyteorg/console@^0.0.13, @flyteorg/console@workspace:packages/console":
   version: 0.0.0-use.local
   resolution: "@flyteorg/console@workspace:packages/console"
   dependencies:


### PR DESCRIPTION
# TL;DR
Fixes left nav logic that doesn't accurately update when navigating to a specific workflow version

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Updated the workflow detail path to include the workflow version path
To repro:
* checkout branch, run & navigate to [this link
](https://localhost.development.uniondemo.run:3000/console/projects/flytesnacks/domains/development/workflow/1.wf/version/DW6W2hJD0NJeK_EOj5SmPw==) Result: The workflows left nav item should be highlighted
* compare to the same [link in production](https://development.uniondemo.run/console/projects/flytesnacks/domains/development/workflow/1.wf/version/DW6W2hJD0NJeK_EOj5SmPw==) 
<img width="850" alt="image" src="https://user-images.githubusercontent.com/6610300/224097878-975134a8-f74c-4758-ae44-5bf57de4089b.png">
