### PR TITLE
fix: Partial revert PR #853

### DIFF
--- a/website/console/env/index.ts
+++ b/website/console/env/index.ts
@@ -31,13 +31,13 @@ const CERTIFICATE_PATH = '../../scripts/certificate';
 const ADMIN_API_USE_SSL = process.env.ADMIN_API_USE_SSL || 'http';
 
 // Admin domain used as base for window URL and API urls
-const ADMIN_API_URL = process.env.ADMIN_API_URL?.replace(/https?:\/\//, '') || 'localhost:30080';
+const ADMIN_API_URL = process.env.ADMIN_API_URL?.replace(/https?:\/\//, '') || '';
 
 // If this is unset, API calls will default to the same host used to serve this app
 const ADMIN_API = ADMIN_API_URL ? `//${ADMIN_API_URL}` : '';
 
 // Webpage for local development
-const LOCAL_DEV_HOST = process.env.LOCAL_DEV_HOST || 'localhost';
+const LOCAL_DEV_HOST = process.env.LOCAL_DEV_HOST || `localhost.${ADMIN_API_URL}`;
 
 /**
  * @depricated use BASE_HREF


### PR DESCRIPTION
# TL;DR

flyteorg/flyteconsole#853 breaks the production environment. This PR partially revert it by making `LOCAL_DEV_HOST` to read from the environment variable instead of a hard-coded value.

Related PR: https://github.com/flyteorg/flyteconsole/pull/864

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description

## Tracking Issue

N/A

## Follow-up issue
_NA_

