### PR TITLE
chore: fix 404 due to bad state

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyteorg/console",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "description": "Flyteconsole main app module",
   "main": "./dist/index.js",
   "module": "./lib/index.js",

--- a/packages/console/src/components/Navigation/NavLinkWithSearch.tsx
+++ b/packages/console/src/components/Navigation/NavLinkWithSearch.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 
-interface NavLinkWithSearchProps extends React.ComponentProps<typeof NavLink> {
+interface NavLinkWithSearchProps extends React.ComponentProps<NavLink> {
   preserve?: string[];
 }
 

--- a/packages/console/src/components/Navigation/SearchableProjectList.tsx
+++ b/packages/console/src/components/Navigation/SearchableProjectList.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { Box, Fade, Grid, Tooltip, Typography } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import classnames from 'classnames';
@@ -7,8 +8,9 @@ import { useCommonStyles } from 'components/common/styles';
 import { defaultProjectDescription } from 'components/SelectProject/constants';
 import { primaryHighlightColor } from 'components/Theme/constants';
 import { Project } from 'models/Project/types';
-import * as React from 'react';
 import { Routes } from 'routes';
+import { history } from 'routes/history';
+import t from './strings';
 
 const useStyles = makeStyles((theme: Theme) => ({
   container: {
@@ -49,13 +51,6 @@ const SearchResults: React.FC<SearchResultsProps> = ({
   onProjectSelected,
   results,
 }) => {
-  const viewAllProjects = {
-    id: Routes.SelectProject.id,
-    name: 'View All Projects',
-    description: 'View All Projects',
-    domains: [],
-  } as Project;
-
   const commonStyles = useCommonStyles();
   const styles = useStyles();
   return (
@@ -67,7 +62,7 @@ const SearchResults: React.FC<SearchResultsProps> = ({
         title={
           <Typography variant="body1">
             <div className={commonStyles.textMonospace}>
-              {viewAllProjects.description}
+              {t('viewAllProjects')}
             </div>
           </Typography>
         }
@@ -77,11 +72,13 @@ const SearchResults: React.FC<SearchResultsProps> = ({
           justifyContent="space-between"
           alignItems="center"
           className={styles.searchResult}
-          onClick={() => onProjectSelected(viewAllProjects)}
+          onClick={() => {
+            history.push(Routes.SelectProject.path);
+          }}
         >
           <Grid item>
             <Typography color="primary" className={styles.itemName}>
-              {viewAllProjects.name}…
+              {t('viewAllProjects')}…
             </Typography>
           </Grid>
         </Grid>
@@ -108,7 +105,7 @@ const SearchResults: React.FC<SearchResultsProps> = ({
               >
                 <div
                   className={styles.searchResult}
-                  onClick={onProjectSelected.bind(null, value)}
+                  onClick={() => onProjectSelected(value)}
                 >
                   <div
                     className={classnames(

--- a/packages/console/src/components/Navigation/strings.ts
+++ b/packages/console/src/components/Navigation/strings.ts
@@ -6,6 +6,7 @@ const str = {
   versionConsolePackage: 'Package Version',
   versionAdmin: 'Admin Version',
   versionGoogleAnalytics: 'Google Analytics',
+  viewAllProjects: 'View All Projects',
   gaActive_: 'Active',
   gaActive_true: 'Active',
   gaActive_false: 'Inactive',

--- a/packages/console/src/components/common/LocalStoreDefaults.ts
+++ b/packages/console/src/components/common/LocalStoreDefaults.ts
@@ -1,3 +1,5 @@
+import { Routes } from 'routes';
+
 export const LOCAL_STORE_DEFAULTS = 'flyteDefaults';
 export const LOCAL_PROJECT_DOMAIN = 'projectDomain';
 
@@ -49,6 +51,16 @@ export const getLocalStore = (key: string | null = null): any | false => {
  * Sets values to 'flyteDefaults' for use in persisting various user defaults.
  */
 export const setLocalStore = (key: string, value: any) => {
+  /**
+   * TODO: the Routes.SelectProject.id check should be removed once we phase out the
+           local storage bug that leads to 404
+   */
+  if (
+    key === LOCAL_PROJECT_DOMAIN &&
+    value.project === Routes.SelectProject.id
+  ) {
+    return;
+  }
   const localStoreDefaults = localStorage.getItem(LOCAL_STORE_DEFAULTS) || '{}';
   const storeDefaultsJSON = JSON.parse(
     localStoreDefaults,

--- a/packages/console/src/routes/ApplicationRouter.tsx
+++ b/packages/console/src/routes/ApplicationRouter.tsx
@@ -102,10 +102,16 @@ export const ApplicationRouter: React.FC = () => {
         path={makeRoute('/')}
         render={() => {
           /**
-           * If LocalStoreDefaults exist, we direct them to the project detail view
+           * If LocalStoreDefaults exists, we direct them to the project detail view
            * for those values.
+           *
+           * TODO: the Routes.SelectProject.id check should be removed once we phase out the
+           *       local storage bug that leads to 404
            */
-          if (localProjectDomain) {
+          if (
+            localProjectDomain &&
+            localProjectDomain.project !== Routes.SelectProject.id
+          ) {
             return (
               <Redirect
                 to={`${makeRoute('/')}/projects/${

--- a/website/package.json
+++ b/website/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@flyteorg/common": "^0.0.4",
-    "@flyteorg/console": "^0.0.40",
+    "@flyteorg/console": "^0.0.41",
     "long": "^4.0.0",
     "protobufjs": "~6.11.3",
     "react-ga4": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2020,7 +2020,7 @@ __metadata:
   resolution: "@flyteconsole/client-app@workspace:website"
   dependencies:
     "@flyteorg/common": ^0.0.4
-    "@flyteorg/console": ^0.0.40
+    "@flyteorg/console": ^0.0.41
     "@types/long": ^3.0.32
     long: ^4.0.0
     protobufjs: ~6.11.3
@@ -2059,7 +2059,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@flyteorg/console@^0.0.40, @flyteorg/console@workspace:packages/console":
+"@flyteorg/console@^0.0.41, @flyteorg/console@workspace:packages/console":
   version: 0.0.0-use.local
   resolution: "@flyteorg/console@workspace:packages/console"
   dependencies:


### PR DESCRIPTION
# TL;DR
When clicking 'View all projects' users get a bad local storage state that leads to 404's next time they land on the homepage


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Replaces the View all projects action to bypass the regular select-project path and directly navigate to the select-project page. Back-compat for users with corrupted states was added in the application router

## Tracking Issue
fixes [#3877](https://github.com/flyteorg/flyte/issues/3877)
