### PR TITLE
Show Array Node MetaData

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -39,6 +39,7 @@ jobs:
         run: make test_unit_codecov
       - uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: .coverage/coverage-final.json
           fail_ci_if_error: true
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: .coverage/coverage-final.json
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   lint_project:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -37,7 +37,7 @@ jobs:
         run: yarn install  --immutable
       - name: Run tests and generate coverage
         run: make test_unit_codecov
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         with:
           files: .coverage/coverage-final.json
           fail_ci_if_error: true
@@ -68,13 +68,7 @@ jobs:
   release:
     name: Generate Release
     if: ${{ (github.event_name != 'pull_request') && (needs.extract_branch.outputs.branch == 'master') }}
-    needs:
-      [
-        unit_tests_with_coverage,
-        lint_project,
-        build_docker_image,
-        extract_branch,
-      ]
+    needs: [unit_tests_with_coverage, lint_project, build_docker_image, extract_branch]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/packages/oss-console/src/components/Executions/contextProvider/NodeExecutionDetails/createExecutionArray.tsx
+++ b/packages/oss-console/src/components/Executions/contextProvider/NodeExecutionDetails/createExecutionArray.tsx
@@ -7,6 +7,7 @@ import { Identifier } from '../../../../models/Common/types';
 import { CompiledTask } from '../../../../models/Task/types';
 import { dNode } from '../../../../models/Graph/types';
 import { isEndNode, isStartNode } from '../../../../models/Node/utils';
+import { getTaskTypeFromCompiledNode } from '../../../WorkflowGraph/utils';
 
 interface NodeExecutionInfo extends NodeExecutionDetails {
   scopedId?: string;
@@ -104,6 +105,16 @@ export const getNodeDetails = (
     };
   }
 
+  if (compiledNode?.arrayNode) {
+    returnVal = {
+      ...returnVal,
+      displayType:
+        returnVal.displayType !== NodeExecutionDisplayType.Unknown
+          ? returnVal.displayType
+          : NodeExecutionDisplayType.ArrayNode,
+    };
+  }
+
   return returnVal;
 };
 
@@ -118,6 +129,13 @@ export const getNodeDetailsFromTask = (node: dNode, task?: CompiledTask): NodeEx
     taskTemplate: task?.template,
     displayType: taskType ?? NodeExecutionDisplayType.Unknown,
   };
