### PR TITLE
fix: tab not spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build_prod:
 
 .PHONY: pack
 pack:
- 	yarn run build:pack
+	yarn run build:pack
 
 .PHONY: types
 types:


### PR DESCRIPTION
# TL;DR

`make pack` target doesn't work because a rogue space at the beginning of the line. Removing that so the target works again.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 
Running `make pack` doesn't work:
```
$ make pack
make: Nothing to be done for 'pack'.
```
This is due to a space at the start of the line. Removing it so only a tab remains, which is a requirement for `Makefile` format. Once done the target works as expected:
```
$ make pack
yarn run build:pack
➤ YN0000: [@flyteorg/common]: Process started
➤ YN0000: [@flyteorg/common]: No matches found: "**.tsbuildinfo"
➤ YN0000: [@flyteorg/common]: Process exited (exit code 0), completed in 8s 258ms

➤ YN0000: [@flyteorg/flyte-api]: Process started
➤ YN0000: [@flyteorg/flyte-api]: No matches found: "**.tsbuildinfo"
➤ YN0000: [@flyteorg/flyte-api]: Process exited (exit code 0), completed in 7s 830ms

➤ YN0000: [@flyteorg/flyteidl-types]: Process started
➤ YN0000: [@flyteorg/flyteidl-types]: No matches found: "**.tsbuildinfo"
➤ YN0000: [@flyteorg/flyteidl-types]: Process exited (exit code 0), completed in 7s 793ms

➤ YN0000: [@flyteorg/locale]: Process started
➤ YN0000: [@flyteorg/locale]: Process exited (exit code 0), completed in 7s 406ms

➤ YN0000: [@flyteorg/ui-atoms]: Process started
➤ YN0000: [@flyteorg/ui-atoms]: No matches found: "**.tsbuildinfo"
➤ YN0000: [@flyteorg/ui-atoms]: Process exited (exit code 0), completed in 8s 650ms

➤ YN0000: [@flyteorg/components]: Process started
➤ YN0000: [@flyteorg/components]: Process exited (exit code 0), completed in 8s 928ms

➤ YN0000: [@flyteorg/console]: Process started
➤ YN0000: [@flyteorg/console]: Process exited (exit code 0), completed in 22s 764ms
➤ YN0000: Done in 1m 12s
```

## Tracking Issue

https://github.com/flyteorg/flyte/issues/4892

## Follow-up issue

N/A

