### PR TITLE
fix: cross execution breadcrumb link

### DIFF
--- a/packages/console/src/components/Breadcrumbs/components/BreadcrumbFormControl.tsx
+++ b/packages/console/src/components/Breadcrumbs/components/BreadcrumbFormControl.tsx
@@ -130,6 +130,23 @@ const BreadcrumbFormControlDefault = (
     },
   }))();
 
+  const selfLinkHref = useMemo(() => {
+    if (props.asyncData || asyncSelfLinkData) {
+      return asyncSelfLinkData;
+    }
+    if (typeof props.selfLink === 'function') {
+      return props.selfLink(window.location, props);
+    } else {
+      return props.selfLink;
+    }
+  }, [
+    props.selfLink,
+    props.projectId,
+    props.domainId,
+    props.asyncData,
+    asyncSelfLinkData,
+  ]);
+
   return (
     <div className={`breadcrumb-form-control ${styles.formControl}`}>
       <Grid container alignItems="center" className={styles.noWrap}>
@@ -143,6 +160,7 @@ const BreadcrumbFormControlDefault = (
                 disabled={!(props.selfLink || props.asyncSelfLink)}
                 className="breadcrumb-form-control-input"
                 onClick={handleValueClick}
+                href={selfLinkHref}
                 onKeyDown={e => {
                   if (e.key === 'Enter') {
                     handleValueClick(e);


### PR DESCRIPTION
# TL;DR
- Link to cross namespace workflow/task from the breadcrumb (different origin project/namespace than where it eecuted)
- Better self link markup

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Used the launch plan spec for the execution to compare against.

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
