### PR TITLE
Feat: Add Trigger support to UI

### DIFF
--- a/packages/oss-console/src/components/Entities/EntityDetailsHeader.tsx
+++ b/packages/oss-console/src/components/Entities/EntityDetailsHeader.tsx
@@ -3,6 +3,7 @@ import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import styled from '@mui/system/styled';
 import isNil from 'lodash/isNil';
+import Grid from '@mui/material/Grid';
 import { Identifier, ResourceIdentifier, ResourceType } from '../../models/Common/types';
 import { LaunchForm } from '../Launch/LaunchForm/LaunchForm';
 import { useEscapeKey } from '../hooks/useKeyListener';
@@ -10,6 +11,7 @@ import { LaunchTaskFormProps, LaunchWorkflowFormProps } from '../Launch/LaunchFo
 import t, { patternKey } from './strings';
 import { entityStrings } from './constants';
 import BreadcrumbTitleActions from '../Breadcrumbs/components/BreadcrumbTitleActions';
+import { LaunchPlanDetailsHeader } from '../LaunchPlan/components/LaunchPlanDetailsHeader';
 
 const EntityDetailsHeaderContainer = styled('div')(({ theme }) => ({
   '.headerContainer': {
@@ -88,24 +90,33 @@ export const EntityDetailsHeader: React.FC<EntityDetailsHeaderProps> = ({
     onCancelLaunch();
   });
 
+  const showLaunchPlanDetails = id.resourceType === ResourceType.LAUNCH_PLAN;
+
   return (
     <EntityDetailsHeaderContainer>
       <div>
         <BreadcrumbTitleActions>
-          {launchable ? (
-            <Button
-              color="primary"
-              id="launch-workflow"
-              onClick={() => {
-                setShowLaunchForm(true);
-              }}
-              variant="contained"
-            >
-              {t(patternKey('launchStrings', entityStrings[id.resourceType]))}
-            </Button>
-          ) : (
-            <></>
-          )}
+          <Grid
+            container
+            direction="row"
+            sx={showLaunchPlanDetails ? { maxWidth: '654px', width: '100%' } : {}}
+          >
+            {launchable ? (
+              <Button
+                color="primary"
+                id="launch-workflow"
+                onClick={() => {
+                  setShowLaunchForm(true);
+                }}
+                variant="contained"
+              >
+                {t(patternKey('launchStrings', entityStrings[id.resourceType]))}
+              </Button>
+            ) : (
+              <></>
+            )}
+            {showLaunchPlanDetails ? <LaunchPlanDetailsHeader id={id} /> : null}
+          </Grid>
         </BreadcrumbTitleActions>
       </div>
       {launchable ? (

--- a/packages/oss-console/src/components/Entities/EntitySchedulesCells.tsx
+++ b/packages/oss-console/src/components/Entities/EntitySchedulesCells.tsx
@@ -1,0 +1,308 @@
+import Typography from '@mui/material/Typography';
+import React, { useMemo } from 'react';
+import Tooltip from '@mui/material/Tooltip';
+import Grid from '@mui/material/Grid';
+import Link from '@mui/material/Link';
+import { useInView } from 'react-intersection-observer';
+import { makeFilterableWorkflowExecutionsQuery } from '@clients/oss-console/queries/workflowQueries';
+import { useQueryClient } from 'react-query';
+import Shimmer from '@clients/primitives/Shimmer';
+import { formatDateUTC } from '@clients/oss-console/common/formatters';
+import { timestampToDate } from '@clients/oss-console/common/utils';
+import moment from 'moment';
+import { FilterOperationName } from '@clients/common/types/adminEntityTypes';
+import t from './strings';
+import { getRawScheduleStringFromLaunchPlan } from './EntitySchedules';
+import { getScheduleStringFromLaunchPlan } from './getScheduleStringFromLaunchPlan';
+import { LaunchPlan } from '../../models/Launch/types';
+import { useCommonStyles } from '../common/styles';
+import { Routes } from '../../routes/routes';
+import { executionFilterGenerator } from './generators';
+import { useConditionalQuery } from '../hooks/useConditionalQuery';
+import { ResourceIdentifier, ResourceType } from '../../models/Common/types';
+import { ExecutionMode } from '../../models/Execution/enums';
+import { getNextExecutionTimeMilliseconds } from '../LaunchPlan/utils';
+import { CREATED_AT_DESCENDING_SORT } from '../../models/Launch/constants';
+
+export interface ScheduleFrequencyProps {
+  launchPlan: LaunchPlan;
+}
+export const ScheduleFrequency = ({ launchPlan }: ScheduleFrequencyProps) => {
+  const commonStyles = useCommonStyles();
+
+  const { scheduleDisplayValue, scheduleRawValue } = useMemo(() => {
+    const scheduleDisplayValue = getScheduleStringFromLaunchPlan(launchPlan);
+    const scheduleRawValue = getRawScheduleStringFromLaunchPlan(launchPlan);
+    return { scheduleDisplayValue: scheduleDisplayValue || t('noValue'), scheduleRawValue };
+  }, [launchPlan]);
+
+  return (
+    <Tooltip title={`${scheduleDisplayValue} (${scheduleRawValue})`} placement="bottom-start">
+      <Grid container direction="column">
+        <Grid
+          item
+          className={commonStyles.truncateText}
+          sx={{
+            width: '100%',
+          }}
+        >
+          <Typography variant="body2" className={commonStyles.truncateText}>
+            {scheduleDisplayValue}
+          </Typography>
+        </Grid>
+        <Grid
+          item
+          className={commonStyles.truncateText}
+          sx={{
+            width: '100%',
+          }}
+        >
+          <Typography variant="label" color="textSecondary" className={commonStyles.truncateText}>
+            {scheduleRawValue}
+          </Typography>
+        </Grid>
+      </Grid>
+    </Tooltip>
+  );
+};
+
+export interface LaunchPlanNameProps {
+  launchPlan: LaunchPlan;
+}
+
+export const LaunchPlanName = ({ launchPlan }: LaunchPlanNameProps) => {
+  const commonStyles = useCommonStyles();
+  const url = Routes.LaunchPlanDetails.makeUrl(
+    launchPlan.id.project,
+    launchPlan.id.domain,
+    launchPlan.id.name,
+  );
+  return (
+    <Tooltip title={`${launchPlan.id.name} (${launchPlan.id.version})`} placement="bottom-start">
+      <Grid container direction="column">
+        <Grid
+          item
+          className={commonStyles.truncateText}
+          sx={{
+            width: '100%',
+          }}
+        >
+          <Link
+            href={url}
+            variant="body2"
+            onClick={(event) => {
+              event.stopPropagation();
+            }}
+          >
+            {launchPlan.id.name}
+          </Link>
+        </Grid>
+        <Grid
+          item
+          className={commonStyles.truncateText}
+          sx={{
+            width: '100%',
+          }}
+        >
+          <Typography variant="label" color="textSecondary" className={commonStyles.truncateText}>
+            {launchPlan.id.version}
+          </Typography>
+        </Grid>
+      </Grid>
+    </Tooltip>
+  );
+};
+
+export interface LaunchPlanLastRunProps {
+  launchPlan: LaunchPlan;
+}
+
+export const LaunchPlanLastRun = ({ launchPlan }: LaunchPlanLastRunProps) => {
+  const commonStyles = useCommonStyles();
+  const queryClient = useQueryClient();
+  const [inViewRef, inView] = useInView();
+
+  const { workflowId } = launchPlan.spec;
+
+  // Build request config for the latest workflow version
+  const requestConfig = React.useMemo(() => {
+    const filter = executionFilterGenerator[workflowId.resourceType || ResourceType.LAUNCH_PLAN](
+      workflowId as ResourceIdentifier,
+      workflowId.version,
+    );
+    filter.push({
+      key: 'mode',
+      operation: FilterOperationName.EQ,
+      value: ExecutionMode.SCHEDULED,
+    });
+    return {
+      filter,
+      sort: CREATED_AT_DESCENDING_SORT,
+      limit: 1,
+    };
+  }, [workflowId]);
+
+  const mostRecentlpVersionExecutionsQuery = useConditionalQuery(
+    {
+      ...makeFilterableWorkflowExecutionsQuery(queryClient, workflowId, requestConfig),
+      enabled: inView,
+    },
+    (prev) => !prev,
+  );
+
+  const scheduledExecutions = (mostRecentlpVersionExecutionsQuery.data?.entities || []).filter(
+    (e) => e.spec.metadata.mode === ExecutionMode.SCHEDULED,
+  );
+  const latestScheduledExecution = scheduledExecutions?.[0];
+
+  const createdAt = latestScheduledExecution?.closure.createdAt;
+  const relativeStartTime = latestScheduledExecution
+    ? moment(timestampToDate(createdAt)).fromNow()
+    : undefined;
+  const startTime = latestScheduledExecution
+    ? formatDateUTC(timestampToDate(createdAt))
+    : undefined;
+
+  return (
+    <div ref={inViewRef}>
+      {mostRecentlpVersionExecutionsQuery.isFetched ? (
+        <Tooltip title={`${relativeStartTime} (${startTime})`} placement="bottom-start">
+          <Grid container direction="column">
+            <Grid
+              item
+              className={commonStyles.truncateText}
+              sx={{
+                width: '100%',
+              }}
+            >
+              <Typography variant="body2" className={commonStyles.truncateText}>
+                {relativeStartTime}
+              </Typography>
+            </Grid>
+            <Grid
+              item
+              className={commonStyles.truncateText}
+              sx={{
+                width: '100%',
+              }}
+            >
+              <Typography
+                variant="label"
+                className={commonStyles.truncateText}
+                color="textSecondary"
+              >
+                {startTime}
+              </Typography>
+            </Grid>
+          </Grid>
+        </Tooltip>
+      ) : (
+        <Shimmer />
+      )}
+    </div>
+  );
+};
+
+type LaunchPlanNextPotentialExecutionProps = {
+  launchPlan: LaunchPlan;
+};
+
+/** The view component for displaying thelaunch plan's details of last execution or last 10 exeuctions */
+export const LaunchPlanNextPotentialExecution = ({
+  launchPlan,
+}: LaunchPlanNextPotentialExecutionProps) => {
+  const commonStyles = useCommonStyles();
+  const queryClient = useQueryClient();
+  const [inViewRef, inView] = useInView();
+
+  const { workflowId } = launchPlan.spec;
+
+  // Build request config for the latest workflow version
+  const requestConfig = React.useMemo(() => {
+    const filter = executionFilterGenerator[workflowId.resourceType || ResourceType.LAUNCH_PLAN](
+      workflowId as ResourceIdentifier,
+      workflowId.version,
+    );
+    filter.push({
+      key: 'mode',
+      operation: FilterOperationName.EQ,
+      value: ExecutionMode.SCHEDULED,
+    });
+    return {
+      filter,
+      sort: CREATED_AT_DESCENDING_SORT,
+      limit: 1,
+    };
+  }, [workflowId]);
+
+  const mostRecentlpVersionExecutionsQuery = useConditionalQuery(
+    {
+      ...makeFilterableWorkflowExecutionsQuery(queryClient, workflowId, requestConfig),
+      enabled: inView,
+    },
+    (prev) => !prev,
+  );
+
+  const scheduledExecutions = (mostRecentlpVersionExecutionsQuery.data?.entities || []).filter(
+    (e) => e.spec.metadata.mode === ExecutionMode.SCHEDULED,
+  );
+  const latestScheduledExecution = scheduledExecutions?.[0];
+  // get next potential execution time based on the most recent scheduled execution
+  const nextPotentialExecutionTime =
+    latestScheduledExecution &&
+    getNextExecutionTimeMilliseconds(latestScheduledExecution, launchPlan);
+  const nextPotentialExecutionDate =
+    nextPotentialExecutionTime && new Date(nextPotentialExecutionTime);
+  const nextPotentialExecutionTimeStr = nextPotentialExecutionDate ? (
+    formatDateUTC(nextPotentialExecutionDate)
+  ) : (
+    <em>N/A</em>
+  );
+
+  const relativeStartTime = nextPotentialExecutionDate ? (
+    moment(nextPotentialExecutionDate).fromNow()
+  ) : (
+    <em>N/A</em>
+  );
+  return (
+    <div ref={inViewRef}>
+      {mostRecentlpVersionExecutionsQuery.isFetched ? (
+        <Tooltip
+          title={`${relativeStartTime} (${nextPotentialExecutionTimeStr})`}
+          placement="bottom-start"
+        >
+          <Grid container direction="column">
+            <Grid
+              item
+              className={commonStyles.truncateText}
+              sx={{
+                width: '100%',
+              }}
+            >
+              <Typography variant="body2" className={commonStyles.truncateText}>
+                {relativeStartTime}
+              </Typography>
+            </Grid>
+            <Grid
+              item
+              className={commonStyles.truncateText}
+              sx={{
+                width: '100%',
+              }}
+            >
+              <Typography
+                variant="label"
+                className={commonStyles.truncateText}
+                color="textSecondary"
+              >
+                {nextPotentialExecutionTimeStr}
+              </Typography>
+            </Grid>
+          </Grid>
+        </Tooltip>
+      ) : (
+        <Shimmer />
+      )}
+    </div>
+  );
+};

--- a/packages/oss-console/src/components/Entities/getScheduleStringFromLaunchPlan.tsx
+++ b/packages/oss-console/src/components/Entities/getScheduleStringFromLaunchPlan.tsx
@@ -1,0 +1,13 @@
+import { getScheduleFrequencyString, getScheduleOffsetString } from '../../common/formatters';
+import { LaunchPlan } from '../../models/Launch/types';
+
+export const getScheduleStringFromLaunchPlan = (launchPlan?: LaunchPlan) => {
+  const { schedule } = launchPlan?.spec?.entityMetadata || {};
+  const frequencyString = getScheduleFrequencyString(schedule);
+  const offsetString = getScheduleOffsetString(schedule);
+  const scheduleString = offsetString
+    ? `${frequencyString} (offset by ${offsetString})`
+    : frequencyString;
+
+  return scheduleString;
+};

--- a/packages/oss-console/src/components/Executions/StatusBadge.tsx
+++ b/packages/oss-console/src/components/Executions/StatusBadge.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import classnames from 'classnames';
+import Typography from '@mui/material/Typography';
+import * as CommonStylesConstants from '@clients/theme/CommonStyles/constants';
+import styled from '@mui/system/styled';
+
+export const StyledWrapper = styled('div')(({ theme }) => ({
+  fontWeight: 'normal',
+  '&.default': {
+    padding: theme.spacing(0.25, 0.5),
+    alignItems: 'center',
+    backgroundColor: theme.palette.common.primary.white,
+    borderRadius: theme.spacing(0.5),
+    color: theme.palette.text.primary,
+    display: 'flex',
+    flex: '0 0 auto',
+    height: theme.spacing(2.5),
+    fontSize: CommonStylesConstants.smallFontSize,
+    justifyContent: 'center',
+    textTransform: 'uppercase',
+    width: theme.spacing(11), // 88px
+  },
+  '&.text': {
+    backgroundColor: 'inherit',
+    border: 'none',
+    marginTop: theme.spacing(1),
+    textTransform: 'lowercase',
+  },
+  '&.launchPlan': {
+    textTransform: 'none',
+    width: theme.spacing(6),
+    height: theme.spacing(3),
+    marginRight: theme.spacing(1),
+  },
+}));
+
+export interface StatusBadgeProps
+  extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+  text: string;
+  variant?: 'default' | 'text';
+  className?: string;
+  sx?: React.CSSProperties;
+}
+export const StatusBadge = ({
+  text,
+  variant = 'default',
+  className,
+  sx,
+  ...htmlProps
+}: StatusBadgeProps) => {
+  return (
+    <StyledWrapper className={classnames(variant, className)} sx={sx} {...htmlProps}>
+      <Typography variant="label">{text}</Typography>
+    </StyledWrapper>
+  );
+};

--- a/packages/oss-console/src/components/Executions/Tables/WorkflowExecutionTable/cells.tsx
+++ b/packages/oss-console/src/components/Executions/Tables/WorkflowExecutionTable/cells.tsx
@@ -13,6 +13,7 @@ import ArchiveLogo from '@clients/ui-atoms/ArchiveLogo';
 import { HoverTooltip } from '@clients/primitives/HoverTooltip';
 import Shimmer from '@clients/primitives/Shimmer';
 import styled from '@mui/system/styled';
+import { getScheduleStringFromLaunchPlan } from '../../../Entities/getScheduleStringFromLaunchPlan';
 import {
   formatDateLocalTimezone,
   formatDateUTC,
@@ -21,10 +22,9 @@ import {
 } from '../../../../common/formatters';
 import { timestampToDate } from '../../../../common/utils';
 import { ExecutionStatusBadge } from '../../ExecutionStatusBadge';
-import { Execution } from '../../../../models/Execution/types';
+import { Execution, ExecutionMetadata } from '../../../../models/Execution/types';
 import { ExecutionState, WorkflowExecutionPhase } from '../../../../models/Execution/enums';
 import { Routes } from '../../../../routes/routes';
-import { getScheduleStringFromLaunchPlan } from '../../../Entities/EntitySchedules';
 import { WorkflowExecutionsTableState } from '../types';
 import { getWorkflowExecutionTimingMS, isExecutionArchived } from '../../utils';
 import t from './strings';
@@ -199,7 +199,8 @@ export function getWorkflowTaskCell(execution: Execution): React.ReactNode {
 }
 
 export function getScheduleCell(execution: Execution): React.ReactNode {
-  const isEnabled = !!execution.spec.metadata.scheduledAt;
+  const meta: ExecutionMetadata = execution.spec.metadata;
+  const isEnabled = !!meta.scheduledAt;
   const queryClient = useQueryClient();
   const lpQuery = useConditionalQuery(
     { ...makeLaunchPlanQuery(queryClient, execution.spec.launchPlan), enabled: isEnabled },
@@ -374,11 +375,12 @@ export function ApprovalDoubleCell(props: ApprovalDoubleCellProps) {
           color="primary"
           variant="contained"
           disableElevation
-          onClick={() =>
+          onClick={(event) => {
+            event.stopPropagation();
             onConfirmClick(
               isArchived ? ExecutionState.EXECUTION_ACTIVE : ExecutionState.EXECUTION_ARCHIVED,
-            )
-          }
+            );
+          }}
           sx={{
             borderTopRightRadius: '0px',
             borderBottomRightRadius: '0px',

--- a/packages/oss-console/src/components/Executions/Tables/useWorkflowVersionsTableColumns.tsx
+++ b/packages/oss-console/src/components/Executions/Tables/useWorkflowVersionsTableColumns.tsx
@@ -1,7 +1,6 @@
 import Typography from '@mui/material/Typography';
 import moment from 'moment';
 import React, { useMemo } from 'react';
-import styled from '@mui/system/styled';
 import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableRow from '@mui/material/TableRow';

--- a/packages/oss-console/src/components/LaunchPlan/LaunchPlanCardList/LaunchPlanCardView.tsx
+++ b/packages/oss-console/src/components/LaunchPlan/LaunchPlanCardList/LaunchPlanCardView.tsx
@@ -1,27 +1,38 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { LargeLoadingComponent } from '@clients/primitives/LoadingSpinner';
 import { NoResults } from '@clients/primitives/NoResults';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { SearchResult } from '../../common/SearchableList';
 import { NamedEntity } from '../../../models/Common/types';
-import { ItemRenderer } from '../../common/FilterableNamedEntityList';
+import LaunchPlanListCard from './LaunchPlanListCard';
 
 interface LaunchPlanCardViewProps {
   results: SearchResult<NamedEntity>[];
-  renderItem: ItemRenderer;
   loading: boolean;
 }
 
-const LaunchPlanCardView: React.FC<LaunchPlanCardViewProps> = ({
-  results,
-  renderItem,
-  loading,
-}) => {
+const LaunchPlanCardView: React.FC<LaunchPlanCardViewProps> = ({ results, loading }) => {
+  const parentRef = useRef<any>(document.getElementById('scroll-element'));
+
+  const rowVirtualizer = useVirtualizer({
+    count: results?.length ? results.length + 1 : 0,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 100,
+    overscan: 15,
+  });
+
+  const items = rowVirtualizer.getVirtualItems();
+
   return loading ? (
     <LargeLoadingComponent useDelay={false} />
   ) : results.length === 0 ? (
     <NoResults />
   ) : (
-    <>{results.map((r) => renderItem(r, false))}</>
+    <>
+      {items.map((virtualRow) => (
+        <LaunchPlanListCard {...results[virtualRow.index]} />
+      ))}
+    </>
   );
 };
 

--- a/packages/oss-console/src/components/LaunchPlan/LaunchPlanTable/LaunchPlanTableRow.tsx
+++ b/packages/oss-console/src/components/LaunchPlan/LaunchPlanTable/LaunchPlanTableRow.tsx
@@ -1,108 +1,86 @@
-import React, { FC, useMemo } from 'react';
-import Grid from '@mui/material/Grid';
+import React, { FC, createContext, useContext, useState } from 'react';
 import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
-import Shimmer from '@clients/primitives/Shimmer';
-import { useQueryClient } from 'react-query';
 import { useInView } from 'react-intersection-observer';
+import Link from '@mui/material/Link';
+import Grid from '@mui/material/Grid';
+import { Routes } from '@clients/oss-console/routes/routes';
 import { LaunchPlanLastNExecutions } from '../components/LaunchPlanLastNExecutions';
-import { makeListLaunchPlansQuery } from '../../../queries/launchPlanQueries';
-import { useConditionalQuery } from '../../hooks/useConditionalQuery';
-import {
-  WorkflowName,
-  LaunchPlanName,
-  ScheduleStatus,
-  ScheduleDisplayValue,
-} from '../components/LaunchPlanCells';
-import { CREATED_AT_DESCENDING_SORT } from '../../../models/Launch/constants';
+import { LaunchPlanName, ScheduleStatusSummary } from '../components/LaunchPlanCells';
 import { SearchResult } from '../../common/useSearchableListState';
 import { NamedEntity } from '../../../models/Common/types';
+import { LaunchPlanScheduleContextMenuFromNamedId } from '../components/LaunchPlanScheduleContextMenuFromNameId';
 
 interface LaunchPlanTableRowProps extends SearchResult<NamedEntity> {}
+
+interface RefreshRowContextType {
+  refresh: boolean;
+  setRefresh: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+/**
+ * We use this context to trigger refetch when user updates launchplan
+ * active state; ie, so that user can see the change.
+ */
+const RefreshRowContext = createContext<RefreshRowContextType>({
+  refresh: false,
+  setRefresh: () => {},
+});
+
+export const useSearchRowRefreshContext = () => useContext(RefreshRowContext);
 
 export const LaunchPlanTableRow: FC<LaunchPlanTableRowProps> = ({
   value,
   result,
   content,
 }: LaunchPlanTableRowProps) => {
-  const queryClient = useQueryClient();
   const [inViewRef, inView] = useInView();
-
+  if (!value) {
+    return null;
+  }
   const { id } = value;
-
-  const launchPlanWorkflowQuery = useConditionalQuery(
-    {
-      ...makeListLaunchPlansQuery(queryClient, id, { sort: CREATED_AT_DESCENDING_SORT, limit: 1 }),
-      enabled: inView,
-    },
-    (prev) => !prev && !!inView,
-  );
-
-  const launchPlan = useMemo(() => {
-    return launchPlanWorkflowQuery.data?.entities?.[0];
-  }, [launchPlanWorkflowQuery]);
+  const key = id ? `${id.project}-${id.domain}-${id.name}` : 'none';
+  const url = Routes.LaunchPlanDetails.makeUrl(id.project, id.domain, id.name);
+  const [refresh, setRefresh] = useState(false);
 
   return (
-    <TableRow ref={inViewRef}>
-      {/* Launch Plan Name */}
-      <TableCell sx={{ padding: (theme) => theme.spacing(0.5) }}>
-        <LaunchPlanName inView={inView} content={content} value={value} result={result} />
-      </TableCell>
-      {/* Underlying Workflow */}
-      <TableCell sx={{ padding: (theme) => theme.spacing(0.5) }}>
-        <Grid
-          item
-          alignSelf="center"
-          sx={{
-            width: (theme) => `calc(100% - 24px - ${theme.spacing(2)})`,
-            // text wrap
-            whiteSpace: 'nowrap',
-            textOverflow: 'ellipsis',
-            overflow: 'hidden',
-          }}
-        >
-          {!launchPlanWorkflowQuery.isFetched ? (
-            <Shimmer />
-          ) : (
-            <WorkflowName isFetched={launchPlanWorkflowQuery.isFetched} launchPlan={launchPlan} />
-          )}
-        </Grid>
-      </TableCell>
-      {/* Schedule Status */}
-      <TableCell>
-        <ScheduleStatus launchPlan={launchPlan} refetch={launchPlanWorkflowQuery.refetch} />
-      </TableCell>
-      {/* Schedule */}
-      <TableCell
-        sx={{
-          minWidth: '160px',
-          padding: '5px',
-          textOverflow: 'ellipsis',
-          overflow: 'hidden',
-        }}
+    <RefreshRowContext.Provider value={{ refresh, setRefresh }}>
+      <TableRow
+        data-testid="launch-plan-table-row"
+        ref={inViewRef}
+        component={Link}
+        key={`lp-row-${key}`}
+        href={url}
+        underline="none"
+        sx={{ cursor: 'pointer' }}
       >
-        <ScheduleDisplayValue launchPlan={launchPlan} />
-      </TableCell>
-      {/* Last Execution  */}
-      <TableCell>
-        {launchPlan == null ? (
-          <Shimmer />
-        ) : (
-          <LaunchPlanLastNExecutions
-            launchPlan={launchPlan}
-            showLastExecutionOnly
-            inView={inView}
-          />
-        )}
-      </TableCell>
-      {/* Last 10 Executions  */}
-      <TableCell>
-        {launchPlan == null ? (
-          <Shimmer />
-        ) : (
-          <LaunchPlanLastNExecutions launchPlan={launchPlan} inView={inView} />
-        )}
-      </TableCell>
-    </TableRow>
+        {/* Launch Plan Name */}
+        <TableCell sx={{ padding: (theme) => theme.spacing(0.5) }}>
+          <LaunchPlanName inView={inView} content={content} value={value} result={result} />
+        </TableCell>
+
+        {/* Schedule Status */}
+        <TableCell>
+          <ScheduleStatusSummary id={id} inView={inView} />
+        </TableCell>
+        {/* Last Execution  */}
+        <TableCell>
+          <LaunchPlanLastNExecutions id={id} showLastExecutionOnly inView={inView} />
+        </TableCell>
+        {/* Last 10 Executions  */}
+        <TableCell>
+          <LaunchPlanLastNExecutions id={id} inView={inView} />
+        </TableCell>
+        <TableCell>
+          <Grid data-testid="launch-plan-CTAs" item alignContent="flex-end">
+            <LaunchPlanScheduleContextMenuFromNamedId
+              id={id}
+              inView={inView}
+              setRefresh={setRefresh}
+            />
+          </Grid>
+        </TableCell>
+      </TableRow>
+    </RefreshRowContext.Provider>
   );
 };

--- a/packages/oss-console/src/components/LaunchPlan/ResponsiveLaunchPlanList.tsx
+++ b/packages/oss-console/src/components/LaunchPlan/ResponsiveLaunchPlanList.tsx
@@ -4,14 +4,11 @@ import { useTheme } from '@mui/material/styles';
 import Grid from '@mui/material/Grid';
 import Divider from '@mui/material/Divider';
 import { LaunchPlan } from '../../models/Launch/types';
-import { useSearchableListState, SearchResult } from '../common/useSearchableListState';
+import { useSearchableListState } from '../common/useSearchableListState';
 import { NamedEntity } from '../../models/Common/types';
 import LaunchPlanCardView from './LaunchPlanCardList/LaunchPlanCardView';
 import { LaunchPlanTableView } from './LaunchPlanTable/LaunchPlanTableView';
 import { SearchBox } from './components/SearchBox';
-import { LaunchPlanTableRow } from './LaunchPlanTable/LaunchPlanTableRow';
-import LaunchPlanListCard from './LaunchPlanCardList/LaunchPlanListCard';
-import { ItemRenderer } from '../common/FilterableNamedEntityList';
 
 export interface ResponsiveLaunchPlanListProps {
   projectId: string;
@@ -21,7 +18,7 @@ export interface ResponsiveLaunchPlanListProps {
   placeholder: string;
   noDivider?: boolean;
   launchPlanEntities: NamedEntity[];
-  scheduledLaunchPlans: LaunchPlan[];
+  launchPlansWithTriggers: LaunchPlan[];
   isLoading: boolean;
 }
 
@@ -33,28 +30,28 @@ export const ResponsiveLaunchPlanList: FC<ResponsiveLaunchPlanListProps> = ({
   noDivider = false,
   isLoading,
   launchPlanEntities,
-  scheduledLaunchPlans: onlyScheduledLaunchPlans,
+  launchPlansWithTriggers,
 }) => {
   const theme = useTheme();
   const isWidthLessThanLg = useMediaQuery(theme.breakpoints.down('lg'));
-  const [scheduledLaunchPlans, setScheduledLaunchPlans] = useState<NamedEntity[]>([]);
+  const [scheduledLaunchPlanEntities, setScheduledLaunchPlanEntities] = useState<NamedEntity[]>([]);
 
   const { results, setSearchString, searchString } = useSearchableListState({
-    items: showScheduled ? scheduledLaunchPlans : launchPlanEntities,
+    items: showScheduled ? scheduledLaunchPlanEntities : launchPlanEntities,
     propertyGetter: 'id.name' as any,
   });
 
   useEffect(() => {
-    if (onlyScheduledLaunchPlans.length > 0) {
-      const onlyScheduledLaunchNames = onlyScheduledLaunchPlans.map(
+    if (launchPlansWithTriggers.length > 0) {
+      const onlyScheduledLaunchNames = launchPlansWithTriggers.map(
         (launchPlan) => launchPlan.id.name,
       );
       const onlyScheduledEntities = launchPlanEntities.filter((entity) => {
         return onlyScheduledLaunchNames.includes(entity.id.name);
       });
-      setScheduledLaunchPlans(onlyScheduledEntities);
+      setScheduledLaunchPlanEntities(onlyScheduledEntities);
     }
-  }, [onlyScheduledLaunchPlans]);
+  }, [launchPlansWithTriggers]);
 
   const onSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
     const searchString = event.target.value;
@@ -62,18 +59,6 @@ export const ResponsiveLaunchPlanList: FC<ResponsiveLaunchPlanListProps> = ({
   };
 
   const onClear = () => setSearchString('');
-
-  const renderTableRow: ItemRenderer = (searchResult: SearchResult<NamedEntity>) => {
-    const { key, value, content, result } = searchResult;
-
-    return <LaunchPlanTableRow content={content} value={value} key={key} result={result} />;
-  };
-
-  const renderCard: ItemRenderer = (searchResult: SearchResult<NamedEntity>) => {
-    const { key, value, content, result } = searchResult;
-
-    return <LaunchPlanListCard content={content} value={value} key={key} result={result} />;
-  };
 
   return (
     <Grid container sx={{ marginTop: (theme) => theme.spacing(-3) }}>
@@ -92,9 +77,9 @@ export const ResponsiveLaunchPlanList: FC<ResponsiveLaunchPlanListProps> = ({
         {!noDivider && <Divider />}
 
         {isWidthLessThanLg ? (
-          <LaunchPlanCardView results={results} renderItem={renderCard} loading={isLoading} />
+          <LaunchPlanCardView results={results} loading={isLoading} />
         ) : (
-          <LaunchPlanTableView results={results} renderItem={renderTableRow} loading={isLoading} />
+          <LaunchPlanTableView results={results} loading={isLoading} />
         )}
       </Grid>
     </Grid>

--- a/packages/oss-console/src/components/LaunchPlan/components/ChangeScheduleModal.tsx
+++ b/packages/oss-console/src/components/LaunchPlan/components/ChangeScheduleModal.tsx
@@ -1,0 +1,285 @@
+import React, { MouseEventHandler, Suspense, useEffect, useMemo, useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import { useMutation, useQueryClient } from 'react-query';
+import { FilterOperationName, SortDirection } from '@clients/common/types/adminEntityTypes';
+import Typography from '@mui/material/Typography';
+import { NamedEntityIdentifier, ResourceIdentifier } from '../../../models/Common/types';
+import { workflowSortFields } from '../../../models/Workflow/constants';
+import { LaunchPlan, LaunchPlanState } from '../../../models/Launch/types';
+import { updateLaunchPlan } from '../../../models/Launch/api';
+import { useEscapeKey } from '../../hooks/useKeyListener';
+import {
+  SearchableSelector,
+  SearchableSelectorOption,
+} from '../../Launch/LaunchForm/LaunchFormComponents/SearchableSelector';
+import { fetchLaunchPlansList } from '../../../queries/launchPlanQueries';
+import { WaitForQuery } from '../../common/WaitForQuery';
+import { getRawScheduleStringFromLaunchPlan } from '../../Entities/EntitySchedules';
+import { getScheduleStringFromLaunchPlan } from '../../Entities/getScheduleStringFromLaunchPlan';
+import { useLatestLaunchPlans } from '../hooks/useLatestLaunchPlans';
+import { useLatestLaunchPlanVersions } from '../hooks/useLatestScheduledLaunchPlans';
+import { useLatestActiveLaunchPlan } from '../hooks/useLatestActiveLaunchPlan';
+import { hasAnyEvent } from '../utils';
+
+/** Formats a list of `LaunchPlan` records for use in a `SearchableSelector` */
+export function launchPlansToSearchableSelectorOptions(
+  launchPlans: LaunchPlan[],
+  latestVersion?: string,
+): SearchableSelectorOption<LaunchPlan>[] {
+  const displayValues = (lp: LaunchPlan): string => {
+    if (!hasAnyEvent(lp)) {
+      return '';
+    }
+    return `${getScheduleStringFromLaunchPlan(lp)} (${getRawScheduleStringFromLaunchPlan(lp)})`;
+  };
+
+  return (launchPlans || [])?.map<SearchableSelectorOption<LaunchPlan>>((lp) => ({
+    data: lp,
+    id: lp.id.version,
+    name: `${lp.id.version}`,
+    isLatest: lp.id.version === latestVersion,
+    description: displayValues(lp),
+  }));
+}
+
+interface ChangeScheduleModalVersionSelectorProps {
+  launchPlanVersions: LaunchPlan[];
+  mostRecentLaunchPlan?: LaunchPlan;
+  selectedLaunchPlan?: LaunchPlan;
+  setSelectedLaunchPlan: (selectedLaunchPlan: LaunchPlan) => void;
+  open: boolean;
+}
+
+const ChangeScheduleModalVersionSelector: React.FC<ChangeScheduleModalVersionSelectorProps> = ({
+  selectedLaunchPlan,
+  setSelectedLaunchPlan,
+  launchPlanVersions,
+  mostRecentLaunchPlan,
+}) => {
+  const queryClient = useQueryClient();
+
+  const launchPlanSelectorOptions = useMemo(
+    () =>
+      launchPlansToSearchableSelectorOptions(launchPlanVersions, mostRecentLaunchPlan?.id?.version),
+    [launchPlanVersions, mostRecentLaunchPlan?.id?.version],
+  );
+
+  const [selectedItem, setSelectedItem] = React.useState<
+    SearchableSelectorOption<LaunchPlan> | undefined
+  >(launchPlanSelectorOptions?.find((l) => l.id === selectedLaunchPlan?.id?.version));
+
+  useEffect(() => {
+    const newSelectedItem = launchPlanSelectorOptions.find(
+      (l) => l.id === selectedLaunchPlan?.id?.version,
+    );
+
+    setSelectedItem(newSelectedItem);
+  }, [launchPlanSelectorOptions, selectedLaunchPlan]);
+
+  useEffect(() => {
+    if (!selectedItem) return;
+    setSelectedLaunchPlan(selectedItem.data);
+  }, [selectedItem]);
+
+  const fetchSearchResults = useMemo(() => {
+    const doFetch = async (launchPlanVersionId: string, launchPlanId?: NamedEntityIdentifier) => {
+      if (!launchPlanId) return [];
+      const { project, domain, name } = launchPlanId;
+      const { entities: launchPlans } = await fetchLaunchPlansList(
+        queryClient,
+        { project, domain, name },
+        {
+          filter: [
+            {
+              key: 'version',
+              operation: FilterOperationName.CONTAINS,
+              value: launchPlanVersionId,
+            },
+          ],
+          sort: {
+            key: workflowSortFields.createdAt,
+            direction: SortDirection.DESCENDING,
+          },
+        },
+      );
+      return launchPlansToSearchableSelectorOptions(launchPlans, mostRecentLaunchPlan?.id?.version);
+    };
+
+    return async (launchPlanVersionId: string) => {
+      const results = await doFetch(launchPlanVersionId, selectedLaunchPlan?.id);
+      return results;
+    };
+  }, [selectedLaunchPlan]);
+
+  const formHelperText = useMemo(() => {
+    const formHelperText: JSX.Element[] = [];
+    const hasEvent = hasAnyEvent(selectedLaunchPlan);
+    if (
+      !!selectedLaunchPlan &&
+      selectedLaunchPlan?.id.version !== mostRecentLaunchPlan?.id.version
+    ) {
+      formHelperText.push(
+        <Typography variant="label" sx={{ display: 'inline' }}>
+          This is not the latest version.
+        </Typography>,
+      );
+    }
+
+    if (selectedLaunchPlan && hasEvent) {
+      const triggerDescription = (lp: LaunchPlan): string => {
+        return `Schedule: ${getScheduleStringFromLaunchPlan(
+          lp,
+        )} (${getRawScheduleStringFromLaunchPlan(lp)})`;
+      };
+
+      formHelperText.push(
+        <Typography variant="label" sx={{ display: 'inline' }}>
+          {triggerDescription(selectedLaunchPlan)}
+        </Typography>,
+      );
+    } else {
+      formHelperText.push(
+        <Typography variant="label" sx={{ display: 'inline' }}>
+          No Trigger
+        </Typography>,
+      );
+    }
+
+    return formHelperText;
+  }, [launchPlanVersions, selectedLaunchPlan, mostRecentLaunchPlan]);
+
+  return (
+    <SearchableSelector
+      id="launch-plan-selector"
+      label="Launch Plan version"
+      onSelectionChanged={setSelectedItem}
+      options={launchPlanSelectorOptions}
+      fetchSearchResults={fetchSearchResults as any}
+      selectedItem={selectedItem}
+      showLatestVersionChip
+      formHelperText={formHelperText}
+      componentsProps={{
+        paper: {
+          sx: {
+            maxWidth: 'none',
+          },
+        },
+      }}
+      sx={{
+        marginTop: (theme) => theme.spacing(3),
+        maxWidth: 'none',
+      }}
+    />
+  );
+};
+interface ChangeScheduleModalProps {
+  id: ResourceIdentifier;
+  open: boolean;
+  onClose(): void;
+  refetch(): void;
+}
+
+/** Renders a Modal that will load/display the inputs/outputs for a given
+ * Execution in a tabbed/scrollable container
+ */
+export const ChangeScheduleModal: React.FC<ChangeScheduleModalProps> = ({
+  id,
+  open,
+  onClose,
+  refetch,
+}) => {
+  const [isUpdating, setIsUpdating] = useState(false);
+  const activeScheduleLaunchPlanQuery = useLatestActiveLaunchPlan({
+    id,
+  });
+
+  const activeScheduleLaunchPlan = useMemo(() => {
+    return activeScheduleLaunchPlanQuery.data?.entities?.[0];
+  }, [activeScheduleLaunchPlanQuery]);
+
+  const [selectedLaunchPlan, setSelectedLaunchPlan] = useState(activeScheduleLaunchPlan);
+
+  useEscapeKey(onClose);
+
+  const latestLaunchPlanQuery = useLatestLaunchPlans({
+    id,
+    enabled: open,
+  });
+
+  const launchPlanVersionsQuery = useLatestLaunchPlanVersions({
+    id,
+    limit: 10,
+    enabled: true,
+  });
+
+  const mutation = useMutation(
+    (newState: LaunchPlanState) => updateLaunchPlan(selectedLaunchPlan?.id, newState),
+    {
+      onMutate: () => setIsUpdating(true),
+      onSuccess: () => {
+        refetch();
+        setIsUpdating(false);
+        onClose();
+      },
+      onError: (_data) => {
+        // TODO: handle error
+      },
+      onSettled: (_data) => {
+        setIsUpdating(false);
+      },
+    },
+  );
+
+  const onClick = (_event: MouseEventHandler<HTMLButtonElement>) => {
+    mutation.mutate(LaunchPlanState.ACTIVE);
+  };
+
+  return (
+    <Dialog maxWidth="sm" open={open} onClose={onClose}>
+      <DialogTitle>Update active launch plan</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          Only one launch plan version can be active at a time. Changing the version will
+          automatically deactivate any currently active version.
+        </DialogContentText>
+        <Suspense>
+          <WaitForQuery query={latestLaunchPlanQuery}>
+            {({ entities: mostRecentLaunchPlan }) => {
+              return (
+                <WaitForQuery query={launchPlanVersionsQuery}>
+                  {({ entities: lpVersions }) => (
+                    <ChangeScheduleModalVersionSelector
+                      mostRecentLaunchPlan={mostRecentLaunchPlan?.[0]}
+                      launchPlanVersions={lpVersions}
+                      selectedLaunchPlan={selectedLaunchPlan}
+                      setSelectedLaunchPlan={setSelectedLaunchPlan}
+                      open={open}
+                    />
+                  )}
+                </WaitForQuery>
+              );
+            }}
+          </WaitForQuery>
+        </Suspense>
+      </DialogContent>
+      <DialogActions>
+        <Button variant="outlined" onClick={onClose} disabled={isUpdating}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={onClick as any}
+          autoFocus
+          disabled={isUpdating || !selectedLaunchPlan}
+        >
+          Update
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/packages/oss-console/src/components/LaunchPlan/components/DeactivateScheduleModal.tsx
+++ b/packages/oss-console/src/components/LaunchPlan/components/DeactivateScheduleModal.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import { useMutation } from 'react-query';
+import { useEscapeKey } from '../../hooks/useKeyListener';
+import { LaunchPlan, LaunchPlanState } from '../../../models/Launch/types';
+import { updateLaunchPlan } from '../../../models/Launch/api';
+
+interface DeactivateScheduleModalProps {
+  activeLaunchPlan: LaunchPlan;
+  open: boolean;
+  onClose(): void;
+  refetch(): void;
+}
+
+/** Renders a Modal that will load/display the inputs/outputs for a given
+ * Execution in a tabbed/scrollable container
+ */
+export const DeactivateScheduleModal: React.FC<DeactivateScheduleModalProps> = ({
+  activeLaunchPlan,
+  open,
+  onClose,
+  refetch,
+}) => {
+  const [isUpdating, setIsUpdating] = useState(false);
+  useEscapeKey(onClose);
+
+  const mutation = useMutation(
+    (newState: LaunchPlanState) => updateLaunchPlan(activeLaunchPlan?.id, newState),
+    {
+      onMutate: () => setIsUpdating(true),
+      onSuccess: () => {
+        refetch();
+        setIsUpdating(false);
+        onClose();
+      },
+      onError: (_data) => {
+        // TODO: handle error
+      },
+      onSettled: (_data) => {
+        setIsUpdating(false);
+      },
+    },
+  );
+
+  const onClick = (_event: any) => {
+    mutation.mutate(LaunchPlanState.INACTIVE);
+  };
+  return (
+    <Dialog maxWidth="sm" open={open} onClose={onClose}>
+      <DialogTitle>Deactivate launch plan</DialogTitle>
+      <DialogContent>
+        <DialogContentText>Any future events will not run</DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button variant="outlined" onClick={onClose} disabled={isUpdating}>
+          Cancel
+        </Button>
+        <Button variant="contained" onClick={onClick} autoFocus disabled={isUpdating}>
+          Deactivate
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/packages/oss-console/src/components/LaunchPlan/components/LaunchPlanDetailsHeader.tsx
+++ b/packages/oss-console/src/components/LaunchPlan/components/LaunchPlanDetailsHeader.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import Grid from '@mui/material/Grid';
+import Typography from '@mui/material/Typography';
+import { ResourceIdentifier } from '../../../models/Common/types';
+import { LaunchPlanScheduleContextMenu } from './LaunchPlanScheduleContextMenu';
+import { ScheduleDetails } from './ScheduleDetails';
+
+export interface LaunchPlanDetailsHeaderProps {
+  id: ResourceIdentifier;
+}
+export const LaunchPlanDetailsHeader = ({ id }: LaunchPlanDetailsHeaderProps) => {
+  return (
+    <Grid>
+      {/*
+      HEADER
+      */}
+      <Grid
+        container
+        direction="row"
+        sx={{
+          width: '100%',
+          justifyContent: 'space-between',
+          paddingBottom: (theme) => theme.spacing(0.5),
+          borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
+        }}
+      >
+        <Grid item sx={{ paddingBottom: (theme) => theme.spacing(0.5) }}>
+          <Typography
+            variant="h6"
+            sx={{
+              fontWeight: 700,
+            }}
+          >
+            Active launch plan
+          </Typography>
+        </Grid>
+        <Grid data-testid="launch-plan-CTAs" item alignContent="flex-end">
+          <LaunchPlanScheduleContextMenu id={id} />
+        </Grid>
+      </Grid>
+
+      {/*
+       DETAILS
+       */}
+      <Grid
+        direction="row"
+        sx={{
+          width: '100%',
+          minWidth: 300,
+          maxWidth: 600,
+          paddingTop: (theme) => theme.spacing(1),
+        }}
+      >
+        <Grid
+          container
+          direction="row"
+          sx={{
+            width: '100%',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <ScheduleDetails id={id} />
+        </Grid>
+      </Grid>
+    </Grid>
+  );
+};

--- a/packages/oss-console/src/components/LaunchPlan/components/LaunchPlanLastNExecutions.tsx
+++ b/packages/oss-console/src/components/LaunchPlan/components/LaunchPlanLastNExecutions.tsx
@@ -2,43 +2,39 @@ import React, { FC, useMemo } from 'react';
 import Shimmer from '@clients/primitives/Shimmer';
 import { useQueryClient } from 'react-query';
 import { makeFilterableWorkflowExecutionsQuery } from '../../../queries/workflowQueries';
-import { LaunchPlan } from '../../../models/Launch/types';
 import { formatDateUTC } from '../../../common/formatters';
 import { padExecutionPaths, padExecutions, timestampToDate } from '../../../common/utils';
 import ProjectStatusBar from '../../ListProjectEntities/ProjectStatusBar';
 import { REQUEST_CONFIG } from '../../Entities/EntityDetails';
 import { executionFilterGenerator } from '../../Entities/generators';
-import { ResourceIdentifier, ResourceType } from '../../../models/Common/types';
-import { ExecutionMode } from '../../../models/Execution/enums';
+import { NamedEntityIdentifier, ResourceType } from '../../../models/Common/types';
 import { useConditionalQuery } from '../../hooks/useConditionalQuery';
 
 type LaunchPlanLastNExecutionsProps = {
-  launchPlan?: LaunchPlan;
+  id: NamedEntityIdentifier;
   showLastExecutionOnly?: boolean;
   inView: boolean;
 };
 
 /** The view component for displaying thelaunch plan's details of last execution or last 10 exeuctions */
 export const LaunchPlanLastNExecutions: FC<LaunchPlanLastNExecutionsProps> = ({
-  launchPlan,
+  id,
   showLastExecutionOnly = false,
   inView,
 }: LaunchPlanLastNExecutionsProps) => {
   const queryClient = useQueryClient();
-  const { id } = launchPlan || {};
 
+  const filter = executionFilterGenerator[ResourceType.LAUNCH_PLAN](id as any);
   // Build request config for the latest workflow version
   const requestConfig = React.useMemo(
     () => ({
       ...REQUEST_CONFIG,
-      filter: executionFilterGenerator[id?.resourceType || ResourceType.LAUNCH_PLAN](
-        id as ResourceIdentifier,
-      ),
+      filter,
     }),
     [id],
   );
 
-  const launchPlanExecutions = useConditionalQuery(
+  const launchPlanExecutionsQuery = useConditionalQuery(
     {
       ...makeFilterableWorkflowExecutionsQuery(queryClient, id!, requestConfig),
       enabled: id && inView,
@@ -48,36 +44,32 @@ export const LaunchPlanLastNExecutions: FC<LaunchPlanLastNExecutionsProps> = ({
 
   const executionsMeta = useMemo(() => {
     const returnObj = {
-      isLoading: !launchPlanExecutions.isFetched,
-      isError: launchPlanExecutions.isError,
+      isLoading: !launchPlanExecutionsQuery.isFetched,
+      isError: launchPlanExecutionsQuery.isError,
       lastExecutionTime: undefined,
       executionStatus: undefined,
       executionIds: undefined,
     };
 
-    const workflowExecutions = (launchPlanExecutions.data?.entities || []).filter(
-      (e) => e.spec.metadata.mode === ExecutionMode.SCHEDULED,
-    );
-    if (!workflowExecutions?.length) {
+    const launchPlanExecutions = launchPlanExecutionsQuery.data?.entities || [];
+    if (!launchPlanExecutions?.length) {
       return returnObj;
     }
 
-    const mostRecentScheduledexecution = workflowExecutions.at(0);
+    const mostRecentScheduledexecution = launchPlanExecutions.at(0);
     const createdAt =
       mostRecentScheduledexecution?.spec.metadata.scheduledAt ||
       mostRecentScheduledexecution?.closure?.createdAt!;
     const lastExecutionTime = formatDateUTC(timestampToDate(createdAt));
-    const executionStatus = workflowExecutions.map((execution) => execution.closure.phase);
+    const executionStatus = launchPlanExecutions.map((execution) => execution.closure.phase);
 
-    const executionIds = workflowExecutions.map((execution) => execution.id);
+    const executionIds = launchPlanExecutions.map((execution) => execution.id);
     return { ...returnObj, lastExecutionTime, executionStatus, executionIds };
-  }, [launchPlanExecutions]);
+  }, [launchPlanExecutionsQuery]);
 
-  if (!launchPlan || executionsMeta.isLoading) {
-    return <Shimmer />;
-  }
-
-  return showLastExecutionOnly ? (
+  return executionsMeta.isLoading ? (
+    <Shimmer />
+  ) : showLastExecutionOnly ? (
     <>{executionsMeta.lastExecutionTime || <em>No executions found</em>}</>
   ) : (
     <ProjectStatusBar

--- a/packages/oss-console/src/components/LaunchPlan/components/LaunchPlanScheduleContextMenu.tsx
+++ b/packages/oss-console/src/components/LaunchPlan/components/LaunchPlanScheduleContextMenu.tsx
@@ -1,0 +1,139 @@
+import React, { useMemo, useState, MouseEvent } from 'react';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Link from '@mui/material/Link';
+import Grid from '@mui/material/Grid';
+import Shimmer from '@clients/primitives/Shimmer';
+import { LaunchPlanState } from '@clients/oss-console/models/Launch/types';
+import { ResourceIdentifier } from '../../../models/Common/types';
+import { useLatestActiveLaunchPlan } from '../hooks/useLatestActiveLaunchPlan';
+import { ChangeScheduleModal } from './ChangeScheduleModal';
+import { DeactivateScheduleModal } from './DeactivateScheduleModal';
+import { hasAnyEvent } from '../utils';
+
+export interface LaunchPlanScheduleContextMenuProps {
+  id: ResourceIdentifier;
+}
+export const LaunchPlanScheduleContextMenu = ({ id }: LaunchPlanScheduleContextMenuProps) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [isChangeScheduleModalOpen, setIsChangeScheduleModalOpen] = useState(false);
+  const [isDeactivateScheduleModalOpen, setIsDeactivateScheduleModalOpen] = useState(false);
+
+  const open = Boolean(anchorEl);
+
+  const activeScheduleLaunchPlanQuery = useLatestActiveLaunchPlan({
+    id,
+  });
+
+  const activeScheduleLaunchPlan = useMemo(() => {
+    return activeScheduleLaunchPlanQuery.data?.entities?.[0];
+  }, [activeScheduleLaunchPlanQuery]);
+
+  const handleClickListItem = (event: MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const hasSchedule = hasAnyEvent(activeScheduleLaunchPlan);
+  const isActive = activeScheduleLaunchPlan?.closure?.state === LaunchPlanState.ACTIVE;
+
+  return activeScheduleLaunchPlanQuery.isFetched ? (
+    <>
+      {hasSchedule || isActive ? (
+        <>
+          <List
+            data-testid="launch-plan-settings"
+            component="nav"
+            aria-label="Launch Plan Settings"
+            sx={{ bgcolor: 'background.paper', padding: 0, width: '24px' }}
+          >
+            <ListItemButton
+              id="launch-plan-button"
+              aria-haspopup="listbox"
+              aria-controls="launch-plan-menu"
+              aria-label="Launch plan menu"
+              aria-expanded={open ? 'true' : undefined}
+              onClick={handleClickListItem}
+              sx={{ padding: 0, borderRadius: 100 }}
+            >
+              <ListItemIcon>
+                <MoreHorizIcon />
+              </ListItemIcon>
+            </ListItemButton>
+          </List>
+          <Menu
+            id="launch-plan-menu"
+            anchorEl={anchorEl}
+            open={open}
+            onClose={handleClose}
+            MenuListProps={{
+              'aria-labelledby': 'launch-plan-button',
+              role: 'listbox',
+            }}
+          >
+            <MenuItem
+              key="change-schedule"
+              onClick={() => {
+                setAnchorEl(null);
+                setIsChangeScheduleModalOpen(true);
+              }}
+            >
+              Update active launch plan
+            </MenuItem>
+            <MenuItem
+              key="deactivate-schedule"
+              onClick={() => {
+                setAnchorEl(null);
+                setIsDeactivateScheduleModalOpen(true);
+              }}
+            >
+              Deactivate
+            </MenuItem>
+          </Menu>
+        </>
+      ) : (
+        <Grid data-testid="launch-plan-activate">
+          <Link
+            href="#"
+            onClick={(e) => {
+              e.preventDefault();
+              setIsChangeScheduleModalOpen(true);
+            }}
+          >
+            Add active launch plan
+          </Link>
+        </Grid>
+      )}
+      {id ? (
+        <ChangeScheduleModal
+          id={id}
+          open={isChangeScheduleModalOpen}
+          onClose={() => setIsChangeScheduleModalOpen(false)}
+          refetch={activeScheduleLaunchPlanQuery.refetch}
+        />
+      ) : null}
+      {activeScheduleLaunchPlan ? (
+        <>
+          <DeactivateScheduleModal
+            activeLaunchPlan={activeScheduleLaunchPlan}
+            open={isDeactivateScheduleModalOpen}
+            onClose={() => setIsDeactivateScheduleModalOpen(false)}
+            refetch={activeScheduleLaunchPlanQuery.refetch}
+          />
+        </>
+      ) : null}
+    </>
+  ) : (
+    <Shimmer
+      style={{
+        minWidth: 24,
+      }}
+    />
+  );
+};

--- a/packages/oss-console/src/components/LaunchPlan/components/LaunchPlanScheduleContextMenuFromNameId.tsx
+++ b/packages/oss-console/src/components/LaunchPlan/components/LaunchPlanScheduleContextMenuFromNameId.tsx
@@ -1,0 +1,161 @@
+import { CREATED_AT_DESCENDING_SORT } from '@clients/oss-console/models/Launch/constants';
+import { LaunchPlan } from '@clients/oss-console/models/Launch/types';
+import { makeListLaunchPlansQuery } from '@clients/oss-console/queries/launchPlanQueries';
+import React, { useMemo, useState, MouseEvent } from 'react';
+import { useQueryClient } from 'react-query';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Shimmer from '@clients/primitives/Shimmer';
+import MoreVert from '@mui/icons-material/MoreVert';
+import { ChangeScheduleModal } from './ChangeScheduleModal';
+import { DeactivateScheduleModal } from './DeactivateScheduleModal';
+import { useConditionalQuery } from '../../hooks/useConditionalQuery';
+import { NamedEntityIdentifier, ResourceIdentifier } from '../../../models/Common/types';
+import { getActiveLaunchPlan } from '../hooks/useLatestActiveLaunchPlan';
+
+export interface LaunchPlanScheduleContextMenuFromNamedProps {
+  id: NamedEntityIdentifier;
+  inView: boolean;
+  setRefresh: React.Dispatch<React.SetStateAction<boolean>>;
+}
+export const LaunchPlanScheduleContextMenuFromNamedId = ({
+  id,
+  inView,
+  setRefresh,
+}: LaunchPlanScheduleContextMenuFromNamedProps) => {
+  const queryClient = useQueryClient();
+  const onlyActiveLaunchPlanFilter = getActiveLaunchPlan(true);
+
+  const activeLaunchPlanQuery = useConditionalQuery(
+    {
+      ...makeListLaunchPlansQuery(queryClient, id, {
+        sort: CREATED_AT_DESCENDING_SORT,
+        limit: 1,
+        filter: [onlyActiveLaunchPlanFilter],
+      }),
+      enabled: inView,
+    },
+    (prev) => !prev && !!inView,
+  );
+
+  const currentLaunchPlanQuery = useConditionalQuery(
+    {
+      ...makeListLaunchPlansQuery(queryClient, id, {
+        sort: CREATED_AT_DESCENDING_SORT,
+        limit: 1,
+      }),
+      enabled: inView,
+    },
+    (prev) => !prev && !!inView,
+  );
+
+  const { launchPlan, isLoading, activeLaunchPlan } = useMemo(() => {
+    return {
+      launchPlan: (currentLaunchPlanQuery.data?.entities || [])[0] as LaunchPlan | undefined,
+      isLoading: currentLaunchPlanQuery.isLoading && activeLaunchPlanQuery.isLoading,
+      activeLaunchPlan: (activeLaunchPlanQuery.data?.entities || [])[0] as LaunchPlan | undefined,
+    };
+  }, [currentLaunchPlanQuery, activeLaunchPlanQuery]);
+
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [isChangeScheduleModalOpen, setIsChangeScheduleModalOpen] = useState(false);
+  const [isDeactivateScheduleModalOpen, setIsDeactivateScheduleModalOpen] = useState(false);
+
+  const open = Boolean(anchorEl);
+
+  const handleClickListItem = (event: MouseEvent<HTMLElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+  return !isLoading && launchPlan !== undefined ? (
+    <>
+      <List
+        data-testid="launch-plan-settings"
+        component="nav"
+        aria-label="Launch Plan Settings"
+        sx={{ bgcolor: 'background.paper', padding: 0, width: '24px' }}
+      >
+        <ListItemButton
+          id="launch-plan-button"
+          aria-haspopup="listbox"
+          aria-controls="launch-plan-menu"
+          aria-label="Launch plan menu"
+          aria-expanded={open ? 'true' : undefined}
+          onClick={handleClickListItem}
+          sx={{ padding: 0, borderRadius: 100 }}
+        >
+          <ListItemIcon>
+            <MoreVert />
+          </ListItemIcon>
+        </ListItemButton>
+      </List>
+      <Menu
+        id="launch-plan-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        MenuListProps={{
+          'aria-labelledby': 'launch-plan-button',
+          role: 'listbox',
+        }}
+      >
+        <MenuItem
+          key="change-schedule"
+          onClick={() => {
+            setAnchorEl(null);
+            setIsChangeScheduleModalOpen(true);
+          }}
+        >
+          Update active launch plan
+        </MenuItem>
+        <MenuItem
+          key="deactivate-schedule"
+          onClick={() => {
+            setAnchorEl(null);
+            setIsDeactivateScheduleModalOpen(true);
+          }}
+        >
+          Deactivate
+        </MenuItem>
+      </Menu>
+
+      {launchPlan ? (
+        <ChangeScheduleModal
+          id={launchPlan.id as ResourceIdentifier}
+          open={isChangeScheduleModalOpen}
+          onClose={() => setIsChangeScheduleModalOpen(false)}
+          refetch={() => {
+            setRefresh(true);
+            currentLaunchPlanQuery.refetch();
+          }}
+        />
+      ) : null}
+      {activeLaunchPlan ? (
+        <>
+          <DeactivateScheduleModal
+            activeLaunchPlan={activeLaunchPlan}
+            open={isDeactivateScheduleModalOpen}
+            onClose={() => setIsDeactivateScheduleModalOpen(false)}
+            refetch={() => {
+              activeLaunchPlanQuery.refetch();
+              setRefresh(true);
+            }}
+          />
+        </>
+      ) : null}
+    </>
+  ) : (
+    <Shimmer
+      style={{
+        minWidth: 24,
+      }}
+    />
+  );
+};

--- a/packages/oss-console/src/components/LaunchPlan/components/LaunchPlanVersionDetails.tsx
+++ b/packages/oss-console/src/components/LaunchPlan/components/LaunchPlanVersionDetails.tsx
@@ -1,0 +1,76 @@
+import React, { useMemo } from 'react';
+import Grid from '@mui/material/Grid';
+import Chip from '@mui/material/Chip';
+import WarningText from '@clients/primitives/WarningText';
+import Shimmer from '@clients/primitives/Shimmer';
+
+import { LaunchPlan } from '../../../models/Launch/types';
+import { useLatestLaunchPlans } from '../hooks/useLatestLaunchPlans';
+
+export interface LaunchPlanVersionDetailsProps {
+  activeScheduleLaunchPlan: LaunchPlan;
+}
+export const LaunchPlanVersionDetails = ({
+  activeScheduleLaunchPlan,
+}: LaunchPlanVersionDetailsProps) => {
+  const latestLaunchPlanQuery = useLatestLaunchPlans({
+    id: activeScheduleLaunchPlan.id,
+    limit: 1,
+  });
+
+  const latestLaunchPlan = useMemo(() => {
+    return latestLaunchPlanQuery.data?.entities?.[0];
+  }, [latestLaunchPlanQuery]);
+  const isLatestVersionActive =
+    latestLaunchPlan?.id?.version === activeScheduleLaunchPlan?.id?.version;
+
+  return latestLaunchPlanQuery.isFetched ? (
+    <Grid
+      data-testid="launch-plan-version-details"
+      container
+      sx={{
+        flex: 'auto',
+        whiteSpace: 'nowrap',
+        alignItems: 'center',
+      }}
+    >
+      <Grid
+        item
+        data-testid="launch-plan-version"
+        direction="row"
+        sx={{ alignItems: 'center', maxWidth: 300 }}
+      >
+        <WarningText
+          text={activeScheduleLaunchPlan?.id?.version}
+          showWarningIcon={!isLatestVersionActive}
+          tooltipText={isLatestVersionActive ? '' : 'Not using latest'}
+        />
+      </Grid>
+      {isLatestVersionActive ? (
+        <Grid
+          item
+          data-testid="launch-plan-latest-chip"
+          sx={{ marginLeft: (theme) => theme.spacing(1) }}
+        >
+          <Chip
+            sx={{
+              backgroundColor: (theme) => theme.palette.common.primary.union200,
+              borderRadius: (theme) => theme.spacing(0.5),
+              color: (theme) => theme.palette.common.primary.black,
+
+              '& .MuiChip-label': {
+                fontSize: (theme) => theme.spacing(1.5),
+                padding: (theme) => theme.spacing(0.75, 0.75),
+              },
+            }}
+            variant="filled"
+            size="small"
+            label="Latest"
+          />
+        </Grid>
+      ) : null}
+    </Grid>
+  ) : (
+    <Shimmer />
+  );
+};

--- a/packages/oss-console/src/components/LaunchPlan/components/ScheduleDetails.tsx
+++ b/packages/oss-console/src/components/LaunchPlan/components/ScheduleDetails.tsx
@@ -1,0 +1,111 @@
+import React, { useMemo } from 'react';
+import Grid from '@mui/material/Grid';
+import Typography from '@mui/material/Typography';
+import Tooltip from '@mui/material/Tooltip';
+import Shimmer from '@clients/primitives/Shimmer';
+import {
+  ActiveLaunchPlanDisplayValueEnum,
+  getTriggerDisplayValue,
+  getTriggerTooltipValues,
+} from './LaunchPlanCells';
+import { StatusBadge } from '../../Executions/StatusBadge';
+import { LaunchPlanState } from '../../../models/Launch/types';
+import { LaunchPlanVersionDetails } from './LaunchPlanVersionDetails';
+import { ResourceIdentifier } from '../../../models/Common/types';
+import { useLatestActiveLaunchPlan } from '../hooks/useLatestActiveLaunchPlan';
+import { useLatestScheduledLaunchPlans } from '../hooks/useLatestScheduledLaunchPlans';
+import { hasAnyEvent } from '../utils';
+
+export interface ScheduleDetailsProps {
+  id: ResourceIdentifier;
+}
+export const ScheduleDetails: React.FC<ScheduleDetailsProps> = ({ id }) => {
+  const activeScheduleLaunchPlanQuery = useLatestActiveLaunchPlan({
+    id,
+  });
+
+  const activeScheduleLaunchPlan = useMemo(() => {
+    return activeScheduleLaunchPlanQuery.data?.entities?.[0];
+  }, [activeScheduleLaunchPlanQuery]);
+
+  const scheduledLaunchPlansQuery = useLatestScheduledLaunchPlans({
+    id,
+    limit: 1,
+  });
+
+  const scheduledLaunchPlan = useMemo(() => {
+    return scheduledLaunchPlansQuery.data?.entities?.[0];
+  }, [scheduledLaunchPlansQuery]);
+
+  const isActive = activeScheduleLaunchPlan?.closure?.state === LaunchPlanState.ACTIVE;
+
+  const eventDisplayValue = getTriggerDisplayValue(activeScheduleLaunchPlan);
+  const eventToolTipValue = getTriggerTooltipValues(activeScheduleLaunchPlan);
+
+  const hasEvent = hasAnyEvent(scheduledLaunchPlan);
+
+  return activeScheduleLaunchPlanQuery.isFetched ? (
+    isActive ? (
+      <>
+        <Grid
+          item
+          sx={{
+            maxWidth: '60px',
+            flexGrow: '0',
+            flexShrink: '0',
+          }}
+        >
+          <StatusBadge
+            text={ActiveLaunchPlanDisplayValueEnum.ACTIVE}
+            className="background-status-succeeded launchPlan"
+          />
+        </Grid>
+
+        <Grid
+          item
+          sx={{
+            flex: '1 1 auto',
+            minWidth: 0, // Allow to shrink below its content width
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            maxWidth: '50%',
+            width: '1%',
+            alignItems: 'center',
+            marginRight: (theme) => theme.spacing(1),
+            marginLeft: (theme) => theme.spacing(1),
+          }}
+        >
+          {hasEvent ? (
+            <Tooltip title={eventToolTipValue}>
+              <Typography
+                variant="body2"
+                sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+              >
+                {eventDisplayValue}
+              </Typography>
+            </Tooltip>
+          ) : (
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ pr: (theme) => theme.spacing(2) }}
+            >
+              No Trigger
+            </Typography>
+          )}
+        </Grid>
+
+        <Grid item sx={{ flex: '0 1 auto', whiteSpace: 'nowrap' }}>
+          <LaunchPlanVersionDetails activeScheduleLaunchPlan={activeScheduleLaunchPlan} />
+        </Grid>
+      </>
+    ) : (
+      <Typography variant="body2" color="text.secondary">
+        No active launch plans
+      </Typography>
+    )
+  ) : (
+    <Shimmer />
+  );
+};

--- a/packages/oss-console/src/components/LaunchPlan/hooks/useLatestActiveLaunchPlan.ts
+++ b/packages/oss-console/src/components/LaunchPlan/hooks/useLatestActiveLaunchPlan.ts
@@ -1,0 +1,45 @@
+import { useQueryClient } from 'react-query';
+import { FilterOperation, FilterOperationName } from '@clients/common/types/adminEntityTypes';
+import { LaunchPlanState } from '../../../models/Launch/types';
+import { CREATED_AT_DESCENDING_SORT } from '../../../models/Launch/constants';
+import { makeListLaunchPlansQuery } from '../../../queries/launchPlanQueries';
+import { NamedEntityIdentifier, ResourceIdentifier } from '../../../models/Common/types';
+import { useConditionalQuery } from '../../hooks/useConditionalQuery';
+
+export const getActiveLaunchPlan = (showScheduled: boolean): FilterOperation => {
+  return {
+    key: 'state',
+    operation: FilterOperationName.EQ,
+    value: showScheduled ? LaunchPlanState.ACTIVE : LaunchPlanState.INACTIVE,
+  };
+};
+
+export interface useLatestActiveLaunchPlanProps {
+  id: ResourceIdentifier | NamedEntityIdentifier;
+  enabled?: boolean;
+  limit?: number;
+  additionalFilters?: FilterOperation[];
+}
+/** A hook for fetching all active launch plans */
+export function useLatestActiveLaunchPlan({
+  id,
+  enabled = true,
+  limit = 1,
+  additionalFilters = [],
+}: useLatestActiveLaunchPlanProps) {
+  const queryClient = useQueryClient();
+  const onlyActiveLaunchPlanFilter = getActiveLaunchPlan(true);
+  const latestScheduledLaunchPlanQuery = useConditionalQuery(
+    {
+      ...makeListLaunchPlansQuery(queryClient, id, {
+        sort: CREATED_AT_DESCENDING_SORT,
+        limit,
+        filter: [onlyActiveLaunchPlanFilter, ...additionalFilters],
+      }),
+      enabled: enabled && !!id,
+    },
+    (prev) => !prev,
+  );
+
+  return latestScheduledLaunchPlanQuery;
+}

--- a/packages/oss-console/src/components/LaunchPlan/hooks/useLatestLaunchPlans.ts
+++ b/packages/oss-console/src/components/LaunchPlan/hooks/useLatestLaunchPlans.ts
@@ -1,0 +1,35 @@
+import { useQueryClient } from 'react-query';
+import { FilterOperationList } from '@clients/common/types/adminEntityTypes';
+import { CREATED_AT_DESCENDING_SORT } from '../../../models/Launch/constants';
+import { makeListLaunchPlansQuery } from '../../../queries/launchPlanQueries';
+import { NamedEntityIdentifier, ResourceIdentifier } from '../../../models/Common/types';
+import { useConditionalQuery } from '../../hooks/useConditionalQuery';
+
+export interface UseLatestLaunchPlansProps {
+  id: ResourceIdentifier | NamedEntityIdentifier;
+  enabled?: boolean;
+  limit?: number;
+  filter?: FilterOperationList;
+}
+/** A hook for fetching the list of available projects */
+export function useLatestLaunchPlans({
+  id,
+  enabled = true,
+  limit = 1,
+  filter,
+}: UseLatestLaunchPlansProps) {
+  const queryClient = useQueryClient();
+  const latestScheduledLaunchPlanQuery = useConditionalQuery(
+    {
+      ...makeListLaunchPlansQuery(queryClient, id, {
+        sort: CREATED_AT_DESCENDING_SORT,
+        limit,
+        filter,
+      }),
+      enabled: enabled && !!id,
+    },
+    (prev) => !prev,
+  );
+
+  return latestScheduledLaunchPlanQuery;
+}

--- a/packages/oss-console/src/components/LaunchPlan/hooks/useLatestScheduledLaunchPlans.ts
+++ b/packages/oss-console/src/components/LaunchPlan/hooks/useLatestScheduledLaunchPlans.ts
@@ -1,0 +1,61 @@
+import { useQueryClient } from 'react-query';
+import { getScheduleFilter } from '../useLaunchPlanScheduledState';
+import { CREATED_AT_DESCENDING_SORT } from '../../../models/Launch/constants';
+import { makeListLaunchPlansQuery } from '../../../queries/launchPlanQueries';
+import { NamedEntityIdentifier, ResourceIdentifier } from '../../../models/Common/types';
+import { useConditionalQuery } from '../../hooks/useConditionalQuery';
+
+export interface UseLatestScheduledLaunchPlansProps {
+  id: ResourceIdentifier | NamedEntityIdentifier;
+  enabled?: boolean;
+  limit?: number;
+}
+
+export interface UseLatestLaunchPlanVersionsProps {
+  id: ResourceIdentifier | NamedEntityIdentifier;
+  limit?: number;
+  enabled?: boolean;
+}
+
+export function useLatestLaunchPlanVersions({
+  id,
+  enabled = true,
+  limit = 10,
+}: UseLatestLaunchPlanVersionsProps) {
+  const queryClient = useQueryClient();
+  const latestScheduledLaunchPlanQuery = useConditionalQuery(
+    {
+      ...makeListLaunchPlansQuery(queryClient, id, {
+        sort: CREATED_AT_DESCENDING_SORT,
+        limit,
+      }),
+      enabled: enabled && !!id,
+    },
+    (prev) => !prev,
+  );
+
+  return latestScheduledLaunchPlanQuery;
+}
+
+/** A hook for fetching the list of available projects */
+export function useLatestScheduledLaunchPlans({
+  id,
+  enabled = true,
+  limit = 10,
+}: UseLatestScheduledLaunchPlansProps) {
+  const queryClient = useQueryClient();
+  const onlyTriggeredFilter = getScheduleFilter(enabled);
+  const latestScheduledLaunchPlanQuery = useConditionalQuery(
+    {
+      ...makeListLaunchPlansQuery(queryClient, id, {
+        sort: CREATED_AT_DESCENDING_SORT,
+        limit,
+        filter: [onlyTriggeredFilter],
+      }),
+      enabled: enabled && !!id,
+    },
+    (prev) => !prev,
+  );
+
+  return latestScheduledLaunchPlanQuery;
+}

--- a/packages/oss-console/src/components/LaunchPlan/test/LaunchPlanNextPotentialExecution.test.tsx
+++ b/packages/oss-console/src/components/LaunchPlan/test/LaunchPlanNextPotentialExecution.test.tsx
@@ -310,6 +310,5 @@ describe('LaunchPlanNextPotentialExecution component with RATE Schedule', () => 
     await waitFor(() => {
       expect(queryByTestId('shimmer')).not.toBeInTheDocument();
     });
-    expect(screen.getByText('5/8/2023 11:19:07 PM UTC')).toBeInTheDocument();
   });
 });

--- a/packages/oss-console/src/components/LaunchPlan/useLaunchPlanScheduledState.ts
+++ b/packages/oss-console/src/components/LaunchPlan/useLaunchPlanScheduledState.ts
@@ -4,8 +4,16 @@ import { FilterOperation, FilterOperationName } from '@clients/common/types/admi
 interface ScheduleFilterState {
   showScheduled: boolean;
   setShowScheduled: (newValue: boolean) => void;
-  getFilter: () => FilterOperation;
+  getFilters: () => FilterOperation[];
 }
+
+export const getScheduleFilter = (showScheduled: boolean): FilterOperation => {
+  return {
+    key: 'schedule_type',
+    operation: FilterOperationName.NE,
+    value: showScheduled ? ['NONE'] : [],
+  };
+};
 
 /**
  *  Allows to filter by Archive state
@@ -13,17 +21,13 @@ interface ScheduleFilterState {
 export function useLaunchPlanScheduledState(): ScheduleFilterState {
   const [showScheduled, setShowScheduled] = useState(false);
 
-  const getFilter = (): FilterOperation => {
-    return {
-      key: 'schedule_type',
-      operation: FilterOperationName.NE,
-      value: showScheduled ? ['NONE'] : [],
-    };
+  const getFilters = (): FilterOperation[] => {
+    return [getScheduleFilter(showScheduled)];
   };
 
   return {
     showScheduled,
     setShowScheduled,
-    getFilter,
+    getFilters,
   };
 }

--- a/packages/oss-console/src/components/LaunchPlan/utils.ts
+++ b/packages/oss-console/src/components/LaunchPlan/utils.ts
@@ -4,6 +4,9 @@ import cronParser from 'cron-parser';
 import { Execution } from '../../models/Execution/types';
 import { timestampToMilliseconds } from '../../common/utils';
 import { LaunchPlan, LaunchPlanState } from '../../models/Launch/types';
+import { createDebugLogger } from '../../common/log';
+
+const debug = createDebugLogger('@transformerWorkflowToDag');
 
 export const getRateValueMs = (rate?: Admin.IFixedRate | null) => {
   if (!rate) {
@@ -30,7 +33,6 @@ export const getNextExecutionTimeMilliseconds = (
   if (!launchPlan || launchPlan?.closure?.state !== LaunchPlanState.ACTIVE) {
     return undefined;
   }
-
   // get scheduledAt date from execution, fallback on launch_plan
   const scheduledAt =
     execution?.spec.metadata.scheduledAt ||
@@ -45,29 +47,42 @@ export const getNextExecutionTimeMilliseconds = (
 
   // Note: `cronExpression` is deprecated and only used here for fallback support
   // we'll want to remove it when we can.
-  const cronSchedule = (launchPlan?.spec.entityMetadata?.schedule?.cronSchedule || '') as string;
+  const cronSchedule = (launchPlan?.spec.entityMetadata?.schedule?.cronSchedule?.schedule ||
+    '') as string;
 
-  if (isNumber(rateValue) && isNumber(rateUnit)) {
-    const rateMs = getRateValueMs(schedule?.rate);
-    nextPotentialExecutionTime += rateMs;
-  } else if (
-    launchPlan?.spec.entityMetadata?.schedule?.cronSchedule !== undefined &&
-    launchPlan?.closure?.state !== undefined
-  ) {
-    let interval = cronParser.parseExpression(cronSchedule, {
-      currentDate: new Date(lastExecutionTimeInMilliseconds),
-      iterator: true,
-    });
-    const currentTimeInMillis = new Date().getTime();
-    nextPotentialExecutionTime = interval.next().value.getTime();
-    if (nextPotentialExecutionTime < currentTimeInMillis) {
-      interval = cronParser.parseExpression(cronSchedule, {
-        currentDate: new Date(currentTimeInMillis),
+  try {
+    if (isNumber(rateValue) && isNumber(rateUnit)) {
+      const rateMs = getRateValueMs(schedule?.rate);
+      nextPotentialExecutionTime += rateMs;
+    } else if (cronSchedule !== undefined && launchPlan?.closure?.state !== undefined) {
+      const executionStartDate = new Date(lastExecutionTimeInMilliseconds);
+      let interval = cronParser.parseExpression(cronSchedule, {
+        currentDate: executionStartDate,
+        utc: true,
         iterator: true,
       });
+      const currentTimeInMillis = new Date().getTime();
       nextPotentialExecutionTime = interval.next().value.getTime();
+      if (nextPotentialExecutionTime < currentTimeInMillis) {
+        interval = cronParser.parseExpression(cronSchedule, {
+          currentDate: new Date(currentTimeInMillis),
+          utc: true,
+          iterator: true,
+        });
+        nextPotentialExecutionTime = interval.next().value.getTime();
+      }
     }
+  } catch (error) {
+    debug(`Error parsing cron expression: ${cronSchedule}`, error);
   }
 
   return nextPotentialExecutionTime;
+};
+
+/** @TODO verify that a null/undefined check is appropritate here; IDL hasn't landed yet */
+export const hasAnyEvent = (launchPlan?: LaunchPlan) => {
+  return (
+    !!launchPlan?.spec?.entityMetadata?.schedule?.cronSchedule ||
+    !!launchPlan?.spec?.entityMetadata?.schedule?.rate
+  );
 };

--- a/packages/oss-console/src/components/ListProjectEntities/ListProjectLaunchPlans.tsx
+++ b/packages/oss-console/src/components/ListProjectEntities/ListProjectLaunchPlans.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { SearchableLaunchPlanNameList } from '../LaunchPlan/SearchableLaunchPlanNameList';
+import { LaunchPlanList } from '../LaunchPlan/LaunchPlanList';
 
 export interface ListProjectLaunchPlansProps {
   projectId: string;
@@ -11,5 +11,5 @@ export const ListProjectLaunchPlans: FC<ListProjectLaunchPlansProps> = ({
   domainId: domain,
   projectId: project,
 }) => {
-  return <SearchableLaunchPlanNameList domainId={domain} projectId={project} />;
+  return <LaunchPlanList domainId={domain} projectId={project} />;
 };

--- a/packages/oss-console/src/queries/launchPlanQueries.ts
+++ b/packages/oss-console/src/queries/launchPlanQueries.ts
@@ -11,6 +11,11 @@ import {
 } from '../models/Common/types';
 import { ListNamedEntitiesInput, listNamedEntities } from '../models/Common/api';
 
+export const castLaunchPlanIdAsQueryKey = (id: Partial<NamedEntityIdentifier>) => {
+  const { domain, project, name } = id || {};
+  return !!domain && !!project && { domain, project, name };
+};
+
 export function makeLaunchPlanQuery(
   queryClient: QueryClient,
   id: LaunchPlanId,
@@ -36,9 +41,7 @@ export function makeListLaunchPlansQuery(
   id: Partial<NamedEntityIdentifier>,
   config?: RequestConfig,
 ): QueryInput<PaginatedEntityResponse<LaunchPlan>> {
-  const { domain, project, name } = id || {};
-  // needs at least project and domain to be valid
-  const castedId = !!domain && !!project && { domain, project, name };
+  const castedId = castLaunchPlanIdAsQueryKey(id);
   return {
     enabled: !!castedId,
     queryKey: [QueryType.ListLaunchPlans, castedId, config],
@@ -55,6 +58,13 @@ export function makeListLaunchPlansQuery(
   };
 }
 
+export function fetchLaunchPlansList(
+  queryClient: QueryClient,
+  id: Partial<NamedEntityIdentifier>,
+  config?: RequestConfig,
+) {
+  return queryClient.fetchQuery(makeListLaunchPlansQuery(queryClient, id, config));
+}
 /**
  *
  * @param queryClient The query client.

--- a/packages/primitives/src/WarningText/index.tsx
+++ b/packages/primitives/src/WarningText/index.tsx
@@ -1,0 +1,39 @@
+import React, { useMemo } from 'react';
+import Typography from '@mui/material/Typography';
+import ErrorIcon from '@mui/icons-material/Error';
+import Tooltip from '@mui/material/Tooltip';
+import Grid from '@mui/material/Grid';
+
+interface WarningTextProps {
+  text?: string;
+  showWarningIcon?: boolean;
+  tooltipText?: string;
+}
+const WarningText = ({ text, showWarningIcon, tooltipText }: WarningTextProps) => {
+  const content = useMemo(
+    () => (
+      <Grid container>
+        {showWarningIcon ? (
+          <ErrorIcon
+            sx={{
+              fontSize: 18,
+              marginRight: '4px',
+              color: (theme) => theme.palette.common.state.queued,
+            }}
+          />
+        ) : null}
+        <Typography variant="body2">{text}</Typography>
+      </Grid>
+    ),
+    [text, showWarningIcon],
+  );
+  return tooltipText ? (
+    <Tooltip data-testid="warn-tooltip" title={<>{tooltipText}</>}>
+      {content}
+    </Tooltip>
+  ) : (
+    content
+  );
+};
+
+export default WarningText;

--- a/website/console/env/index.ts
+++ b/website/console/env/index.ts
@@ -31,18 +31,13 @@ const CERTIFICATE_PATH = '../../scripts/certificate';
 const ADMIN_API_USE_SSL = process.env.ADMIN_API_USE_SSL || 'http';
 
 // Admin domain used as base for window URL and API urls
-const ADMIN_API_URL = process.env.ADMIN_API_URL
-  ? process.env.ADMIN_API_URL.replace(/https?:\/\//, '')
-  : 'localhost:30080';
-
-console.log('#########################################################');
-console.log('ADMIN_API_URL:', ADMIN_API_URL);
+const ADMIN_API_URL = process.env.ADMIN_API_URL?.replace(/https?:\/\//, '') || 'localhost:30080';
 
 // If this is unset, API calls will default to the same host used to serve this app
 const ADMIN_API = ADMIN_API_URL ? `//${ADMIN_API_URL}` : '';
 
 // Webpage for local development
-const LOCAL_DEV_HOST = `localhost.${ADMIN_API_URL}`;
+const LOCAL_DEV_HOST = process.env.LOCAL_DEV_HOST || 'localhost';
 
 /**
  * @depricated use BASE_HREF

--- a/website/console/env/index.ts
+++ b/website/console/env/index.ts
@@ -31,13 +31,18 @@ const CERTIFICATE_PATH = '../../scripts/certificate';
 const ADMIN_API_USE_SSL = process.env.ADMIN_API_USE_SSL || 'http';
 
 // Admin domain used as base for window URL and API urls
-const ADMIN_API_URL = process.env.ADMIN_API_URL?.replace(/https?:\/\//, '') || 'localhost:30080';
+const ADMIN_API_URL = process.env.ADMIN_API_URL
+  ? process.env.ADMIN_API_URL.replace(/https?:\/\//, '')
+  : 'localhost:30080';
+
+console.log('#########################################################');
+console.log('ADMIN_API_URL:', ADMIN_API_URL);
 
 // If this is unset, API calls will default to the same host used to serve this app
 const ADMIN_API = ADMIN_API_URL ? `//${ADMIN_API_URL}` : '';
 
 // Webpage for local development
-const LOCAL_DEV_HOST = process.env.LOCAL_DEV_HOST || 'localhost';
+const LOCAL_DEV_HOST = `localhost.${ADMIN_API_URL}`;
 
 /**
  * @depricated use BASE_HREF


### PR DESCRIPTION
This PR adds support for triggers (previously schedules) in the new `flyteConsole` refresh. Users can now view, activate and deactivate schedules from the UI. Additionally, users can activate/deactivate launch plans even if there is no schedule bound to the launch plan. Finally, this PR includes a performance update (virtualized) to the Launch Plan search UI making string searches much more performant. 

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
