### PR TITLE
feat: remove schedules ui from LP detail page

### DIFF
--- a/packages/oss-console/src/components/Entities/constants.ts
+++ b/packages/oss-console/src/components/Entities/constants.ts
@@ -36,7 +36,7 @@ export const entitySections: { [k in ResourceType]: EntitySectionsFlags } = {
     executions: true,
     launch: false,
     inputs: true,
-    schedules: true,
+    schedules: false,
     versions: true,
   },
   [ResourceType.TASK]: {


### PR DESCRIPTION
## _Read then delete this section_
This PR hides the schedules UI from the Launch Plan details view.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
