### PR TITLE
fix: Broken breadcrumbs when using custom BASE_URL

### DIFF
--- a/packages/oss-console/src/components/Breadcrumbs/registry/index.ts
+++ b/packages/oss-console/src/components/Breadcrumbs/registry/index.ts
@@ -106,7 +106,7 @@ export class BreadcrumbRegistry {
 
   static makeUrlSegments(location: Location, projectId = '', domainId = '') {
     const pathName = location.pathname;
-    const basePath = process.env.BASE_PATH || '/console';
+    const basePath = process.env.BASE_URL || '/console';
 
     // Remove first occurence of base path
     const pathNameWithoutBasePath = pathName.replace(basePath, '');


### PR DESCRIPTION
# TL;DR
Typo – causes breadcrumbs to not appear in flyteconsole. To fix, use BASE_URL not BASE_PATH.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

Missing breadcrumbs for custom BASE_URL like `/custom-base/console`

<img width="358" alt="image" src="https://github.com/flyteorg/flyteconsole/assets/140021987/e8864efe-900f-4dd7-ba62-ecb1e5f69038">

Expectation: breadcrumbs are present for custom BASE_URL Flyte instance.

<img width="510" alt="image" src="https://github.com/flyteorg/flyteconsole/assets/140021987/c20ec3ed-c166-4002-b199-b70c99a32085">

This happens because when `BASE_PATH` is used instead of `BASE_URL`, the logic that generates the breadcrumbs at `breadcrumbRegistry.breadcrumbBuilder` ends up using the wrong `BASE_URL` value (this starts from `makeUrlSegments`). This causes it to parse the window location incorrectly, and the resulting generated breadcrumbs is missing the expected entries. 

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
