### PR TITLE
Fix: breadcrumb feature flag priority order

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyteorg/console",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "description": "Flyteconsole main app module",
   "main": "./dist/index.js",
   "module": "./lib/index.js",

--- a/packages/console/src/basics/FeatureFlags/FeatureFlags.tsx
+++ b/packages/console/src/basics/FeatureFlags/FeatureFlags.tsx
@@ -41,7 +41,6 @@ const search: string = window.location.search || '';
 // To turn on flag for local development only - update flag value here
 // REMOVE change prior to commit
 let runtimeConfig: FeatureFlagConfig = {
-  ...defaultFlagConfig,
   ...getSearchParamFlags(search),
   // 'test-flag-true': true,  <== locally turns flag on
 };

--- a/packages/console/src/basics/FeatureFlags/FeatureFlags.tsx
+++ b/packages/console/src/basics/FeatureFlags/FeatureFlags.tsx
@@ -82,7 +82,11 @@ export const FeatureFlagsProvider = (props: FeatureFlagProviderProps) => {
 
   const setFeatureFlag = useCallback((flag: FeatureFlag, newValue: boolean) => {
     runtimeConfig[flag] = newValue;
-    setFlags({ ...defaultFlagConfig, ...runtimeConfig });
+    setFlags({
+      ...defaultFlagConfig,
+      ...props.externalFlags,
+      ...runtimeConfig,
+    });
   }, []);
 
   const getFeatureFlag = useCallback(
@@ -96,7 +100,7 @@ export const FeatureFlagsProvider = (props: FeatureFlagProviderProps) => {
   );
 
   const clearRuntimeConfig = useCallback(() => {
-    runtimeConfig = { ...defaultFlagConfig };
+    runtimeConfig = { ...defaultFlagConfig, ...props.externalFlags };
   }, []);
 
   useEffect(() => {

--- a/packages/console/src/components/App/App.tsx
+++ b/packages/console/src/components/App/App.tsx
@@ -68,8 +68,8 @@ export const AppComponent: React.FC<AppComponentProps> = (
     <FeatureFlagsProvider
       externalFlags={{
         ...props.env,
-        breadcrumbs: breadcrumbsFlag,
-        'horizontal-layout': horizontalLayoutFlag,
+        breadcrumbs: `${breadcrumbsFlag}`,
+        'horizontal-layout': `${horizontalLayoutFlag}`,
       }}
     >
       <GlobalStyles />

--- a/website/package.json
+++ b/website/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@flyteorg/common": "^0.0.4",
-    "@flyteorg/console": "^0.0.46",
+    "@flyteorg/console": "^0.0.47",
     "long": "^4.0.0",
     "protobufjs": "~6.11.3",
     "react-ga4": "^1.4.1",


### PR DESCRIPTION
# TL;DR
Change the feature flag logic priority order.

Old: default, env, default, params,
New: default, env, params
Now:
`default: false` `env: true` will enable a flag
`default: false` `env: true` `params: false` will disable a flag

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Tested by adding the breadcrumb env var to `yarn start` script to verify loading order.

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/3896

## Follow-up issue
_NA_
