### PR TITLE
fix: Add CODE_SNIPPET_USE_AUTO_CONFIG environment variable

### DIFF
--- a/packages/common/src/environment/index.ts
+++ b/packages/common/src/environment/index.ts
@@ -33,6 +33,12 @@ export interface Env extends NodeJS.ProcessEnv {
    * @example MAINTENANCE_MODE="We are currently down for maintenance.\n\nPlease try again later."
    */
   MAINTENANCE_MODE?: string;
+
+  /**
+   * Controls whether the config object in the inputs/outputs Python code snippet is automatically constructed
+   * Leave unset to use the config object for endpoint window.location.host
+   */
+  CODE_SNIPPET_USE_AUTO_CONFIG?: string;
 }
 
 /** Represents a plain object where string keys map to values of the same type */

--- a/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionNodeURL.tsx
+++ b/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionNodeURL.tsx
@@ -11,6 +11,7 @@ import Grid from '@mui/material/Grid';
 import Link from '@mui/material/Link';
 import { RowExpander } from '../Tables/RowExpander';
 import { ScrollableMonospaceText } from '../../common/ScrollableMonospaceText';
+import { env } from '@clients/common/environment';
 
 const StyledScrollableMonospaceText = styled(ScrollableMonospaceText)(({ theme }) => ({
   '&>div': {
@@ -31,19 +32,18 @@ export const ExecutionNodeURL: React.FC<{
   const isHttps = /^https:/.test(window.location.href);
   const ref = React.useRef<HTMLDivElement>(null);
 
-  const code = isHttps
-    ? // https snippet
-      `from flytekit.remote.remote import FlyteRemote
+  const config =
+    env.CODE_SNIPPET_USE_AUTO_CONFIG === "true"
+      ? 'Config.auto()'
+      : isHttps
+      ? // https snippet
+        `Config.for_endpoint("${window.location.host}")`
+      : // http snippet
+        `Config.for_endpoint("${window.location.host}", True)`;
+    const code = `from flytekit.remote.remote import FlyteRemote
 from flytekit.configuration import Config
 remote = FlyteRemote(
-    Config.for_endpoint("${window.location.host}"),
-)
-remote.get("${dataSourceURI}")`
-    : // http snippet
-      `from flytekit.remote.remote import FlyteRemote
-from flytekit.configuration import Config
-remote = FlyteRemote(
-    Config.for_endpoint("${window.location.host}", True),
+    ${config},
 )
 remote.get("${dataSourceURI}")`;
 

--- a/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionNodeURL.tsx
+++ b/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionNodeURL.tsx
@@ -3,6 +3,7 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { prism } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import FileCopyIcon from '@mui/icons-material/FileCopy';
 import copyToClipboard from 'copy-to-clipboard';
+import { env } from '@clients/common/environment';
 import { errorBackgroundColor } from '@clients/theme/CommonStyles/constants';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
@@ -11,7 +12,6 @@ import Grid from '@mui/material/Grid';
 import Link from '@mui/material/Link';
 import { RowExpander } from '../Tables/RowExpander';
 import { ScrollableMonospaceText } from '../../common/ScrollableMonospaceText';
-import { env } from '@clients/common/environment';
 
 const StyledScrollableMonospaceText = styled(ScrollableMonospaceText)(({ theme }) => ({
   '&>div': {
@@ -33,6 +33,7 @@ export const ExecutionNodeURL: React.FC<{
   const ref = React.useRef<HTMLDivElement>(null);
 
   const config =
+    // eslint-disable-next-line no-nested-ternary
     env.CODE_SNIPPET_USE_AUTO_CONFIG === "true"
       ? 'Config.auto()'
       : isHttps

--- a/website/console/env/index.ts
+++ b/website/console/env/index.ts
@@ -77,6 +77,11 @@ const ASSETS_PATH = `${BASE_URL}/assets/`;
  */
 const MAINTENANCE_MODE = process.env.MAINTENANCE_MODE || '';
 
+/**
+ * Controls whether the config object in the inputs/outputs Python code snippet is automatically constructed
+ */
+const CODE_SNIPPET_USE_AUTO_CONFIG = process.env.CODE_SNIPPET_USE_AUTO_CONFIG || '';
+
 const processEnv = {
   NODE_ENV,
   PORT,
@@ -86,6 +91,7 @@ const processEnv = {
   BASE_HREF,
   DISABLE_CONSOLE_ROUTE_PREFIX,
   MAINTENANCE_MODE,
+  CODE_SNIPPET_USE_AUTO_CONFIG,
 };
 
 export {
@@ -101,5 +107,6 @@ export {
   ADMIN_API,
   LOCAL_DEV_HOST,
   MAINTENANCE_MODE,
+  CODE_SNIPPET_USE_AUTO_CONFIG,
   processEnv,
 };


### PR DESCRIPTION
# TL;DR
The inputs/outputs Python code snippet leads to a "Failed to connect" error

Introduce the environment variable `CODE_SNIPPET_USE_AUTO_CONFIG`, to control whether the config object in the inputs/outputs Python code snippet is automatically constructed i.e. `Config.auto()`. This will tend to use the `admin.endpoint` that users can set in their `~/.flyte/config.yaml`

It can be left unset to keep [the current behavior e.g. uses `Config.for_endpoint(window.location.host)`
](https://github.com/flyteorg/flyteconsole/blob/7636e32d2b1dbefb7d08fb79e5ed063c3ad44ca4/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionNodeURL.tsx#L39)
## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Users already configure flytekit in `~/.flyte/config.yaml` to set `admin.endpoint` to the correct gRPC endpoint. We can leverage this by using `Config.auto()` auto config, and building the code snippet around this Config.

Tested fix correctly shows the new code snippet when setting is enabled:
![image](https://github.com/user-attachments/assets/e4fa6927-4960-44ae-86fa-9d65f1466b21)

Tested fix uses current behavior when setting is not enabled:
![image](https://github.com/user-attachments/assets/e190cae2-4133-45c7-b273-51af84ae2f60)


## Tracking Issue
https://github.com/flyteorg/flyte/issues/5578

