### PR TITLE
Add localStorage for selected Project/Domain

### DIFF
--- a/packages/console/src/components/Navigation/ProjectNavigation.tsx
+++ b/packages/console/src/components/Navigation/ProjectNavigation.tsx
@@ -14,6 +14,10 @@ import { matchPath, NavLinkProps, RouteComponentProps } from 'react-router-dom';
 import { history } from 'routes/history';
 import { Routes } from 'routes/routes';
 import { MuiLaunchPlanIcon } from '@flyteorg/ui-atoms';
+import {
+  LOCAL_PROJECT_DOMAIN,
+  setLocalStore,
+} from 'components/common/LocalStoreDefaults';
 import { primaryHighlightColor } from 'components/Theme/constants';
 import { ProjectSelector } from './ProjectSelector';
 import NavLinkWithSearch from './NavLinkWithSearch';
@@ -72,6 +76,12 @@ const ProjectNavigationImpl: React.FC<ProjectNavigationRouteParams> = ({
   const projects = useProjects();
   const onProjectSelected = (project: Project) => {
     const path = Routes.ProjectDetails.makeUrl(project.id, section);
+    const projectDomain = {
+      project: project.id,
+      domain: domainId || 'development',
+    };
+    /* Store user intent in localStorage */
+    setLocalStore(LOCAL_PROJECT_DOMAIN, projectDomain);
     return history.push(path);
   };
 

--- a/packages/console/src/components/Navigation/ProjectNavigation.tsx
+++ b/packages/console/src/components/Navigation/ProjectNavigation.tsx
@@ -70,8 +70,10 @@ const ProjectNavigationImpl: React.FC<ProjectNavigationRouteParams> = ({
   const commonStyles = useCommonStyles();
   const project = useProject(projectId);
   const projects = useProjects();
-  const onProjectSelected = (project: Project) =>
-    history.push(Routes.ProjectDetails.makeUrl(project.id, section));
+  const onProjectSelected = (project: Project) => {
+    const path = Routes.ProjectDetails.makeUrl(project.id, section);
+    return history.push(path);
+  };
 
   const routes: ProjectRoute[] = [
     {

--- a/packages/console/src/components/Navigation/ProjectSelector.tsx
+++ b/packages/console/src/components/Navigation/ProjectSelector.tsx
@@ -7,8 +7,6 @@ import { useCommonStyles } from 'components/common/styles';
 import { listhoverColor } from 'components/Theme/constants';
 import { Project } from 'models/Project/types';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
-import { Routes } from 'routes';
 import { SearchableProjectList } from './SearchableProjectList';
 
 const expanderGridHeight = 12;

--- a/packages/console/src/components/Navigation/ProjectSelector.tsx
+++ b/packages/console/src/components/Navigation/ProjectSelector.tsx
@@ -83,16 +83,6 @@ export const ProjectSelector: React.FC<ProjectSelectorProps> = ({
     }
   };
 
-  const projectsNav = React.useMemo(() => {
-    const viewAllProjects = {
-      id: Routes.SelectProject.id,
-      name: 'View All Projects',
-      description: 'Project overview page',
-      domains: [],
-    } as Project;
-    return [viewAllProjects, ...projects];
-  }, [projects]);
-
   return (
     <div onKeyDownCapture={onKeyDown}>
       <ButtonBase
@@ -118,7 +108,7 @@ export const ProjectSelector: React.FC<ProjectSelectorProps> = ({
         <div className={styles.listContainer}>
           <SearchableProjectList
             onProjectSelected={onSelect}
-            projects={projectsNav}
+            projects={projects}
           />
         </div>
       )}

--- a/packages/console/src/components/Navigation/ProjectSelector.tsx
+++ b/packages/console/src/components/Navigation/ProjectSelector.tsx
@@ -1,3 +1,4 @@
+import { makeRoute } from '@flyteorg/common';
 import ButtonBase from '@material-ui/core/ButtonBase';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import ExpandMore from '@material-ui/icons/ExpandMore';
@@ -7,6 +8,7 @@ import { useCommonStyles } from 'components/common/styles';
 import { listhoverColor } from 'components/Theme/constants';
 import { Project } from 'models/Project/types';
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import { SearchableProjectList } from './SearchableProjectList';
 
 const expanderGridHeight = 12;
@@ -40,6 +42,15 @@ const useStyles = makeStyles((theme: Theme) => ({
     overflowY: 'scroll',
     top: theme.spacing(expanderGridHeight),
     width: '100%',
+  },
+  viewProjects: {
+    display: 'flex',
+    padding: '.25rem',
+    justifyContent: 'flex-end',
+    color: theme.palette.text.primary,
+    fontSize: theme.typography.body1.fontSize,
+    textAlign: 'right',
+    textDecoration: 'none',
   },
 }));
 
@@ -95,6 +106,9 @@ export const ProjectSelector: React.FC<ProjectSelectorProps> = ({
       </ButtonBase>
       {expanded && (
         <div className={styles.listContainer}>
+          <Link className={styles.viewProjects} to={makeRoute('/select')}>
+            View All Projects
+          </Link>
           <SearchableProjectList
             onProjectSelected={onSelect}
             projects={projects}

--- a/packages/console/src/components/Navigation/ProjectSelector.tsx
+++ b/packages/console/src/components/Navigation/ProjectSelector.tsx
@@ -1,4 +1,3 @@
-import { makeRoute } from '@flyteorg/common';
 import ButtonBase from '@material-ui/core/ButtonBase';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import ExpandMore from '@material-ui/icons/ExpandMore';

--- a/packages/console/src/components/Navigation/ProjectSelector.tsx
+++ b/packages/console/src/components/Navigation/ProjectSelector.tsx
@@ -9,6 +9,7 @@ import { listhoverColor } from 'components/Theme/constants';
 import { Project } from 'models/Project/types';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+import { Routes } from 'routes';
 import { SearchableProjectList } from './SearchableProjectList';
 
 const expanderGridHeight = 12;
@@ -106,7 +107,7 @@ export const ProjectSelector: React.FC<ProjectSelectorProps> = ({
       </ButtonBase>
       {expanded && (
         <div className={styles.listContainer}>
-          <Link className={styles.viewProjects} to={makeRoute('/select')}>
+          <Link className={styles.viewProjects} to={Routes.SelectProject.path}>
             View All Projects
           </Link>
           <SearchableProjectList

--- a/packages/console/src/components/Navigation/ProjectSelector.tsx
+++ b/packages/console/src/components/Navigation/ProjectSelector.tsx
@@ -84,6 +84,16 @@ export const ProjectSelector: React.FC<ProjectSelectorProps> = ({
     }
   };
 
+  const projectsNav = React.useMemo(() => {
+    const viewAllProjects = {
+      id: Routes.SelectProject.id,
+      name: 'View All Projects',
+      description: 'Project overview page',
+      domains: [],
+    } as Project;
+    return [viewAllProjects, ...projects];
+  }, [projects]);
+
   return (
     <div onKeyDownCapture={onKeyDown}>
       <ButtonBase
@@ -107,12 +117,9 @@ export const ProjectSelector: React.FC<ProjectSelectorProps> = ({
       </ButtonBase>
       {expanded && (
         <div className={styles.listContainer}>
-          <Link className={styles.viewProjects} to={Routes.SelectProject.path}>
-            View All Projects
-          </Link>
           <SearchableProjectList
             onProjectSelected={onSelect}
-            projects={projects}
+            projects={projectsNav}
           />
         </div>
       )}

--- a/packages/console/src/components/Navigation/SearchableProjectList.tsx
+++ b/packages/console/src/components/Navigation/SearchableProjectList.tsx
@@ -1,5 +1,6 @@
-import { Fade, Tooltip, Typography } from '@material-ui/core';
+import { Box, Fade, Grid, Icon, Tooltip, Typography } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
+import { KeyboardArrowRight } from '@material-ui/icons';
 import classnames from 'classnames';
 import { NoResults } from 'components/common/NoResults';
 import { SearchableList, SearchResult } from 'components/common/SearchableList';
@@ -8,6 +9,7 @@ import { defaultProjectDescription } from 'components/SelectProject/constants';
 import { primaryHighlightColor } from 'components/Theme/constants';
 import { Project } from 'models/Project/types';
 import * as React from 'react';
+import { Routes } from 'routes';
 
 const useStyles = makeStyles((theme: Theme) => ({
   container: {
@@ -76,7 +78,22 @@ const SearchResults: React.FC<SearchResultsProps> = ({
             <div
               className={classnames(styles.itemName, commonStyles.textWrapped)}
             >
-              {content}
+              <Grid
+                container
+                justifyContent="space-between"
+                alignItems="center"
+              >
+                <Grid item>
+                  <Box>{content}</Box>
+                </Grid>
+                {value.id === Routes.SelectProject.id && (
+                  <Grid item>
+                    <Icon>
+                      <KeyboardArrowRight />
+                    </Icon>
+                  </Grid>
+                )}
+              </Grid>
             </div>
           </div>
         </Tooltip>

--- a/packages/console/src/components/Navigation/SearchableProjectList.tsx
+++ b/packages/console/src/components/Navigation/SearchableProjectList.tsx
@@ -50,55 +50,102 @@ const SearchResults: React.FC<SearchResultsProps> = ({
   onProjectSelected,
   results,
 }) => {
+  const viewAllProjects = {
+    id: Routes.SelectProject.id,
+    name: 'View All Projects',
+    description: 'View All Projects',
+    domains: [],
+  } as Project;
+
   const commonStyles = useCommonStyles();
   const styles = useStyles();
-  return results.length === 0 ? (
-    <NoResults />
-  ) : (
-    <ul className={commonStyles.listUnstyled}>
-      {results.map(({ content, value }) => (
-        <Tooltip
-          TransitionComponent={Fade}
-          key={value.id}
-          placement="bottom-end"
-          enterDelay={500}
-          title={
-            <Typography variant="body1">
-              <div className={commonStyles.textMonospace}>{value.id}</div>
-              <div>
-                <em>{value.description || defaultProjectDescription}</em>
-              </div>
-            </Typography>
-          }
-        >
-          <div
-            className={styles.searchResult}
-            onClick={onProjectSelected.bind(null, value)}
-          >
-            <div
-              className={classnames(styles.itemName, commonStyles.textWrapped)}
-            >
-              <Grid
-                container
-                justifyContent="space-between"
-                alignItems="center"
-              >
-                <Grid item>
-                  <Box>{content}</Box>
-                </Grid>
-                {value.id === Routes.SelectProject.id && (
-                  <Grid item>
-                    <Icon>
-                      <KeyboardArrowRight />
-                    </Icon>
-                  </Grid>
-                )}
-              </Grid>
+  return (
+    <>
+      <Tooltip
+        TransitionComponent={Fade}
+        placement="bottom-end"
+        enterDelay={500}
+        title={
+          <Typography variant="body1">
+            <div className={commonStyles.textMonospace}>
+              {viewAllProjects.description}
             </div>
-          </div>
-        </Tooltip>
-      ))}
-    </ul>
+          </Typography>
+        }
+      >
+        <Grid
+          container
+          justifyContent="space-between"
+          alignItems="center"
+          className={styles.searchResult}
+          onClick={() => onProjectSelected(viewAllProjects)}
+        >
+          <Grid item>
+            <Typography color="primary" className={styles.itemName}>
+              {viewAllProjects.name}
+            </Typography>
+          </Grid>
+          <Grid item>
+            <Icon color="primary">
+              <KeyboardArrowRight />
+            </Icon>
+          </Grid>
+        </Grid>
+      </Tooltip>
+      {!results ? (
+        <NoResults />
+      ) : (
+        <ul className={commonStyles.listUnstyled}>
+          <li>
+            {results.map(({ content, value }) => (
+              <Tooltip
+                TransitionComponent={Fade}
+                key={value.id}
+                placement="bottom-end"
+                enterDelay={500}
+                title={
+                  <Typography variant="body1">
+                    <div className={commonStyles.textMonospace}>{value.id}</div>
+                    <div>
+                      <em>{value.description || defaultProjectDescription}</em>
+                    </div>
+                  </Typography>
+                }
+              >
+                <div
+                  className={styles.searchResult}
+                  onClick={onProjectSelected.bind(null, value)}
+                >
+                  <div
+                    className={classnames(
+                      styles.itemName,
+                      commonStyles.textWrapped,
+                    )}
+                  >
+                    <Grid
+                      container
+                      justifyContent="space-between"
+                      alignItems="center"
+                    >
+                      <Grid item>
+                        <Box>{content}</Box>
+                      </Grid>
+                      {value.id === Routes.SelectProject.id && (
+                        <Grid item>
+                          <Icon color="primary">
+                            <KeyboardArrowRight />
+                          </Icon>
+                        </Grid>
+                      )}
+                    </Grid>
+                  </div>
+                </div>
+              </Tooltip>
+            ))}
+          </li>
+        </ul>
+      )}
+    </>
   );
 };
 

--- a/packages/console/src/components/Navigation/SearchableProjectList.tsx
+++ b/packages/console/src/components/Navigation/SearchableProjectList.tsx
@@ -92,7 +92,7 @@ const SearchResults: React.FC<SearchResultsProps> = ({
           </Grid>
         </Grid>
       </Tooltip>
-      {!results ? (
+      {!results.length ? (
         <NoResults />
       ) : (
         <ul className={commonStyles.listUnstyled}>

--- a/packages/console/src/components/Navigation/SearchableProjectList.tsx
+++ b/packages/console/src/components/Navigation/SearchableProjectList.tsx
@@ -1,6 +1,5 @@
-import { Box, Fade, Grid, Icon, Tooltip, Typography } from '@material-ui/core';
+import { Box, Fade, Grid, Tooltip, Typography } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
-import { KeyboardArrowRight } from '@material-ui/icons';
 import classnames from 'classnames';
 import { NoResults } from 'components/common/NoResults';
 import { SearchableList, SearchResult } from 'components/common/SearchableList';
@@ -82,13 +81,8 @@ const SearchResults: React.FC<SearchResultsProps> = ({
         >
           <Grid item>
             <Typography color="primary" className={styles.itemName}>
-              {viewAllProjects.name}
+              {viewAllProjects.name}…
             </Typography>
-          </Grid>
-          <Grid item>
-            <Icon color="primary">
-              <KeyboardArrowRight />
-            </Icon>
           </Grid>
         </Grid>
       </Tooltip>
@@ -130,13 +124,6 @@ const SearchResults: React.FC<SearchResultsProps> = ({
                       <Grid item>
                         <Box>{content}</Box>
                       </Grid>
-                      {value.id === Routes.SelectProject.id && (
-                        <Grid item>
-                          <Icon color="primary">
-                            <KeyboardArrowRight />
-                          </Icon>
-                        </Grid>
-                      )}
                     </Grid>
                   </div>
                 </div>

--- a/packages/console/src/components/Project/ProjectDashboard.tsx
+++ b/packages/console/src/components/Project/ProjectDashboard.tsx
@@ -1,5 +1,5 @@
 import { makeStyles, Theme } from '@material-ui/core/styles';
-import * as React from 'react';
+import React, { useEffect } from 'react';
 import { Typography } from '@material-ui/core';
 import {
   useTaskNameList,
@@ -37,6 +37,7 @@ import {
   getProjectAttributes,
   getProjectDomainAttributes,
 } from 'models/Project/api';
+import { LocalStoreDefaults, LOCAL_STORE_DEFAULTS } from 'routes';
 import t from './strings';
 import { failedToLoadExecutionsString } from './constants';
 
@@ -77,6 +78,19 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = ({
   domainId: domain,
   projectId: project,
 }) => {
+  /**
+   * The last project/domain viewed by a user is saved here and used by
+   * ApplicationRouter to bypass the project select UX if this value
+   * exists
+   */
+  useEffect(() => {
+    const projectDomain: LocalStoreDefaults = {
+      domain: domain,
+      project: project,
+    };
+    localStorage.setItem(LOCAL_STORE_DEFAULTS, JSON.stringify(projectDomain));
+  }, []);
+
   const styles = useStyles();
   const archivedFilter = useExecutionShowArchivedState();
   const filtersState = useWorkflowExecutionFiltersState();

--- a/packages/console/src/components/Project/ProjectDashboard.tsx
+++ b/packages/console/src/components/Project/ProjectDashboard.tsx
@@ -1,5 +1,5 @@
 import { makeStyles, Theme } from '@material-ui/core/styles';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Typography } from '@material-ui/core';
 import {
   useTaskNameList,
@@ -37,7 +37,6 @@ import {
   getProjectAttributes,
   getProjectDomainAttributes,
 } from 'models/Project/api';
-import { LocalStoreDefaults, LOCAL_STORE_DEFAULTS } from 'routes';
 import t from './strings';
 import { failedToLoadExecutionsString } from './constants';
 

--- a/packages/console/src/components/Project/ProjectDashboard.tsx
+++ b/packages/console/src/components/Project/ProjectDashboard.tsx
@@ -78,19 +78,6 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = ({
   domainId: domain,
   projectId: project,
 }) => {
-  /**
-   * The last project/domain viewed by a user is saved here and used by
-   * ApplicationRouter to bypass the project select UX if this value
-   * exists
-   */
-  useEffect(() => {
-    const projectDomain: LocalStoreDefaults = {
-      domain: domain,
-      project: project,
-    };
-    localStorage.setItem(LOCAL_STORE_DEFAULTS, JSON.stringify(projectDomain));
-  }, []);
-
   const styles = useStyles();
   const archivedFilter = useExecutionShowArchivedState();
   const filtersState = useWorkflowExecutionFiltersState();

--- a/packages/console/src/components/SelectProject/ProjectList.tsx
+++ b/packages/console/src/components/SelectProject/ProjectList.tsx
@@ -10,6 +10,7 @@ import { ButtonLink } from 'components/common/ButtonLink';
 import { useCommonStyles } from 'components/common/styles';
 import { Project } from 'models/Project/types';
 import * as React from 'react';
+import { LocalStoreDefaults, LOCAL_STORE_DEFAULTS } from 'routes';
 import { Routes } from 'routes/routes';
 import { defaultProjectDescription } from './constants';
 
@@ -59,6 +60,22 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
             color="primary"
             key={domainId}
             component={ButtonLink}
+            onClick={() => {
+              /**
+               * The last project/domain selected by a user is saved here and used by
+               * ApplicationRouter to bypass the project select UX when reopening the
+               * application if this value
+               * exists
+               */
+              const projectDomain: LocalStoreDefaults = {
+                domain: domainId,
+                project: project.name,
+              };
+              localStorage.setItem(
+                LOCAL_STORE_DEFAULTS,
+                JSON.stringify(projectDomain),
+              );
+            }}
             to={Routes.ProjectDetails.sections.dashboard.makeUrl(
               project.id,
               domainId,

--- a/packages/console/src/components/SelectProject/ProjectList.tsx
+++ b/packages/console/src/components/SelectProject/ProjectList.tsx
@@ -7,10 +7,14 @@ import {
 } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import { ButtonLink } from 'components/common/ButtonLink';
+import {
+  LocalStorageProjectDomain,
+  LOCAL_PROJECT_DOMAIN,
+  setLocalStore,
+} from 'components/common/LocalStoreDefaults';
 import { useCommonStyles } from 'components/common/styles';
 import { Project } from 'models/Project/types';
 import * as React from 'react';
-import { LocalStoreDefaults, LOCAL_STORE_DEFAULTS } from 'routes';
 import { Routes } from 'routes/routes';
 import { defaultProjectDescription } from './constants';
 
@@ -67,14 +71,11 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
                * application if this value
                * exists
                */
-              const projectDomain: LocalStoreDefaults = {
+              const projectDomain: LocalStorageProjectDomain = {
                 domain: domainId,
                 project: project.name,
               };
-              localStorage.setItem(
-                LOCAL_STORE_DEFAULTS,
-                JSON.stringify(projectDomain),
-              );
+              setLocalStore(LOCAL_PROJECT_DOMAIN, projectDomain);
             }}
             to={Routes.ProjectDetails.sections.dashboard.makeUrl(
               project.id,

--- a/packages/console/src/components/common/LocalStoreDefaults.ts
+++ b/packages/console/src/components/common/LocalStoreDefaults.ts
@@ -30,19 +30,18 @@ export interface LocalStoreDefaults {
  */
 export const getLocalStore = (key: string | null = null): any | false => {
   const localStoreDefaults = localStorage.getItem(LOCAL_STORE_DEFAULTS);
-  if (localStoreDefaults) {
-    const localJSON = JSON.parse(localStoreDefaults) as LocalStoreDefaults;
-    if (key) {
-      if (localJSON[key]) {
-        return localJSON[key];
-      } else {
-        return false;
-      }
+  if (!localStoreDefaults) {
+    return false;
+  }
+  const localJSON = JSON.parse(localStoreDefaults) as LocalStoreDefaults;
+  if (key) {
+    if (localJSON[key]) {
+      return localJSON[key];
     } else {
-      return localJSON;
+      return false;
     }
   } else {
-    return false;
+    return localJSON;
   }
 };
 
@@ -50,13 +49,10 @@ export const getLocalStore = (key: string | null = null): any | false => {
  * Sets values to 'flyteDefaults' for use in persisting various user defaults.
  */
 export const setLocalStore = (key: string, value: any) => {
-  const localStoreDefaults = localStorage.getItem(LOCAL_STORE_DEFAULTS);
-  let newRecord;
-  if (localStoreDefaults) {
-    newRecord = JSON.parse(localStoreDefaults) as LocalStoreDefaults;
-    newRecord[key] = value;
-  } else {
-    newRecord = { [key]: value };
-  }
-  localStorage.setItem(LOCAL_STORE_DEFAULTS, JSON.stringify(newRecord));
+  const localStoreDefaults = localStorage.getItem(LOCAL_STORE_DEFAULTS) || '{}';
+  const storeDefaultsJSON = JSON.parse(
+    localStoreDefaults,
+  ) as LocalStoreDefaults;
+  storeDefaultsJSON[key] = value;
+  localStorage.setItem(LOCAL_STORE_DEFAULTS, JSON.stringify(storeDefaultsJSON));
 };

--- a/packages/console/src/components/common/LocalStoreDefaults.ts
+++ b/packages/console/src/components/common/LocalStoreDefaults.ts
@@ -1,0 +1,62 @@
+export const LOCAL_STORE_DEFAULTS = 'flyteDefaults';
+export const LOCAL_PROJECT_DOMAIN = 'projectDomain';
+
+export interface LocalStorageRecord {
+  [key: string]: any;
+}
+
+/**
+ * Use: skipping project select page is value is present
+ */
+export type LocalStorageProjectDomain = {
+  project: string;
+  domain: string;
+};
+
+/**
+ * Generic localStorage interface
+ */
+export interface LocalStoreDefaults {
+  projectDomain?: LocalStorageProjectDomain;
+}
+
+/**
+ * Queries localStorage for flye values. If a query key is provided it will
+ * check for only that key (and return false otherwise) else return the entire
+ * JSON
+ *
+ * @param key   Optional param to return just one key from localStorage
+ * @returns     value or false
+ */
+export const getLocalStore = (key: string | null = null): any | false => {
+  const localStoreDefaults = localStorage.getItem(LOCAL_STORE_DEFAULTS);
+  if (localStoreDefaults) {
+    const localJSON = JSON.parse(localStoreDefaults) as LocalStoreDefaults;
+    if (key) {
+      if (localJSON[key]) {
+        return localJSON[key];
+      } else {
+        return false;
+      }
+    } else {
+      return localJSON;
+    }
+  } else {
+    return false;
+  }
+};
+
+/**
+ * Sets values to 'flyteDefaults' for use in persisting various user defaults.
+ */
+export const setLocalStore = (key: string, value: any) => {
+  const localStoreDefaults = localStorage.getItem(LOCAL_STORE_DEFAULTS);
+  let newRecord;
+  if (localStoreDefaults) {
+    newRecord = JSON.parse(localStoreDefaults) as LocalStoreDefaults;
+    newRecord[key] = value;
+  } else {
+    newRecord = { [key]: value };
+  }
+  localStorage.setItem(LOCAL_STORE_DEFAULTS, JSON.stringify(newRecord));
+};

--- a/packages/console/src/routes/ApplicationRouter.tsx
+++ b/packages/console/src/routes/ApplicationRouter.tsx
@@ -4,14 +4,15 @@ import {
 } from 'components/common/ContentContainer';
 import { withSideNavigation } from 'components/Navigation/withSideNavigation';
 import * as React from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Redirect, Route, Switch } from 'react-router-dom';
 import { useExternalConfigurationContext } from 'basics/ExternalConfigurationProvider';
 import { Toolbar } from '@material-ui/core';
 import { styled } from '@material-ui/core/styles';
 import { subnavBarContentId } from 'common/constants';
 import { subnavBackgroundColor } from 'components/Theme/constants';
+import { makeRoute } from '@flyteorg/common';
 import { components } from './components';
-import { Routes } from './routes';
+import { makeProjectBoundPath, Routes } from './routes';
 
 const StyledSubNavBarContent = styled(Toolbar)(() => ({
   minHeight: 'auto',
@@ -87,6 +88,25 @@ export const ApplicationRouter: React.FC = () => {
         path={Routes.SelectProject.path}
         exact={true}
         component={withContentContainer(components.selectProject)}
+      />
+      <Route
+        path={makeRoute('/')}
+        render={() => {
+          // check if value exists in local storage
+          const localStoreProject = 'onboarding';
+          const localStoreDomain = 'development';
+          if (localStoreProject && localStoreDomain) {
+            return (
+              <Redirect
+                to={`${makeRoute(
+                  '/',
+                )}/projects/${localStoreProject}/executions?domain=${localStoreDomain}&duration=all`}
+              />
+            );
+          } else {
+            return <Redirect to={makeRoute('/select')} />;
+          }
+        }}
       />
       <Route component={withContentContainer(components.notFound)} />
     </Switch>

--- a/packages/console/src/routes/ApplicationRouter.tsx
+++ b/packages/console/src/routes/ApplicationRouter.tsx
@@ -3,7 +3,7 @@ import {
   ContentContainerProps,
 } from 'components/common/ContentContainer';
 import { withSideNavigation } from 'components/Navigation/withSideNavigation';
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { useExternalConfigurationContext } from 'basics/ExternalConfigurationProvider';
 import { Toolbar } from '@material-ui/core';
@@ -11,6 +11,11 @@ import { styled } from '@material-ui/core/styles';
 import { subnavBarContentId } from 'common/constants';
 import { subnavBackgroundColor } from 'components/Theme/constants';
 import { makeRoute } from '@flyteorg/common';
+import {
+  getLocalStore,
+  LocalStorageProjectDomain,
+  LOCAL_PROJECT_DOMAIN,
+} from 'components/common/LocalStoreDefaults';
 import { components } from './components';
 import { Routes } from './routes';
 
@@ -46,22 +51,11 @@ export function withContentContainer<P extends {}>(
     </ContentContainer>
   );
 }
-/**
- * The last project/domain viewed by a user is saved to localStorage
- * to bypass the project select UX if values exists
- */
-export interface LocalStoreDefaults {
-  project: string | null;
-  domain: string | null;
-}
-export const LOCAL_STORE_DEFAULTS = 'localProjectDomain';
 
 export const ApplicationRouter: React.FC = () => {
-  const localProject = localStorage.getItem(LOCAL_STORE_DEFAULTS);
-  let projectDomain: LocalStoreDefaults;
-  if (localProject) {
-    projectDomain = JSON.parse(localProject) as LocalStoreDefaults;
-  }
+  const localProjectDomain = getLocalStore(
+    LOCAL_PROJECT_DOMAIN,
+  ) as LocalStorageProjectDomain;
 
   const additionalRoutes =
     useExternalConfigurationContext()?.registry?.additionalRoutes || null;
@@ -111,12 +105,12 @@ export const ApplicationRouter: React.FC = () => {
            * If LocalStoreDefaults exist, we direct them to the project detail view
            * for those values.
            */
-          if (projectDomain) {
+          if (localProjectDomain) {
             return (
               <Redirect
                 to={`${makeRoute('/')}/projects/${
-                  projectDomain.project
-                }/executions?domain=${projectDomain.domain}&duration=all`}
+                  localProjectDomain.project
+                }/executions?domain=${localProjectDomain.domain}&duration=all`}
               />
             );
           } else {

--- a/packages/console/src/routes/ApplicationRouter.tsx
+++ b/packages/console/src/routes/ApplicationRouter.tsx
@@ -120,7 +120,7 @@ export const ApplicationRouter: React.FC = () => {
               />
             );
           } else {
-            return <Redirect to={makeRoute('/select')} />;
+            return <Redirect to={Routes.SelectProject.path} />;
           }
         }}
       />

--- a/packages/console/src/routes/routes.ts
+++ b/packages/console/src/routes/routes.ts
@@ -128,6 +128,6 @@ export class Routes {
 
   // Landing page
   static SelectProject = {
-    path: makeRoute('/'),
+    path: makeRoute('/select'),
   };
 }

--- a/packages/console/src/routes/routes.ts
+++ b/packages/console/src/routes/routes.ts
@@ -18,18 +18,30 @@ export const makeProjectDomainBoundPath = (
 
 export class Routes {
   static NotFound = {};
+
+  // Landing page
+  static SelectProject = {
+    id: 'view-all-projects',
+    path: makeRoute('/select'),
+  };
+
   // Projects
   static ProjectDetails = {
-    makeUrl: (project: string, section?: string) =>
-      makeProjectBoundPath(project, section ? `/${section}` : ''),
+    makeUrl: (project: string, section?: string) => {
+      if (project === this.SelectProject.id) {
+        return this.SelectProject.path;
+      }
+      return makeProjectBoundPath(project, section ? `/${section}` : '');
+    },
     path: projectBasePath,
     sections: {
       dashboard: {
-        makeUrl: (project: string, domain?: string) =>
-          makeProjectBoundPath(
+        makeUrl: (project: string, domain?: string) => {
+          return makeProjectBoundPath(
             project,
             `/executions${domain ? `?domain=${domain}` : ''}`,
-          ),
+          );
+        },
         path: `${projectBasePath}/executions`,
       },
       tasks: {
@@ -124,10 +136,5 @@ export class Routes {
     makeUrl: ({ domain, name, project }: WorkflowExecutionIdentifier) =>
       makeProjectDomainBoundPath(project, domain, `/executions/${name}`),
     path: `${projectDomainBasePath}/executions/:executionId`,
-  };
-
-  // Landing page
-  static SelectProject = {
-    path: makeRoute('/select'),
   };
 }

--- a/packages/console/src/routes/routes.ts
+++ b/packages/console/src/routes/routes.ts
@@ -21,8 +21,8 @@ export class Routes {
 
   // Landing page
   static SelectProject = {
-    id: 'view-all-projects',
-    path: makeRoute('/select'),
+    id: '__FLYTE__VIEW_ALL_PROJECTS__',
+    path: makeRoute('/select-project'),
   };
 
   // Projects


### PR DESCRIPTION
This PR will provide a way to store certain default behaviors/values in `localStorage`. Specifically, this allows users to save a users last selected `project` and `domain` from the project select UI so that subsequent visits will default to those values and skip the need to select project/domain.

- Saves users last selected project/domain in localStorage; will skip the project select UI if value exists in localStorage
- Adds a new "View all projects" link in the project-select dropdown (in left-nav)
- Changes project select URL to `/select-project`
- User intents captured: 
   1. User selects from project select view
   2. User select from project select drop-down (in side-nav) 

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

## Follow-up issue
_NA_
