### PR TITLE
Bug: union val missing for LP relaunch

### DIFF
--- a/packages/console/src/components/Launch/LaunchForm/inputHelpers/test/union.test.ts
+++ b/packages/console/src/components/Launch/LaunchForm/inputHelpers/test/union.test.ts
@@ -1,0 +1,88 @@
+import { Core } from '@flyteorg/flyteidl-types';
+import { unionHelper } from '../union';
+import { InputTypeDefinition } from '../../types';
+
+it('Parse truthy nested union value', () => {
+  const testSubjectLiteral = {
+    scalar: {
+      union: {
+        value: { scalar: { primitive: { stringValue: 'hello' } } },
+        type: { structure: { tag: 'str' }, simple: 3 },
+      },
+    },
+  } as Core.ILiteral;
+
+  const testSubjectTypeDefinition = {
+    literalType: {
+      unionType: {
+        variants: [
+          { structure: { tag: 'str' }, simple: 3 },
+          { structure: { tag: 'none' }, simple: 0 },
+        ],
+      },
+    },
+    type: 'Union',
+    listOfSubTypes: [
+      {
+        literalType: { structure: { tag: 'str' }, simple: 3 },
+        type: 'STRING',
+      },
+      {
+        literalType: { structure: { tag: 'none' }, simple: 0 },
+        type: 'NONE',
+      },
+    ],
+  } as InputTypeDefinition;
+
+  const expected = {
+    typeDefinition: {
+      literalType: { simple: 3, structure: { tag: 'str' } },
+      type: 'STRING',
+    },
+    value: 'hello',
+  };
+
+  const result = unionHelper.fromLiteral(
+    testSubjectLiteral,
+    testSubjectTypeDefinition,
+  );
+
+  expect(expected).toStrictEqual(result);
+});
+
+it('Parse truthy union value', () => {
+  const testSubjectLiteral = {
+    scalar: { primitive: { stringValue: 'hello' } },
+  } as Core.ILiteral;
+
+  const testSubjectTypeDefinition = {
+    literalType: {
+      unionType: {
+        variants: [
+          { structure: { tag: 'str' }, simple: 3 },
+          { structure: { tag: 'none' }, simple: 0 },
+        ],
+      },
+    },
+    type: 'Union',
+    listOfSubTypes: [
+      { literalType: { structure: { tag: 'str' }, simple: 3 }, type: 'STRING' },
+      { literalType: { structure: { tag: 'none' }, simple: 0 }, type: 'NONE' },
+    ],
+  } as InputTypeDefinition;
+
+  const expected = {
+    typeDefinition: {
+      literalType: { simple: 3, structure: { tag: 'str' } },
+      type: 'STRING',
+    },
+    value: 'hello',
+  };
+
+  const result = unionHelper.fromLiteral(
+    testSubjectLiteral,
+    testSubjectTypeDefinition,
+  );
+
+  expect(expected).toStrictEqual(result);
+});

--- a/packages/console/src/components/Launch/LaunchForm/inputHelpers/union.ts
+++ b/packages/console/src/components/Launch/LaunchForm/inputHelpers/union.ts
@@ -14,11 +14,16 @@ function fromLiteral(
     throw new Error(t('missingUnionListOfSubType'));
   }
 
-  // loop though the subtypes to find the correct match literal type
+  // Unpack nested variant of union data value
+  const literalValue = literal?.scalar?.union?.value
+    ? literal.scalar.union.value
+    : literal;
+
+  // loop though the subtypes to find the correct match literal typex`
   for (let i = 0; i < listOfSubTypes.length; i++) {
     try {
       const value = getHelperForInput(listOfSubTypes[i].type).fromLiteral(
-        literal,
+        literalValue,
         listOfSubTypes[i],
       );
       return { value, typeDefinition: listOfSubTypes[i] } as UnionValue;


### PR DESCRIPTION
# TL;DR
Fixed parsing for a more verbose variant of the union data type in the relaunch modal's parsers. This data structure is present on the first relaunch.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [X] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
Added a check to see if the input value is nested and pass the child nested value to the parser.

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/3690

## Follow-up issue
_NA_
