### PR TITLE
chore: add fallback to task execution link 

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyteorg/console",
-  "version": "0.0.17",
+  "version": "0.0.19",
   "description": "Flyteconsole main app module",
   "main": "./dist/index.js",
   "module": "./lib/index.js",

--- a/packages/console/src/components/Executions/TaskExecutionsList/TaskExecutionLogsCard.tsx
+++ b/packages/console/src/components/Executions/TaskExecutionsList/TaskExecutionLogsCard.tsx
@@ -55,27 +55,31 @@ export const TaskExecutionLogsCard: React.FC<
   } = taskExecution;
 
   const taskHasStarted = phase >= TaskExecutionPhase.QUEUED;
-  const externalProps = { ...props, styles, commonStyles };
+  const defaultHeader = (
+    <Typography
+      variant="h6"
+      className={classnames(styles.title, commonStyles.textWrapped)}
+    >
+      {headerText}
+    </Typography>
+  );
+
+  const externalHeader = registry?.taskExecutionAttemps && (
+    <ExternalConfigHoc
+      ChildComponent={registry.taskExecutionAttemps}
+      data={{
+        ...props,
+        styles,
+        commonStyles,
+        fallback: defaultHeader,
+      }}
+    />
+  );
   return (
     <>
       <section className={styles.section}>
         <header className={styles.header}>
-          {registry?.taskExecutionAttemps ? (
-            // Alternate path
-
-            <ExternalConfigHoc
-              ChildComponent={registry.taskExecutionAttemps}
-              data={externalProps}
-            />
-          ) : (
-            // default path
-            <Typography
-              variant="h6"
-              className={classnames(styles.title, commonStyles.textWrapped)}
-            >
-              {headerText}
-            </Typography>
-          )}
+          {externalHeader || defaultHeader}
         </header>
         <ExecutionStatusBadge phase={phase} type="task" variant="text" />
       </section>

--- a/packages/console/src/models/Task/index.ts
+++ b/packages/console/src/models/Task/index.ts
@@ -1,0 +1,1 @@
+export * from './constants';

--- a/packages/console/src/models/index.ts
+++ b/packages/console/src/models/index.ts
@@ -1,5 +1,5 @@
 export * from './AdminEntity';
 export * from './Execution/enums';
 export * from './Execution/types';
-export { taskSortFields } from './Task/constants';
+export * from './Task';
 export * from './Common/types';


### PR DESCRIPTION
# TL;DR
ContextPanel Allow external hooks to have a fallback header

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Added a fallback option
