### PR TITLE
fix: resume form should support all known types

### DIFF
--- a/packages/console/src/components/Launch/LaunchForm/useResumeFormState.ts
+++ b/packages/console/src/components/Launch/LaunchForm/useResumeFormState.ts
@@ -5,6 +5,7 @@ import { partial } from 'lodash';
 import { NodeExecutionIdentifier } from 'models/Execution/types';
 import { CompiledNode } from 'models/Node/types';
 import { RefObject, useMemo, useRef } from 'react';
+import { LiteralType } from 'models';
 import {
   TaskResumeContext,
   TaskResumeTypestate,
@@ -52,9 +53,9 @@ async function loadInputs({ compiledNode }: TaskResumeContext) {
       label: 'Signal Input',
       name: 'signal',
       required: true,
-      typeDefinition: getInputDefintionForLiteralType({
-        simple: signalType.simple ?? undefined,
-      }),
+      typeDefinition: getInputDefintionForLiteralType(
+        signalType as LiteralType,
+      ),
     },
   ];
 


### PR DESCRIPTION

# TL;DR
Allows relaunch form to deserialize all input types as opposed to just simple


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue
