### PR TITLE
fix: usage snippet indentation

### DIFF
--- a/packages/console/src/components/Executions/ExecutionDetails/ExecutionNodeURL.tsx
+++ b/packages/console/src/components/Executions/ExecutionDetails/ExecutionNodeURL.tsx
@@ -97,18 +97,18 @@ export const ExecutionNodeURL: React.FC<{
   const code = isHttps
     ? // https snippet
       `from flytekit.remote.remote import FlyteRemote
-  from flytekit.configuration import Config
-  remote = FlyteRemote(
-      Config.for_endpoint("${window.location.host}"),
-  )
-  remote.get("${dataSourceURI}")`
+from flytekit.configuration import Config
+remote = FlyteRemote(
+    Config.for_endpoint("${window.location.host}"),
+)
+remote.get("${dataSourceURI}")`
     : // http snippet
       `from flytekit.remote.remote import FlyteRemote
-  from flytekit.configuration import Config
-  remote = FlyteRemote(
-      Config.for_endpoint("${window.location.host}", True),
-  )
-  remote.get("${dataSourceURI}")`;
+from flytekit.configuration import Config
+remote = FlyteRemote(
+    Config.for_endpoint("${window.location.host}", True),
+)
+remote.get("${dataSourceURI}")`;
 
   const toggleExpanded = () => {
     setExpanded(!expanded);


### PR DESCRIPTION
# TL;DR
Fixes FlyteRemote Usage snippet indentation
<img width="432" alt="image" src="https://github.com/flyteorg/flyteconsole/assets/6610300/b609c954-e72b-4e88-95c4-b6f22b07d4f2">


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
