### PR TITLE
Make k8 messages collapsible on node execution details panel

### DIFF
--- a/packages/oss-console/src/components/Executions/ExecutionDetails/NodeExecutionDetailsPanelContent.tsx
+++ b/packages/oss-console/src/components/Executions/ExecutionDetails/NodeExecutionDetailsPanelContent.tsx
@@ -28,7 +28,6 @@ import { NoDataIsAvailable } from '../../Literals/LiteralMapViewer';
 import { fetchWorkflow } from '../../../queries/workflowQueries';
 import { PanelSection } from '../../common/PanelSection';
 import { ReactJsonViewWrapper } from '../../common/ReactJsonView';
-import { ScrollableMonospaceText } from '../../common/ScrollableMonospaceText';
 import { dNode } from '../../../models/Graph/types';
 import { NodeExecutionPhase, TaskExecutionPhase } from '../../../models/Execution/enums';
 import { transformWorkflowToKeyedDag, getNodeNameFromDag } from '../../WorkflowGraph/utils';
@@ -46,6 +45,7 @@ import { useNodeExecutionsById } from '../contextProvider/NodeExecutionDetails/W
 import { useNodeExecutionContext } from '../contextProvider/NodeExecutionDetails/NodeExecutionDetailsContextProvider';
 import { useWorkflowNodeExecutionTaskExecutionsQuery } from '../../hooks/useWorkflowNodeExecutionTaskExecutionsQuery';
 import { nodeExecutionRefreshIntervalMs } from '../constants';
+import { ExpandableMonospaceText } from '../../common/ExpandableMonospaceText';
 
 const NodeTypeLink = styled(RouterLink)(() => ({
   fontWeight: 'normal',
@@ -250,7 +250,7 @@ const NodeExecutionStatus: FC<NodeExecutionStatusProps> = ({ nodeExecution, fron
       </div>
       {reasons?.length ? (
         <div className="statusBody">
-          <ScrollableMonospaceText text={reasons.join('\n\n')} />
+          <ExpandableMonospaceText text={reasons.join('\n\n')} />
         </div>
       ) : null}
     </StatusContainer>


### PR DESCRIPTION
This PR makes the k8 messages on the Node Execution Details panel collapsible

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
