### PR TITLE
Alllow port to be set via env instead hardcoded

### DIFF
--- a/website/console/env/index.ts
+++ b/website/console/env/index.ts
@@ -21,6 +21,9 @@ if (file.error) {
 /** Current environment environment. "development", "test" or "production" */
 const NODE_ENV = process.env.NODE_ENV || 'development';
 
+/** Port to run the server on */
+const PORT = process.env.PORT || 8080;
+
 /**
  * Certificate path required for local development, should not include trailing '/'.
  * Located at top level of the repository in script folder
@@ -40,7 +43,7 @@ const ADMIN_API = ADMIN_API_URL ? `//${ADMIN_API_URL}` : '';
 const LOCAL_DEV_HOST = process.env.LOCAL_DEV_HOST || `localhost.${ADMIN_API_URL}`;
 
 /**
- * @depricated use BASE_HREF
+ * @deprecated use BASE_HREF
  */
 const BASE_URL = process.env.BASE_URL || '';
 
@@ -76,6 +79,7 @@ const MAINTENANCE_MODE = process.env.MAINTENANCE_MODE || '';
 
 const processEnv = {
   NODE_ENV,
+  PORT,
   ADMIN_API,
   ADMIN_API_URL,
   BASE_URL,
@@ -86,6 +90,7 @@ const processEnv = {
 
 export {
   NODE_ENV,
+  PORT,
   BASE_URL,
   BASE_HREF,
   DISABLE_CONSOLE_ROUTE_PREFIX,

--- a/website/console/src/server/index.ts
+++ b/website/console/src/server/index.ts
@@ -15,8 +15,6 @@ const fs = require('fs');
 // const https = require('https');
 const env = require('../../env');
 
-const PORT = 8080;
-
 collectDefaultMetrics();
 
 const app = express();
@@ -56,7 +54,7 @@ app.use(mainRouter);
 
 const showEntryPointUrl = () => {
   console.log(chalk.magenta(`Express server ready!`));
-  const url = `https://${env.LOCAL_DEV_HOST}:${PORT}${env.BASE_URL}`;
+  const url = `https://${env.LOCAL_DEV_HOST}:${env.PORT}${env.BASE_URL}`;
 
   // Open a new browser tab if in development
   if (env.NODE_ENV === 'development') {
@@ -84,9 +82,9 @@ if (env.ADMIN_API_USE_SSL === 'https') {
       },
       app,
     )
-    .listen(PORT, showEntryPointUrl);
+    .listen(env.PORT, showEntryPointUrl);
 } else {
-  server = app.listen(PORT, showEntryPointUrl);
+  server = app.listen(env.PORT, showEntryPointUrl);
 }
 
 const shutdown: NodeJS.SignalsListener = (signal) => {


### PR DESCRIPTION
# TL;DR
This allows port to be set via env variable and if not set uses default `8080`.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_
Created an environment variable and use it in the startup code. I've tested this by building a image locally with the env set with a port `9999` and without.

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/5347
