### PR TITLE
The rendering of node status in a dynamic workflow is not functioning correctly

### DIFF
--- a/packages/console/src/components/Executions/ExecutionDetails/ExecutionNodeViews.tsx
+++ b/packages/console/src/components/Executions/ExecutionDetails/ExecutionNodeViews.tsx
@@ -6,7 +6,7 @@ import { DataError } from 'components/Errors/DataError';
 import { useTabState } from 'components/hooks/useTabState';
 import { secondaryBackgroundColor } from 'components/Theme/constants';
 import { Execution } from 'models/Execution/types';
-import { keyBy } from 'lodash';
+import { clone, keyBy, merge } from 'lodash';
 import { LargeLoadingSpinner } from 'components/common/LoadingSpinner';
 import { FilterOperation } from 'models/AdminEntity/types';
 import { NodeExecutionDetailsContextProvider } from '../contextProvider/NodeExecutionDetails';
@@ -77,7 +77,12 @@ export const ExecutionNodeViews: React.FC<ExecutionNodeViewsProps> = ({
       nodeExecutionsQuery.data,
       'scopedId',
     );
-    setCurrentNodeExecutionsById(currentNodeExecutionsById);
+    const prevNodeExecutionsById = clone(nodeExecutionsById);
+    const newNodeExecutionsById = merge(
+      prevNodeExecutionsById,
+      currentNodeExecutionsById,
+    );
+    setCurrentNodeExecutionsById(newNodeExecutionsById);
   }, [nodeExecutionsQuery.data]);
 
   const LoadingComponent = () => {


### PR DESCRIPTION
https://github.com/flyteorg/flyte/issues/3465

The reproduce steps are described in the issue.

How to fix:
on `ExecutionNodeViews`, it reset the NodeExectuionsById. It should merge with the previous states because it could contain the child nodes' data. If it resets it only with the current top node, then the other nodes' status are undefined.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/3465
