### PR TITLE
fix: Refresh auth on 401, better error messaging

### DIFF
--- a/packages/flyte-api/package.json
+++ b/packages/flyte-api/package.json
@@ -26,7 +26,7 @@
     "tslib": "^2.4.1"
   },
   "dependencies": {
-    "axios": "^0.27.2",
+    "axios": "^1.7.1",
     "camelcase-keys": "^7.0.2",
     "snakecase-keys": "^5.4.2"
   }

--- a/packages/oss-console/package.json
+++ b/packages/oss-console/package.json
@@ -63,7 +63,7 @@
     "@tanstack/react-virtual": "^3.0.0-alpha.0",
     "@types/d3-shape": "^1.2.6",
     "@xstate/react": "^1.0.0",
-    "axios": "^0.27.2",
+    "axios": "^1.7.1",
     "copy-to-clipboard": "^3.0.8",
     "cronstrue": "^1.31.0",
     "d3-dag": "^0.3.4",

--- a/packages/oss-console/src/App/ApplicationRouter.tsx
+++ b/packages/oss-console/src/App/ApplicationRouter.tsx
@@ -13,34 +13,52 @@ import { PrettyError } from '../components/Errors/PrettyError';
 import { useDomainPathUpgrade } from '../routes/useDomainPathUpgrade';
 import { Routes } from '../routes/routes';
 import AnimateRoute from '../routes/AnimateRoute';
+import { loadChunkWithAuth } from '../components/data/loadChunkWithAuth';
 
