### PR TITLE
fix: switching projects doesn't respect domain value

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flyteorg/console",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "description": "Flyteconsole main app module",
   "main": "./dist/index.js",
   "module": "./lib/index.js",

--- a/packages/console/src/components/Breadcrumbs/async/fn.ts
+++ b/packages/console/src/components/Breadcrumbs/async/fn.ts
@@ -34,9 +34,11 @@ export const defaultVoid: BreadcrumbAsyncPopOverData = async (
  */
 export const projects: BreadcrumbAsyncPopOverData = async (
   _location,
-  _breadcrumb,
+  breadcrumb,
 ) => {
-  return listProjects().then(data => formatProjectEntities(data));
+  return listProjects().then(data =>
+    formatProjectEntities(data, breadcrumb.domainId),
+  );
 };
 
 /**

--- a/packages/console/src/components/Breadcrumbs/async/utils.ts
+++ b/packages/console/src/components/Breadcrumbs/async/utils.ts
@@ -57,9 +57,12 @@ export const domainIdfromUrl = (location: Location) => {
   return '';
 };
 
-export const formatProjectEntities = data => {
+export const formatProjectEntities = (data: Project[], domain?: string) => {
   return data.map(project => {
-    const url = Routes.ProjectDetails.sections.dashboard.makeUrl(project.id);
+    const url = Routes.ProjectDetails.sections.dashboard.makeUrl(
+      project.id,
+      domain,
+    );
 
     return {
       title: project.name,

--- a/website/package.json
+++ b/website/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@flyteorg/common": "^0.0.4",
-    "@flyteorg/console": "^0.0.50",
+    "@flyteorg/console": "^0.0.51",
     "long": "^4.0.0",
     "protobufjs": "~6.11.3",
     "react-ga4": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2032,7 +2032,7 @@ __metadata:
   resolution: "@flyteconsole/client-app@workspace:website"
   dependencies:
     "@flyteorg/common": ^0.0.4
-    "@flyteorg/console": ^0.0.50
+    "@flyteorg/console": ^0.0.51
     "@types/long": ^3.0.32
     long: ^4.0.0
     protobufjs: ~6.11.3
@@ -2071,7 +2071,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@flyteorg/console@^0.0.50, @flyteorg/console@workspace:packages/console":
+"@flyteorg/console@^0.0.51, @flyteorg/console@workspace:packages/console":
   version: 0.0.0-use.local
   resolution: "@flyteorg/console@workspace:packages/console"
   dependencies:


### PR DESCRIPTION
# TL;DR
When switching projects from the breadcrumbs, if domain is anything other than development, it is not respected
Repro steps:

- go to https://development.uniondemo.run/console/projects/flytesnacks/executions?domain=production&duration=all
- switch to llm-fine-tuning (should load production executions, but the requests are actually for development)
- clicking on any of the executions that are loaded leads to development

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Added the breadcrumb's domain value to the project's format callback function

## Tracking Issue

fixes https://github.com/flyteorg/flyte/issues/3947
