### PR TITLE
chore: update tsconfig.json dependency

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "forceConsistentCasingInFileNames": false,
 
     "jsx": "react",
-    "lib": ["dom", "dom.iterable", "es6", "es2021"],
+    "lib": ["dom", "dom.iterable", "es6", "es2022"],
     "target": "esnext",
     "module": "commonjs",
     "moduleResolution": "node",


### PR DESCRIPTION
lib **es2021** is outdated, I've tried **es2022** and it works

# TL;DR
_Please replace this text with a description of what this PR accomplishes._

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin