### PR TITLE
chore: hide map task runtime info

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyteorg/console",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "description": "Flyteconsole main app module",
   "main": "./dist/index.js",
   "module": "./lib/index.js",

--- a/packages/console/src/components/Executions/TaskExecutionsList/MapTaskExecutionListItem.tsx
+++ b/packages/console/src/components/Executions/TaskExecutionsList/MapTaskExecutionListItem.tsx
@@ -7,6 +7,7 @@ import { useCommonStyles } from 'components/common/styles';
 import { TaskExecutionPhase } from 'models/Execution/enums';
 import { MapTaskExecution, TaskExecution } from 'models/Execution/types';
 import { MapTaskStatusInfo } from 'components/common/MapTaskExecutionsList/MapTaskStatusInfo';
+import { isMapTaskV1 } from 'models';
 import { TaskExecutionDetails } from './TaskExecutionDetails';
 import { TaskExecutionError } from './TaskExecutionError';
 import { TaskExecutionLogs } from './TaskExecutionLogs';
@@ -46,12 +47,28 @@ export const MapTaskExecutionsListItem: React.FC<
   const styles = useStyles();
 
   const {
-    closure: { error, startedAt, updatedAt, duration, phase, logs, metadata },
+    closure: {
+      error,
+      startedAt,
+      updatedAt,
+      duration,
+      phase,
+      logs,
+      metadata,
+      eventVersion,
+      taskType,
+    },
     id: { retryAttempt },
   } = taskExecution;
   const taskHasStarted = phase >= TaskExecutionPhase.QUEUED;
   const headerText = formatRetryAttempt(retryAttempt);
   const logsByPhase = getGroupedLogs(metadata?.externalResources ?? []);
+
+  const isMapTask = isMapTaskV1(
+    eventVersion!,
+    metadata?.externalResources?.length ?? 0,
+    taskType ?? undefined,
+  );
 
   return (
     <PanelSection>
@@ -99,7 +116,7 @@ export const MapTaskExecutionsListItem: React.FC<
         );
       })}
       {/* If map task is actively started - show 'started' and 'run time' details */}
-      {taskHasStarted && (
+      {taskHasStarted && !isMapTask && (
         <section className={styles.section}>
           <TaskExecutionDetails
             startedAt={startedAt}

--- a/packages/console/src/components/Executions/TaskExecutionsList/TaskExecutionLogsCard.tsx
+++ b/packages/console/src/components/Executions/TaskExecutionsList/TaskExecutionLogsCard.tsx
@@ -8,6 +8,7 @@ import { MapTaskExecution, TaskExecution } from 'models/Execution/types';
 import { Core } from '@flyteorg/flyteidl-types';
 import { ExternalConfigHoc } from 'basics/ExternalConfigHoc';
 import { useExternalConfigurationContext } from 'basics/ExternalConfigurationProvider';
+import { isMapTaskV1 } from 'models';
 import { ExecutionStatusBadge } from '../ExecutionStatusBadge';
 import { TaskExecutionDetails } from './TaskExecutionDetails';
 import { TaskExecutionError } from './TaskExecutionError';
@@ -52,7 +53,15 @@ export const TaskExecutionLogsCard: React.FC<
   const { registry } = useExternalConfigurationContext();
 
   const {
-    closure: { error, startedAt, updatedAt, duration },
+    closure: {
+      error,
+      startedAt,
+      updatedAt,
+      duration,
+      metadata,
+      eventVersion,
+      taskType,
+    },
   } = taskExecution;
 
   const taskHasStarted = phase >= TaskExecutionPhase.QUEUED;
@@ -76,6 +85,12 @@ export const TaskExecutionLogsCard: React.FC<
       }}
     />
   );
+
+  const isMapTask = isMapTaskV1(
+    eventVersion!,
+    metadata?.externalResources?.length ?? 0,
+    taskType ?? undefined,
+  );
   return (
     <>
       <section className={styles.section}>
@@ -94,13 +109,15 @@ export const TaskExecutionLogsCard: React.FC<
           <section className={styles.section}>
             <TaskExecutionLogs taskLogs={logs ?? []} />
           </section>
-          <section className={styles.section}>
-            <TaskExecutionDetails
-              startedAt={startedAt}
-              updatedAt={updatedAt}
-              duration={duration}
-            />
-          </section>
+          {!isMapTask && (
+            <section className={styles.section}>
+              <TaskExecutionDetails
+                startedAt={startedAt}
+                updatedAt={updatedAt}
+                duration={duration}
+              />
+            </section>
+          )}
         </>
       )}
     </>

--- a/website/package.json
+++ b/website/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@flyteorg/common": "^0.0.4",
-    "@flyteorg/console": "^0.0.35",
+    "@flyteorg/console": "^0.0.36",
     "long": "^4.0.0",
     "protobufjs": "~6.11.3",
     "react-ga4": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2020,7 +2020,7 @@ __metadata:
   resolution: "@flyteconsole/client-app@workspace:website"
   dependencies:
     "@flyteorg/common": ^0.0.4
-    "@flyteorg/console": ^0.0.35
+    "@flyteorg/console": ^0.0.36
     "@types/long": ^3.0.32
     long: ^4.0.0
     protobufjs: ~6.11.3
@@ -2059,7 +2059,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@flyteorg/console@^0.0.35, @flyteorg/console@workspace:packages/console":
+"@flyteorg/console@^0.0.36, @flyteorg/console@workspace:packages/console":
   version: 0.0.0-use.local
   resolution: "@flyteorg/console@workspace:packages/console"
   dependencies:


### PR DESCRIPTION
# TL;DR
Hide map task runtime info
Before :
<img width="430" alt="image" src="https://github.com/flyteorg/flyteconsole/assets/6610300/b3c94376-9634-4353-a6e3-fe51f721c859">
After:
<img width="432" alt="image" src="https://github.com/flyteorg/flyteconsole/assets/6610300/55b62e4f-543b-4a3b-b49f-aacc2b090dd7">
Before:
<img width="429" alt="image" src="https://github.com/flyteorg/flyteconsole/assets/6610300/4b6388b0-aa29-435c-af1c-604b6d9e1c05">

After:
<img width="436" alt="image" src="https://github.com/flyteorg/flyteconsole/assets/6610300/d78f5a55-2c87-4660-8378-f332b612df8c">

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Hide map task runtime info

## Tracking Issue
_NA_
