### PR TITLE
fix: commit linter running on generated messages

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -92,6 +92,7 @@ jobs:
           GIT_AUTHOR_EMAIL: "admin@flyte.org"
           GIT_COMMITTER_NAME: "flyte bot"
           GIT_COMMITTER_EMAIL: "admin@flyte.org"
+          CI: "true"
         run: npx semantic-release@21.0.7
 
   check_for_tag:

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+# exit if in a CI environment
+[ -n "$CI" ] && exit 0
+
 npx --no -- commitlint --edit ${1}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
+
 . "$(dirname -- "$0")/_/husky.sh"
+# exit if in a CI environment
 [ -n "$CI" ] && exit 0
 
 echo "Linting staged files..."

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -26,7 +26,14 @@ function getProdConfiguration() {
         },
       ],
       // make repo tags that match the package.json version
-      '@semantic-release/git',
+      [
+        '@semantic-release/git',
+        {
+          message:
+            // default + [skip ci] added to commit message
+            'chore: ${nextRelease.version} [skip ci]\n\n<%= nextRelease.notes %>',
+        },
+      ],
       '@semantic-release/github',
     ],
   };
@@ -74,7 +81,13 @@ function getTestConfiguration() {
         },
       ],
       // make repo tags that match the package.json version
-      '@semantic-release/git',
+      [
+        '@semantic-release/git',
+        {
+          message:
+            'chore: release: ${nextRelease.version} [skip ci]\n\n<%= nextRelease.notes %>',
+        },
+      ],
       // ["@semantic-release/github", {
       //   "verifyConditions": false,
       //   "publish": false,

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,4 @@
-module.exports = { extends: ['@commitlint/config-conventional'] };
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  ignores: [commit => commit.includes('[skip ci]')],
+};

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "NODE_ENV=test BASE_URL=/console jest",
     "test:clear": "jest --clearCache",
     "test-coverage": "NODE_OPTIONS='--max-old-space-size=8192' NODE_ENV=test BASE_URL=/console jest --coverage",
-    "test-release": "npx semantic-release@21.0.7 --debug --no-ci --test-run"
+    "test-release": "CI=true npx semantic-release@21.0.7 --debug --no-ci --test-run"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
# TL;DR
Commit linter was running on auto-generated content with long URLs to github artifacts, triggering the lines longer than 100 chars rule.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
- Made sure CI env variable was set - same as linter stage - that it was bypassing. 
- Added `[skip ci]` rule to the generated commit message which is recommended by semantic-release if running within a CI so you can avoid duplicate builds from change log diffs.
- Remote pipeline is  incrementally more in common with local dev environment.

## Follow-up issue
_NA_
