### PR TITLE
Fix project selector failing test

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,8 @@
     "@typescript-eslint/parser": "^5.48.2",
     "babel-loader": "^8.2.5",
     "chalk": "^4",
+    "chart.js": "3.6.2",
+    "chartjs-plugin-datalabels": "2.0.0",
     "cheerio": "^1.0.0-rc.12",
     "compression-webpack-plugin": "^9.2.0",
     "cookie-parser": "^1.4.3",

--- a/packages/console/src/components/Executions/ExecutionDetails/Timeline/TimelineChart/barOptions.ts
+++ b/packages/console/src/components/Executions/ExecutionDetails/Timeline/TimelineChart/barOptions.ts
@@ -1,8 +1,64 @@
-import { Chart as ChartJS, registerables, Tooltip } from 'chart.js';
+import {
+  Chart as ChartJS,
+  // registerables
+  ArcElement,
+  LineElement,
+  BarElement,
+  PointElement,
+  BarController,
+  BubbleController,
+  DoughnutController,
+  LineController,
+  PieController,
+  PolarAreaController,
+  RadarController,
+  ScatterController,
+  CategoryScale,
+  LinearScale,
+  LogarithmicScale,
+  RadialLinearScale,
+  TimeScale,
+  TimeSeriesScale,
+  Decimation,
+  Filler,
+  Legend,
+  Title,
+  Tooltip,
+  SubTitle,
+} from 'chart.js';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 import { isEqual, isNil } from 'lodash';
 
-ChartJS.register(...registerables, ChartDataLabels);
+const registerables = [
+  ArcElement,
+  LineElement,
+  BarElement,
+  PointElement,
+  BarController,
+  BubbleController,
+  DoughnutController,
+  LineController,
+  PieController,
+  PolarAreaController,
+  RadarController,
+  ScatterController,
+  CategoryScale,
+  LinearScale,
+  LogarithmicScale,
+  RadialLinearScale,
+  TimeScale,
+  TimeSeriesScale,
+  Decimation,
+  Filler,
+  Legend,
+  Title,
+  Tooltip,
+  SubTitle,
+];
+
+// "registerables" helper was failing tests
+registerables.forEach(plugin => ChartJS.register(plugin));
+ChartJS.register(ChartDataLabels);
 
 // Create positioner to put tooltip at cursor position
 Tooltip.positioners.cursor = function (_chartElements, coordinates) {

--- a/packages/console/src/components/Navigation/ProjectSelector.tsx
+++ b/packages/console/src/components/Navigation/ProjectSelector.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import ButtonBase from '@material-ui/core/ButtonBase';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import ExpandMore from '@material-ui/icons/ExpandMore';
@@ -6,7 +7,6 @@ import { KeyCodes } from 'common/constants';
 import { useCommonStyles } from 'components/common/styles';
 import { listhoverColor } from 'components/Theme/constants';
 import { Project } from 'models/Project/types';
-import * as React from 'react';
 import { SearchableProjectList } from './SearchableProjectList';
 
 const expanderGridHeight = 12;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11705,6 +11705,8 @@ __metadata:
     "@typescript-eslint/parser": ^5.48.2
     babel-loader: ^8.2.5
     chalk: ^4
+    chart.js: 3.6.2
+    chartjs-plugin-datalabels: 2.0.0
     cheerio: ^1.0.0-rc.12
     compression-webpack-plugin: ^9.2.0
     cookie-parser: ^1.4.3


### PR DESCRIPTION
# TL;DR
A chart.js import was causing the jest tests to fail.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
Moved a way from `registerables` helper to importing the full list to the verbose syntax here: https://www.chartjs.org/docs/3.6.2/getting-started/integration.html

From some light reading it seems like `registrablables` may be generally buggy, even in modern releases. 
