### PR TITLE
wip: simple way to audit npm package licenses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,9 @@ yarn-error.log
 # We always want them in repository, since they are necessary to install dependencies.
 !.yarn/patches
 
+# license audit
+licenses.txt
+
 # Certs
 .srl
 certificate/

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "test": "NODE_ENV=test BASE_URL=/console jest",
     "test:clear": "jest --clearCache",
     "test-coverage": "NODE_ENV=test BASE_URL=/console jest --coverage",
-    "test-release": "npx semantic-release --debug --no-ci --test-run"
+    "test-release": "npx semantic-release --debug --no-ci --test-run",
+    "licenses": "npx nlf \\ -y > licenses.txt \\ echo 'License audit complete! \n View licenses.txt for results.'"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
# TL;DR
Generates a file to produce a summary of licenses used within the project.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Added a `licenses` script to `package.json`. It prints a 

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