+
+  if (node.value?.arrayNode) {
+    returnVal = {
+      ...returnVal,
+      displayType: NodeExecutionDisplayType.ArrayNode,
+    };
+  }
 
   if (node.value?.workflowNode) {
     const { workflowNode } = node.value;
@@ -160,7 +178,7 @@ export const getNodeExecutionDetails = (
   node: dNode,
   tasks: CompiledTask[] = [],
 ): NodeExecutionInfo => {
-  const templateName = node?.value?.taskNode?.referenceId?.name ?? node.name;
-  const task = tasks.find((t) => t.template.id.name === templateName);
+  const taskNode = node?.value?.arrayNode?.node?.taskNode || node?.value?.taskNode;
+  const task = getTaskTypeFromCompiledNode(taskNode!, tasks);
   return getNodeDetailsFromTask(node, task);
 };

--- a/packages/oss-console/src/components/Executions/types.ts
+++ b/packages/oss-console/src/components/Executions/types.ts
@@ -1,7 +1,4 @@
-import {
-  NodeExecution,
-  NodeExecutionMetadata,
-} from '../../models/Execution/types';
+import { NodeExecution, NodeExecutionMetadata } from '../../models/Execution/types';
 import { TaskTemplate } from '../../models/Task/types';
 
 export interface ExecutionPhaseConstants {

--- a/packages/oss-console/src/components/Executions/types.ts
+++ b/packages/oss-console/src/components/Executions/types.ts
@@ -1,8 +1,6 @@
 import {
   NodeExecution,
-  NodeExecutionClosure,
   NodeExecutionMetadata,
-  WorkflowNodeMetadata,
 } from '../../models/Execution/types';
 import { TaskTemplate } from '../../models/Task/types';
 
@@ -15,6 +13,7 @@ export interface ExecutionPhaseConstants {
 }
 
 export enum NodeExecutionDisplayType {
+  ArrayNode = 'Array Node',
   MapTask = 'Map Task',
   BatchHiveTask = 'Hive Batch Task',
   BranchNode = 'Branch Node',

--- a/packages/oss-console/src/components/WorkflowGraph/utils.ts
+++ b/packages/oss-console/src/components/WorkflowGraph/utils.ts
@@ -100,6 +100,9 @@ export const getSubWorkflowFromId = (
 };
 
 export const getTaskTypeFromCompiledNode = (taskNode: TaskNode, tasks: CompiledTask[]) => {
+  if (!taskNode.referenceId) {
+    return undefined;
+  }
   for (let i = 0; i < tasks.length; i++) {
     const compiledTask: CompiledTask = tasks[i];
     const taskTemplate: TaskTemplate = compiledTask.template;
@@ -108,7 +111,7 @@ export const getTaskTypeFromCompiledNode = (taskNode: TaskNode, tasks: CompiledT
       return compiledTask;
     }
   }
-  return null;
+  return undefined;
 };
 
 export const getNodeNameFromDag = (dagData: dNode, nodeId: string) => {

--- a/packages/oss-console/src/components/WorkflowGraph/utils.ts
+++ b/packages/oss-console/src/components/WorkflowGraph/utils.ts
@@ -100,7 +100,7 @@ export const getSubWorkflowFromId = (
 };
 
 export const getTaskTypeFromCompiledNode = (taskNode: TaskNode, tasks: CompiledTask[]) => {
-  if (!taskNode.referenceId) {
+  if (!taskNode?.referenceId) {
     return undefined;
   }
   for (let i = 0; i < tasks.length; i++) {

--- a/packages/oss-console/src/models/Node/types.ts
+++ b/packages/oss-console/src/models/Node/types.ts
@@ -6,7 +6,6 @@ export type WorkflowNode = Core.IWorkflowNode;
 /** A graph node indicating a branching decision. */
 export type BranchNode = Core.IBranchNode;
 
-
 /** A graph node indicating a Array Node. */
 export interface ArrayNode extends Core.IArrayNode {
   node: CompiledNode;

--- a/packages/oss-console/src/models/Node/types.ts
+++ b/packages/oss-console/src/models/Node/types.ts
@@ -6,6 +6,15 @@ export type WorkflowNode = Core.IWorkflowNode;
 /** A graph node indicating a branching decision. */
 export type BranchNode = Core.IBranchNode;
 
+
+/** A graph node indicating a Array Node. */
+export interface ArrayNode extends Core.IArrayNode {
+  node: CompiledNode;
+  parallelism?: number;
+  minSuccesses?: number;
+  minSuccessRatio?: number;
+}
+
 /** A graph node indicating a task to be executed. This is the most common
  * node type in a Flyte graph.
  */
@@ -30,6 +39,7 @@ export interface CompiledNode extends Core.INode {
   inputs?: Binding[];
   metadata?: CompiledNodeMetadata;
   outputAliases?: Alias[];
+  arrayNode?: ArrayNode;
   taskNode?: TaskNode;
   upstreamNodeIds?: string[];
   workflowNode?: WorkflowNode;


### PR DESCRIPTION
# TL;DR
Visualise metadata of array node metadata. This includes the display of the type of the task as well as Task specification of each instance of f.e. array node map tasks

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Before:
<img width="1501" alt="Screenshot at Apr 09 12-28-33" src="https://github.com/flyteorg/flyteconsole/assets/89976021/df7a4748-a72f-4fbb-b94d-ee63512ebc60">

After:



## Tracking Issue
None

