### PR TITLE
feat: improve security measures in SVG elements

### DIFF
--- a/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionNodeDeck.tsx
+++ b/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionNodeDeck.tsx
@@ -41,6 +41,7 @@ export const ExecutionNodeDeck: React.FC<{
           width: '100%',
           height: '100%',
         }}
+        allow="clipboard-write"
       />
     </WaitForData>
   );


### PR DESCRIPTION
# TL;DR
- Add `allow="clipboard-write"` attribute to the SVG element

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
In order to implement the copy function on the iframe, the iframe needs to add attributes. 
For the reasons, please refer to: https://github.com/flyteorg/flytekit/pull/2264#pullrequestreview-1935703764

## Tracking Issue
_NA_

## Follow-up issue
https://github.com/flyteorg/flytekit/pull/2264
