### PR TITLE
Update tsconfig.json dependency

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "forceConsistentCasingInFileNames": false,
 
     "jsx": "react",
-    "lib": ["dom", "dom.iterable", "es6", "es2021"],
+    "lib": ["dom", "dom.iterable", "es6", "es2022"],
     "target": "esnext",
     "module": "commonjs",
     "moduleResolution": "node",


### PR DESCRIPTION
The lib **es2021** will fail now, I've tried **es2022** and it works well

# TL;DR
Update tsconfig.json dependency.
I've followed the new documentation from [here](https://docs.flyte.org/en/latest/community/contribute.html#how-to-setup-dev-environment-for-flytekit)

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin


Signed-off-by: Author Name <eric901201@gmail.com> 
