### PR TITLE
feat: added support for mapped task parent retryAttempt

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyteorg/console",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "Flyteconsole main app module",
   "main": "./dist/index.js",
   "module": "./lib/index.js",

--- a/packages/console/src/components/Executions/TaskExecutionsList/MapTaskExecutionListItem.tsx
+++ b/packages/console/src/components/Executions/TaskExecutionsList/MapTaskExecutionListItem.tsx
@@ -74,7 +74,6 @@ export const MapTaskExecutionsListItem: React.FC<
           <TaskExecutionError error={error} />
         </section>
       ) : null}
-
       {/* If main map task has log attached - show it here */}
       {logs && logs.length > 0 ? (
         <section className={styles.section}>
@@ -99,7 +98,6 @@ export const MapTaskExecutionsListItem: React.FC<
           />
         );
       })}
-
       {/* If map task is actively started - show 'started' and 'run time' details */}
       {taskHasStarted && (
         <section className={styles.section}>

--- a/packages/console/src/components/Executions/TaskExecutionsList/TaskExecutionLogsCard.tsx
+++ b/packages/console/src/components/Executions/TaskExecutionsList/TaskExecutionLogsCard.tsx
@@ -4,7 +4,7 @@ import Typography from '@material-ui/core/Typography';
 import classnames from 'classnames';
 import { useCommonStyles } from 'components/common/styles';
 import { TaskExecutionPhase } from 'models/Execution/enums';
-import { TaskExecution } from 'models/Execution/types';
+import { MapTaskExecution, TaskExecution } from 'models/Execution/types';
 import { Core } from '@flyteorg/flyteidl-types';
 import { ExternalConfigHoc } from 'basics/ExternalConfigHoc';
 import { useExternalConfigurationContext } from 'basics/ExternalConfigurationProvider';
@@ -36,7 +36,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 interface TaskExecutionLogsCardProps {
-  taskExecution: TaskExecution;
+  taskExecution: TaskExecution | MapTaskExecution;
   headerText: string;
   phase: TaskExecutionPhase;
   logs: Core.ITaskLog[];

--- a/packages/console/src/components/common/MapTaskExecutionsList/TaskNameList.tsx
+++ b/packages/console/src/components/common/MapTaskExecutionsList/TaskNameList.tsx
@@ -64,6 +64,7 @@ export const TaskNameList = ({
           onTaskSelected({
             ...taskExecution,
             taskIndex: (log as any).index,
+            parentRetryAttempt: taskExecution.id.retryAttempt,
           });
         };
 

--- a/packages/console/src/models/Execution/types.ts
+++ b/packages/console/src/models/Execution/types.ts
@@ -118,6 +118,7 @@ export interface TaskExecutionIdentifier extends Core.ITaskExecutionIdentifier {
 }
 export interface MapTaskExecution extends TaskExecution {
   taskIndex: number | null;
+  parentRetryAttempt?: number;
 }
 
 export interface TaskExecution extends Admin.ITaskExecution {

--- a/website/package.json
+++ b/website/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@flyteorg/common": "^0.0.4",
-    "@flyteorg/console": "^0.0.30",
+    "@flyteorg/console": "^0.0.31",
     "long": "^4.0.0",
     "protobufjs": "~6.11.3",
     "react-ga4": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2020,7 +2020,7 @@ __metadata:
   resolution: "@flyteconsole/client-app@workspace:website"
   dependencies:
     "@flyteorg/common": ^0.0.4
-    "@flyteorg/console": ^0.0.30
+    "@flyteorg/console": ^0.0.31
     "@types/long": ^3.0.32
     long: ^4.0.0
     protobufjs: ~6.11.3
@@ -2059,7 +2059,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@flyteorg/console@^0.0.30, @flyteorg/console@workspace:packages/console":
+"@flyteorg/console@^0.0.31, @flyteorg/console@workspace:packages/console":
   version: 0.0.0-use.local
   resolution: "@flyteorg/console@workspace:packages/console"
   dependencies:


### PR DESCRIPTION
## _Read then delete this section_
This PR adds support for a mapped task's parentRetry group provided to the attempts UI.

# TL;DR
Adds more correct context to the attempt UI when working with mapped tasks as the current component assumes only the retryAttempt of the mapped execution, not its parent execution. 

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
_NA_

## Tracking Issue
_NA_