-const SelectProject = lazy(
-  () => import(/* webpackChunkName: "SelectProject" */ '../components/SelectProject'),
+const SelectProject = lazy(() =>
+  loadChunkWithAuth(
+    () => import(/* webpackChunkName: "SelectProject" */ '../components/SelectProject'),
+  ),
 );
-const ListProjectEntities = lazy(
-  () => import(/* webpackChunkName: "ListProjectEntities" */ '../components/ListProjectEntities'),
+const ListProjectEntities = lazy(() =>
+  loadChunkWithAuth(
+    () => import(/* webpackChunkName: "ListProjectEntities" */ '../components/ListProjectEntities'),
+  ),
 );
 
-const ExecutionDetails = lazy(
-  () =>
-    import(/* webpackChunkName: "ExecutionDetails" */ '../components/Executions/ExecutionDetails'),
+const ExecutionDetails = lazy(() =>
+  loadChunkWithAuth(
+    () =>
+      import(
+        /* webpackChunkName: "ExecutionDetails" */ '../components/Executions/ExecutionDetails'
+      ),
+  ),
 );
 
-const TaskDetails = lazy(() => import(/* webpackChunkName: "TaskDetails" */ '../components/Task'));
-const WorkflowDetails = lazy(
-  () => import(/* webpackChunkName: "WorkflowDetails" */ '../components/Workflow/WorkflowDetails'),
+const TaskDetails = lazy(() =>
+  loadChunkWithAuth(() => import(/* webpackChunkName: "TaskDetails" */ '../components/Task')),
 );
-const LaunchPlanDetails = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "LaunchPlanDetails" */ '../components/LaunchPlan/LaunchPlanDetails'
-    ),
+const WorkflowDetails = lazy(() =>
+  loadChunkWithAuth(
+    () =>
+      import(/* webpackChunkName: "WorkflowDetails" */ '../components/Workflow/WorkflowDetails'),
+  ),
 );
-const EntityVersionsDetailsContainer = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "EntityVersionsDetailsContainer" */ '../components/Entities/VersionDetails/EntityVersionDetailsContainer'
-    ),
+const LaunchPlanDetails = lazy(() =>
+  loadChunkWithAuth(
+    () =>
+      import(
+        /* webpackChunkName: "LaunchPlanDetails" */ '../components/LaunchPlan/LaunchPlanDetails'
+      ),
+  ),
+);
+const EntityVersionsDetailsContainer = lazy(() =>
+  loadChunkWithAuth(
+    () =>
+      import(
+        /* webpackChunkName: "EntityVersionsDetailsContainer" */ '../components/Entities/VersionDetails/EntityVersionDetailsContainer'
+      ),
+  ),
 );
 
 export const ApplicationRouter: React.FC = () => {

--- a/packages/oss-console/src/App/index.tsx
+++ b/packages/oss-console/src/App/index.tsx
@@ -16,7 +16,6 @@ import { FeatureFlagsProvider } from '../basics/FeatureFlags';
 import { debug, debugPrefix } from '../common/log';
 import { APIContext, useAPIState } from '../components/data/apiContext';
 import { QueryAuthorizationObserver } from '../components/data/QueryAuthorizationObserver';
-import { createQueryClient } from '../components/data/queryCache';
 import { SystemStatusBanner } from '../components/Notifications/SystemStatusBanner';
 import { history } from '../routes/history';
 import { LocalCacheProvider } from '../basics/LocalCache/ContextProvider';
@@ -30,11 +29,10 @@ import TopLevelLayoutProvider from '../components/common/TopLevelLayout/TopLevel
 import ApplicationRouter from './ApplicationRouter';
 import { ErrorBoundary } from '../components/common/ErrorBoundary';
 import DownForMaintenance from '../components/Errors/DownForMaintenance';
+import { globalQueryClient } from '../components/data/globalQueryClient';
 
 const QueryClientProvider: React.FC<PropsWithChildren<QueryClientProviderProps>> =
   QueryClientProviderImport;
-
-const queryClient = createQueryClient();
 
 export const AppComponent: React.FC<unknown> = () => {
   if (env.NODE_ENV === 'development') {
@@ -61,7 +59,7 @@ export const AppComponent: React.FC<unknown> = () => {
             anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
             TransitionComponent={Collapse}
           >
-            <QueryClientProvider client={queryClient}>
+            <QueryClientProvider client={globalQueryClient}>
               <FlyteApiProvider flyteApiDomain={env.ADMIN_API} disableAutomaticLogin>
                 <APIContext.Provider value={apiState}>
                   <QueryAuthorizationObserver />

--- a/packages/oss-console/src/components/Errors/ErrorHandler.tsx
+++ b/packages/oss-console/src/components/Errors/ErrorHandler.tsx
@@ -1,0 +1,142 @@
+import NotAuthorizedError from '@clients/common/Errors/NotAuthorizedError';
+import NotFoundError from '@clients/common/Errors/NotFoundError';
+import { AxiosError } from 'axios';
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Link from '@mui/material/Link';
+import Button from '@mui/material/Button';
+import { useFlyteApi } from '@clients/flyte-api/ApiProvider';
+import { GenericError } from './GenericError';
+
+export interface ErrorHandlerProps {
+  error: NotFoundError | NotAuthorizedError | AxiosError | Error;
+}
+
+export const ErrorHandler: React.FC<ErrorHandlerProps> = ({ error }) => {
+  const { getLoginUrl } = useFlyteApi();
+
+  const contactSupport = (
+    <>
+      <Typography variant="label">
+        Please join the Slack community and explore its history on{' '}
+        <Link
+          color="inherit"
+          variant="label"
+          sx={{
+            fontSize: 'inherit',
+          }}
+          href="https://discuss.flyte.org/"
+          target="_blank"
+        >
+          discuss.flyte.org
+        </Link>
+        {', '}
+        or file a GitHub issue on{' '}
+        <Link
+          color="inherit"
+          variant="label"
+          sx={{
+            fontSize: 'inherit',
+          }}
+          href="https://github.com/flyteorg/flyte"
+          target="_blank"
+        >
+          flyteorg/flyte
+        </Link>{' '}
+        if the problem persists.
+      </Typography>
+    </>
+  );
+
+  if (
+    error instanceof NotFoundError ||
+    (error instanceof AxiosError && error.response?.status === 404)
+  ) {
+    return (
+      <GenericError
+        title="404"
+        description="Not Found"
+        content={
+          <>
+            <Box py={1} />
+            <Typography variant="body2">The requested resource was not found</Typography>
+
+            <Box py={1} />
+
+            {contactSupport}
+          </>
+        }
+      />
+    );
+  }
+
+  if (
+    error instanceof NotAuthorizedError ||
+    (error instanceof AxiosError && error.response?.status === 401)
+  ) {
+    return (
+      <GenericError
+        title="401"
+        description="Unauthorized"
+        content={
+          <>
+            <Box py={1} />
+            <Typography variant="body2">
+              <strong>You do not have the proper authentication to access this page</strong>
+            </Typography>
+
+            <Box py={1} />
+
+            {contactSupport}
+            <Box py={1} />
+
+            <Button
+              variant="contained"
+              href={getLoginUrl()}
+              autoFocus
+              data-cy="login-button-overlay"
+            >
+              Log in
+            </Button>
+          </>
+        }
+      />
+    );
+  }
+
+  if (error instanceof AxiosError && error.response?.status === 403) {
+    return (
+      <GenericError
+        title="403"
+        description="Forbidden"
+        content={
+          <>
+            <Box py={1} />
+            <Typography variant="body2">
+              <strong>You don't have permission to access this page</strong>
+            </Typography>
+
+            <Box py={1} />
+
+            {contactSupport}
+          </>
+        }
+      />
+    );
+  }
+
+  return (
+    <GenericError
+      title={(error as AxiosError)?.response?.status || 'Oops!'}
+      description="Something went wrong."
+      content={
+        <>
+          <Box py={1} />
+
+          {contactSupport}
+        </>
+      }
+    />
+  );
+};

--- a/packages/oss-console/src/components/Errors/GenericError.tsx
+++ b/packages/oss-console/src/components/Errors/GenericError.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { type SvgIconProps } from '@mui/material/SvgIcon';
+import PageMeta from '@clients/primitives/PageMeta';
+import Container from '@mui/material/Container';
+import NotFoundLogo from '@clients/ui-atoms/NotFoundLogo';
+import Grid from '@mui/material/Grid';
+import Typography from '@mui/material/Typography';
+
+export interface GenericErrorProps {
+  title?: string | number;
+  description?: string;
+  content?: React.ReactNode;
+  Icon?: (props: SvgIconProps) => React.JSX.Element;
+}
+
+/**
+ * React prints the \n as "\n" in the DOM,
+ * so we need to split on that to make new lines
+ */
+const makeDescriptionSpans = (description: string = '') => {
+  const descriptionSpans = description.split('\\n').filter((span) => !!span);
+  return descriptionSpans.map((span) => (
+    <span key={span}>
+      {span}
+      <br />
+    </span>
+  ));
+};
+
+export const GenericError: React.FC<GenericErrorProps> = ({
+  title,
+  description,
+  content,
+  Icon = NotFoundLogo,
+}) => {
+  return (
+    <>
+      <PageMeta title={title?.toString()} />
+      <Container
+        sx={{
+          height: '100%',
+          flexGrow: 1,
+          display: 'flex',
+          alignItems: 'center',
+        }}
+      >
+        <Grid
+          container
+          gap={1}
+          sx={{
+            flexDirection: { xs: 'column-reverse', md: 'row' },
+          }}
+        >
+          <Grid item xs={12} md={2} />
+          <Grid
+            item
+            xs={12}
+            md={4}
+            sx={{
+              paddingRight: (t) => t.spacing(2),
+              paddingBottom: (t) => t.spacing(2),
+            }}
+          >
+            <Typography
+              variant="h3"
+              pb={1}
+              sx={{
+                fontSize: '22px',
+              }}
+            >
+              {title}
+            </Typography>
+            <Typography
+              variant="h1"
+              sx={{
+                fontSize: '42px',
+              }}
+            >
+              {makeDescriptionSpans(description)}
+            </Typography>
+
+            {content}
+          </Grid>
+          <Grid item xs={12} md={1} py={3} sx={{ display: 'flex' }} />
+          {Icon && (
+            <Grid item xs={4} md={4} sx={{ display: 'flex' }}>
+              <Icon
+                sx={{
+                  width: '100%',
+                  height: '100%',
+                  maxWidth: { xs: '150px', md: '250px' },
+                  maxHeight: { xs: '150px', md: '250px' },
+                  color: (theme) => theme.palette.common.grays[20],
+                }}
+              />
+            </Grid>
+          )}
+        </Grid>
+      </Container>
+    </>
+  );
+};

--- a/packages/oss-console/src/components/common/ErrorBoundary.tsx
+++ b/packages/oss-console/src/components/common/ErrorBoundary.tsx
@@ -6,10 +6,12 @@ import Typography from '@mui/material/Typography';
 import Card from '@mui/material/Card';
 import ErrorOutline from '@mui/icons-material/ErrorOutline';
 import NotFoundError from '@clients/common/Errors/NotFoundError';
+import NotAuthorizedError from '@clients/common/Errors/NotAuthorizedError';
+import { AxiosError } from 'axios';
 import { log } from '../../common/log';
 import { useCommonStyles } from './styles';
-import { PrettyError } from '../Errors/PrettyError';
 import { NonIdealState } from './NonIdealState';
+import { ErrorHandler } from '../Errors/ErrorHandler';
 
 interface ErrorBoundaryState {
   error?: Error;
@@ -58,8 +60,12 @@ export class ErrorBoundary extends React.Component<
   render() {
     const { fixed = false } = this.props;
     if (this.state.error) {
-      if (this.state.error instanceof NotFoundError) {
-        return <PrettyError />;
+      if (
+        this.state.error instanceof NotFoundError ||
+        this.state.error instanceof NotAuthorizedError ||
+        (this.state.error as AxiosError).response?.status === 403
+      ) {
+        return <ErrorHandler error={this.state.error} />;
       }
 
       return <RenderError error={this.state.error} fixed={fixed} />;

--- a/packages/oss-console/src/components/data/QueryAuthorizationObserver.tsx
+++ b/packages/oss-console/src/components/data/QueryAuthorizationObserver.tsx
@@ -1,26 +1,19 @@
 import * as React from 'react';
 import { onlineManager, Query, useQueryClient } from 'react-query';
 import { useFlyteApi } from '@clients/flyte-api/ApiProvider';
-import NotAuthorizedError from '@clients/common/Errors/NotAuthorizedError';
 
 /** Watches all queries to detect a NotAuthorized error, disabling future queries
  * and triggering the login refresh flow.
  * Note: Should be placed just below the QueryClient and ApiContext providers.
  */
 
-// TODO: narusina - move this one to flyte-api too
 export const QueryAuthorizationObserver: React.FC = () => {
   const queryCache = useQueryClient().getQueryCache();
   const apiContext = useFlyteApi();
   React.useEffect(() => {
-    const unsubscribe = queryCache.subscribe((query?: Query | undefined) => {
-      if (!query || !query.state.error) {
-        return;
-      }
-      if (query.state.error instanceof NotAuthorizedError) {
-        // Stop all in-progress and future requests
-        onlineManager.setOnline(false);
-        // Trigger auth flow
+    const unsubscribe = queryCache.subscribe(async (_query?: Query | undefined) => {
+      if (!onlineManager.isOnline()) {
+        // trigger sign in modal
         apiContext.loginStatus.setExpired(true);
       }
     });

--- a/packages/oss-console/src/components/data/axiosClient.tsx
+++ b/packages/oss-console/src/components/data/axiosClient.tsx
@@ -1,0 +1,54 @@
+import { env } from '@clients/common/environment';
+import axios, { AxiosError, AxiosResponse } from 'axios';
+import { onlineManager } from 'react-query';
+import createAuthRefreshInterceptor from 'axios-auth-refresh';
+
+export const axioClient = axios.create({
+  baseURL: env.ADMIN_API_URL,
+  withCredentials: true,
+  maxRedirects: 0,
+});
+
+export const refreshAuth = async (axiosError?: AxiosError, isChunk?: boolean) => {
+  if (axiosError?.response?.status !== 401 && !isChunk) {
+    return;
+  }
+  return axioClient
+    .get(`${env.ADMIN_API_URL}/login?redirect_url=${env.BASE_URL}/select-project`, {
+      withCredentials: true,
+      headers: {
+        Accept: 'text/html',
+      },
+      responseType: 'text',
+      maxRedirects: 5,
+    })
+    .then((res) => {
+      const redirectUrl = `${env.ADMIN_API_URL}${env.BASE_URL}/select-project`;
+      if (res.request.responseURL.includes(redirectUrl)) {
+        onlineManager.setOnline(true);
+        return res;
+      }
+
+      // throw error if not redirected to the console app
+      throw new Error();
+    })
+    .catch((_error) => {
+      onlineManager.setOnline(false);
+
+      const unauthError = isChunk
+        ? new AxiosError('Not Authorized', '401', undefined, undefined, {
+            status: 401,
+            statusText: 'Not Authorized',
+          } as AxiosResponse)
+        : axiosError;
+
+      return Promise.reject(unauthError);
+    });
+};
+
+createAuthRefreshInterceptor(axioClient, refreshAuth, {
+  statusCodes: [401], // default: [ 401 ]
+  pauseInstanceWhileRefreshing: true,
+  retryInstance: axioClient,
+  interceptNetworkError: true,
+});

--- a/packages/oss-console/src/components/data/globalQueryClient.ts
+++ b/packages/oss-console/src/components/data/globalQueryClient.ts
@@ -1,0 +1,3 @@
+import { createQueryClient } from './queryCache';
+
+export const globalQueryClient = createQueryClient();

--- a/packages/oss-console/src/components/data/loadChunkWithAuth.tsx
+++ b/packages/oss-console/src/components/data/loadChunkWithAuth.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import NotAuthorizedError from '@clients/common/Errors/NotAuthorizedError';
+import { refreshAuth } from './axiosClient';
+import { ErrorHandler } from '../Errors/ErrorHandler';
+
+type ImportFunction = () => Promise<{ default: React.ComponentType<any> }>;
+
+export const loadChunkWithAuth = (
+  importFunction: ImportFunction,
+): Promise<{ default: React.ComponentType<any> }> => {
+  return new Promise((resolve, _reject) => {
+    importFunction()
+      .then((res) => {
+        resolve(res);
+      })
+      .catch((_error) => {
+        refreshAuth(undefined, true)
+          .then((_res) => {
+            importFunction().then((res) => {
+              resolve(res);
+            });
+          })
+
+          .catch((_err) => {
+            // if loading chunk failed, show unauthorized error
+            resolve({
+              default: () => <ErrorHandler error={new NotAuthorizedError('chunk_error')} />,
+            });
+          });
+      });
+  });
+};

--- a/packages/oss-console/src/models/AdminEntity/AdminEntity.ts
+++ b/packages/oss-console/src/models/AdminEntity/AdminEntity.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosRequestConfig, Method } from 'axios';
+import { AxiosRequestConfig, Method } from 'axios';
 import {
   AdminEntityTransformer,
   DecodableType,
@@ -7,6 +7,7 @@ import {
 } from '@clients/common/types/adminEntityTypes';
 import { decodeProtoResponse } from '@clients/common/Utils/decodeProtoResponse';
 import { transformRequestError } from '@clients/flyte-api/utils/transformRequestError';
+import { axioClient } from '@clients/oss-console/components/data/axiosClient';
 import { generateAdminApiQuery } from './AdminApiQuery';
 import { adminApiUrl, encodeProtoPayload, logProtoResponse } from './utils';
 
@@ -54,7 +55,7 @@ async function request(
   };
 
   try {
-    const { data } = await axios.request(finalOptions);
+    const { data } = await axioClient.request(finalOptions);
     return data;
   } catch (e) {
     throw transformRequestError(e, endpoint, true);

--- a/packages/oss-console/src/test/setupTests.ts
+++ b/packages/oss-console/src/test/setupTests.ts
@@ -6,7 +6,18 @@ jest.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({
 
 // mock axios to avoid open handles
 const axiosMock = jest.mock('axios', () => ({
-  request: jest.fn().mockResolvedValue({ data: {} }),
+  create: jest.fn().mockReturnValue({
+    request: jest.fn().mockResolvedValue({ response: {} }),
+    get: jest.fn().mockResolvedValue({ data: {} }),
+    interceptors: {
+      request: {
+        use: jest.fn(),
+      },
+      response: {
+        use: jest.fn(),
+      },
+    }
+  }),
   defaults: {
     transformRequest: [],
     transformResponse: [],

--- a/website/console/package.json
+++ b/website/console/package.json
@@ -25,6 +25,7 @@
     "@patternfly/react-core": "^4.276.8",
     "@patternfly/react-log-viewer": "^4.87.100",
     "@tanstack/react-table": "^8.10.1",
+    "axios-auth-refresh": "^3.3.6",
     "chartjs-plugin-datalabels": "2.0.0",
     "cron-parser": "^4.9.0",
     "moment": "^2.29.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2134,6 +2134,7 @@ __metadata:
     "@patternfly/react-core": ^4.276.8
     "@patternfly/react-log-viewer": ^4.87.100
     "@tanstack/react-table": ^8.10.1
+    axios-auth-refresh: ^3.3.6
     chartjs-plugin-datalabels: 2.0.0
     cron-parser: ^4.9.0
     moment: ^2.29.4
@@ -2172,7 +2173,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@clients/flyte-api@workspace:packages/flyte-api"
   dependencies:
-    axios: ^0.27.2
+    axios: ^1.7.1
     camelcase-keys: ^7.0.2
     snakecase-keys: ^5.4.2
   peerDependencies:
@@ -2232,7 +2233,7 @@ __metadata:
     "@types/serve-static": ^1.7.31
     "@types/shallowequal": ^0.2.3
     "@xstate/react": ^1.0.0
-    axios: ^0.27.2
+    axios: ^1.7.1
     copy-to-clipboard: ^3.0.8
     cronstrue: ^1.31.0
     d3-dag: ^0.3.4
@@ -9605,13 +9606,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.27.2":
-  version: 0.27.2
-  resolution: "axios@npm:0.27.2"
-  dependencies:
-    follow-redirects: ^1.14.9
-    form-data: ^4.0.0
-  checksum: 38cb7540465fe8c4102850c4368053c21683af85c5fdf0ea619f9628abbcb59415d1e22ebc8a6390d2bbc9b58a9806c874f139767389c862ec9b772235f06854
+"axios-auth-refresh@npm:^3.3.6":
+  version: 3.3.6
+  resolution: "axios-auth-refresh@npm:3.3.6"
+  peerDependencies:
+    axios: ">= 0.18 < 0.19.0 || >= 0.19.1"
+  checksum: 74206569065a4ece84830210d4f21900aa9690259c3c21743efb195309bcbcb6c3f5e59ce973ea8fe5d9155f5b241001c35448e527da9f32d7ee37d030d51544
   languageName: node
   linkType: hard
 
@@ -9623,6 +9623,17 @@ __metadata:
     form-data: ^4.0.0
     proxy-from-env: ^1.1.0
   checksum: 87d4d429927d09942771f3b3a6c13580c183e31d7be0ee12f09be6d5655304996bb033d85e54be81606f4e89684df43be7bf52d14becb73a12727bf33298a082
+  languageName: node
+  linkType: hard
+
+"axios@npm:^1.7.1":
+  version: 1.7.1
+  resolution: "axios@npm:1.7.1"
+  dependencies:
+    follow-redirects: ^1.15.6
+    form-data: ^4.0.0
+    proxy-from-env: ^1.1.0
+  checksum: 77760d94b3812e07d4a5b02468a55eed5c8435ef4d605d159f2808775bdd15da60ab5b15b665a6f72800b5d261875d808b410cd3cb1d7571cdc6ec5e0108025a
   languageName: node
   linkType: hard
 
@@ -15022,7 +15033,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.14.9":
+"follow-redirects@npm:^1.0.0":
   version: 1.15.2
   resolution: "follow-redirects@npm:1.15.2"
   peerDependenciesMeta:
@@ -15039,6 +15050,16 @@ __metadata:
     debug:
       optional: true
   checksum: 5ca49b5ce6f44338cbfc3546823357e7a70813cecc9b7b768158a1d32c1e62e7407c944402a918ea8c38ae2e78266312d617dc68783fac502cbb55e1047b34ec
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.15.6":
+  version: 1.15.6
+  resolution: "follow-redirects@npm:1.15.6"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: a62c378dfc8c00f60b9c80cab158ba54e99ba0239a5dd7c81245e5a5b39d10f0c35e249c3379eae719ff0285fff88c365dd446fab19dee771f1d76252df1bbf5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

# TL;DR
* Update axios
* Attempt to refresh auth token in the background when encountering 401's
* Better error messaging

<img width="771" alt="image" src="https://github.com/flyteorg/flyteconsole/assets/6610300/b6584861-795d-4533-b08e-e27e7d7b7d3b">

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
