### PR TITLE
Install deps directly in checks.yml

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,7 +32,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - uses: bahmutov/npm-install@v1
+          cache: yarn
+      - name: Install deps
+        run: yarn install --frozen-lockfile
       - name: Run tests and generate coverage
         run: make test_unit_codecov
       - uses: codecov/codecov-action@v1


### PR DESCRIPTION
# TL;DR
Install dependencies using yarn directly

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
As suggested by https://github.com/bahmutov/npm-install/issues/146#issuecomment-1169226551, we can leverage `actions/setup-node@v3` to cache dependencies.

## Tracking Issue
N/A

## Follow-up issue
_NA_
