### PR TITLE
fix: custom flyteremote usage by protocol

### DIFF
--- a/packages/console/src/components/Executions/ExecutionDetails/NodeExecutionTabs/NodeExecutionInputs.tsx
+++ b/packages/console/src/components/Executions/ExecutionDetails/NodeExecutionTabs/NodeExecutionInputs.tsx
@@ -16,17 +16,23 @@ export const NodeExecutionInputs: React.FC<{
   return (
     <WaitForData {...executionData}>
       <PanelSection>
-        {executionData.value?.flyteUrls?.inputs ? (
-          <ExecutionNodeURL
-            nodeExecutionId={execution.id}
-            dataSourceURI={executionData.value?.flyteUrls?.inputs}
-            copyUrlText="Copy Inputs URI"
-          />
-        ) : null}
-        <LiteralMapViewer
-          map={executionData.value.fullInputs}
-          mapTaskIndex={taskIndex}
-        />
+        {(() => {
+          const data = executionData?.value;
+          const fullInputs = data?.fullInputs;
+          const dataSourceURI = data?.flyteUrls?.inputs;
+          const hasInputs = Object.keys(fullInputs?.literals || {}).length > 0;
+          return (
+            <>
+              {hasInputs && taskIndex === undefined ? (
+                <ExecutionNodeURL
+                  dataSourceURI={dataSourceURI}
+                  copyUrlText="Copy Inputs URI"
+                />
+              ) : null}
+              <LiteralMapViewer map={fullInputs} mapTaskIndex={taskIndex} />
+            </>
+          );
+        })()}
       </PanelSection>
     </WaitForData>
   );

--- a/packages/console/src/components/Executions/ExecutionDetails/NodeExecutionTabs/NodeExecutionOutputs.tsx
+++ b/packages/console/src/components/Executions/ExecutionDetails/NodeExecutionTabs/NodeExecutionOutputs.tsx
@@ -16,17 +16,24 @@ export const NodeExecutionOutputs: React.FC<{
   return (
     <WaitForData {...executionData}>
       <PanelSection>
-        {executionData.value?.flyteUrls?.outputs ? (
-          <ExecutionNodeURL
-            nodeExecutionId={execution.id}
-            dataSourceURI={executionData.value?.flyteUrls?.outputs}
-            copyUrlText="Copy Outputs URI"
-          />
-        ) : null}
-        <LiteralMapViewer
-          map={executionData.value.fullOutputs}
-          mapTaskIndex={taskIndex}
-        />
+        {(() => {
+          const data = executionData?.value;
+          const fullOutputs = data?.fullOutputs;
+          const dataSourceURI = data?.flyteUrls?.outputs;
+          const hasOutputs =
+            Object.keys(fullOutputs?.literals || {}).length > 0;
+          return (
+            <>
+              {hasOutputs && taskIndex === undefined ? (
+                <ExecutionNodeURL
+                  dataSourceURI={dataSourceURI}
+                  copyUrlText="Copy Outputs URI"
+                />
+              ) : null}
+              <LiteralMapViewer map={fullOutputs} mapTaskIndex={taskIndex} />
+            </>
+          );
+        })()}
       </PanelSection>
     </WaitForData>
   );


### PR DESCRIPTION
# TL;DR
* shows custom FlyteRemote snippet based on protocol used
* hides io uri/usage data when:
  * is  map task
  * there is no IO


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue
