### PR TITLE
fix: task recent runs should filter by version

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyteorg/console",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "Flyteconsole main app module",
   "main": "./dist/index.js",
   "module": "./lib/index.js",

--- a/packages/console/src/components/Entities/generators.ts
+++ b/packages/console/src/components/Entities/generators.ts
@@ -16,56 +16,55 @@ export const executionFilterGenerator: {
   ) => FilterOperation[];
 } = {
   [ResourceType.DATASET]: noFilters,
-  [ResourceType.LAUNCH_PLAN]: ({ name }, version) =>
-    version
+  [ResourceType.LAUNCH_PLAN]: ({ name }, version) => [
+    {
+      key: 'launch_plan.name',
+      operation: FilterOperationName.EQ,
+      value: name,
+    },
+    ...(version
       ? [
-          {
-            key: 'launch_plan.name',
-            operation: FilterOperationName.EQ,
-            value: name,
-          },
           {
             key: 'launch_plan.version',
             operation: FilterOperationName.EQ,
             value: version,
           },
         ]
-      : [
-          {
-            key: 'launch_plan.name',
-            operation: FilterOperationName.EQ,
-            value: name,
-          },
-        ],
-  [ResourceType.TASK]: ({ name }) => [
+      : []),
+  ],
+  [ResourceType.TASK]: ({ name }, version) => [
     {
       key: 'task.name',
       operation: FilterOperationName.EQ,
       value: name,
     },
-  ],
-  [ResourceType.UNSPECIFIED]: noFilters,
-  [ResourceType.WORKFLOW]: ({ name }, version) =>
-    version
+    ...(version
       ? [
           {
             key: 'workflow.version',
             operation: FilterOperationName.EQ,
             value: version,
           },
+        ]
+      : []),
+  ],
+  [ResourceType.UNSPECIFIED]: noFilters,
+  [ResourceType.WORKFLOW]: ({ name }, version) => [
+    {
+      key: 'workflow.name',
+      operation: FilterOperationName.EQ,
+      value: name,
+    },
+    ...(version
+      ? [
           {
-            key: 'workflow.name',
+            key: 'workflow.version',
             operation: FilterOperationName.EQ,
-            value: name,
+            value: version,
           },
         ]
-      : [
-          {
-            key: 'workflow.name',
-            operation: FilterOperationName.EQ,
-            value: name,
-          },
-        ],
+      : []),
+  ],
 };
 
 const workflowListGenerator = ({ project, domain }: ResourceIdentifier) =>
@@ -75,14 +74,14 @@ const launchPlanListGenerator = ({ project, domain }: ResourceIdentifier) =>
 const taskListGenerator = ({ project, domain }: ResourceIdentifier) =>
   Routes.ProjectDetails.sections.tasks.makeUrl(project, domain);
 const unspecifiedGenerator = ({
-  project,
-  domain,
+  project: _project,
+  domain: _domain,
 }: ResourceIdentifier | Identifier) => {
   throw new Error('Unspecified Resourcetype.');
 };
 const unimplementedGenerator = ({
-  project,
-  domain,
+  project: _project,
+  domain: _domain,
 }: ResourceIdentifier | Identifier) => {
   throw new Error('Method not implemented.');
 };

--- a/website/package.json
+++ b/website/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@flyteorg/common": "^0.0.4",
-    "@flyteorg/console": "^0.0.33",
+    "@flyteorg/console": "^0.0.34",
     "long": "^4.0.0",
     "protobufjs": "~6.11.3",
     "react-ga4": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2020,7 +2020,7 @@ __metadata:
   resolution: "@flyteconsole/client-app@workspace:website"
   dependencies:
     "@flyteorg/common": ^0.0.4
-    "@flyteorg/console": ^0.0.33
+    "@flyteorg/console": ^0.0.34
     "@types/long": ^3.0.32
     long: ^4.0.0
     protobufjs: ~6.11.3
@@ -2059,7 +2059,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@flyteorg/console@^0.0.33, @flyteorg/console@workspace:packages/console":
+"@flyteorg/console@^0.0.34, @flyteorg/console@workspace:packages/console":
   version: 0.0.0-use.local
   resolution: "@flyteorg/console@workspace:packages/console"
   dependencies:


### PR DESCRIPTION
# TL;DR
filters tasks by version

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
filters tasks by version

test on:
[wf1](https://development.uniondemo.run/console/projects/flytesnacks/domains/development/workflows/async_prototype.flytekit_async.wf?duration=all)
[wf2](https://development.uniondemo.run/console/projects/flytesnacks/domains/development/workflows/core.containerization.use_secrets.my_secret_workflow?duration=all)

[task 1](https://development.uniondemo.run/console/projects/flytesnacks/domains/development/tasks/async_prototype.flytekit_async.main?duration=all)
[task 2](https://development.uniondemo.run/console/projects/flytesnacks/domains/development/tasks/async_prototype.flytekit_async.get_data?duration=all)
[task 3](https://development.uniondemo.run/console/projects/flytesnacks/domains/development/tasks/async_prototype.flytekit_async.process_data?duration=all)

[launch plan](https://development.uniondemo.run/console/projects/flytesnacks/domains/development/launchPlans/async_prototype.flytekit_async.wf?duration=all)

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/3538 

## Follow-up issue
_NA_