### PR TITLE
Fix can't resume with overidden task name 

### DIFF
--- a/packages/oss-console/src/components/Executions/Tables/NodeExecutionActions/ResumeButton.tsx
+++ b/packages/oss-console/src/components/Executions/Tables/NodeExecutionActions/ResumeButton.tsx
@@ -81,6 +81,7 @@ export const ResumeButton: FC<ResumeButtonProps> = ({ node }) => {
               nodeExecutionId={nodeExecution.id as NodeExecutionIdentifier}
               showLaunchForm={showResumeForm}
               setShowLaunchForm={setShowResumeForm}
+              nodeExecutionScopeId={nodeExecution.scopedId}
             />
           ) : null;
         }}

--- a/packages/oss-console/src/components/Launch/LaunchForm/LaunchFormDialog.tsx
+++ b/packages/oss-console/src/components/Launch/LaunchForm/LaunchFormDialog.tsx
@@ -15,6 +15,7 @@ interface LaunchFormDialogProps {
   setShowLaunchForm: React.Dispatch<React.SetStateAction<boolean>>;
   compiledNode?: CompiledNode;
   nodeExecutionId?: NodeExecutionIdentifier;
+  nodeExecutionScopeId?: string;
 }
 
 function getLaunchProps(id: ResourceIdentifier) {
@@ -34,6 +35,7 @@ export const LaunchFormDialog = ({
   setShowLaunchForm,
   compiledNode,
   nodeExecutionId,
+  nodeExecutionScopeId,
 }: LaunchFormDialogProps): JSX.Element => {
   const onCancelLaunch = (_?: any) => {
     setShowLaunchForm(false);
@@ -48,7 +50,7 @@ export const LaunchFormDialog = ({
   const dialogOnClick = (e: React.MouseEvent<HTMLElement>) => {
     e.stopPropagation();
   };
-
+  console.log('kai', nodeExecutionScopeId);
   return (
     <Dialog
       scroll="paper"
@@ -64,12 +66,13 @@ export const LaunchFormDialog = ({
           onClose={onCancelLaunch}
           {...getLaunchProps(id)}
         />
-      ) : compiledNode && nodeExecutionId ? (
+      ) : compiledNode && nodeExecutionId && nodeExecutionScopeId ? (
         <ResumeForm
           initialParameters={initialParameters}
           nodeExecutionId={nodeExecutionId}
           onClose={onCancelLaunch}
           compiledNode={compiledNode}
+          nodeExecutionScopeId={nodeExecutionScopeId}
         />
       ) : null}
     </Dialog>

--- a/packages/oss-console/src/components/Launch/LaunchForm/ResumeForm.tsx
+++ b/packages/oss-console/src/components/Launch/LaunchForm/ResumeForm.tsx
@@ -10,6 +10,7 @@ interface ResumeFormProps extends BaseLaunchFormProps {
   compiledNode: CompiledNode;
   initialParameters?: TaskInitialLaunchParameters;
   nodeExecutionId: NodeExecutionIdentifier;
+  nodeExecutionScopeId: string;
 }
 
 /** Renders the form for requesting a resume request on a gate node */

--- a/packages/oss-console/src/components/Launch/LaunchForm/ResumeSignalForm.tsx
+++ b/packages/oss-console/src/components/Launch/LaunchForm/ResumeSignalForm.tsx
@@ -26,6 +26,7 @@ export interface ResumeSignalFormProps extends BaseLaunchFormProps {
   compiledNode: CompiledNode;
   initialParameters?: TaskInitialLaunchParameters;
   nodeExecutionId: NodeExecutionIdentifier;
+  nodeExecutionScopeId: string;
 }
 
 /** Renders the form for requesting a resume request on a gate node */
@@ -33,6 +34,7 @@ export const ResumeSignalForm: React.FC<ResumeSignalFormProps> = ({
   compiledNode,
   nodeExecutionId,
   onClose,
+  nodeExecutionScopeId,
 }) => {
   const { formInputsRef, state, service } = useResumeFormState({
     compiledNode,
@@ -41,14 +43,15 @@ export const ResumeSignalForm: React.FC<ResumeSignalFormProps> = ({
   });
   const { nodeExecutionsById } = useNodeExecutionsById();
   const [nodeExecution, setNodeExecution] = useState<NodeExecution>(
-    nodeExecutionsById[nodeExecutionId.nodeId],
+    nodeExecutionsById[nodeExecutionScopeId],
   );
+  window.console.log('kai', nodeExecutionScopeId, nodeExecution);
   const styles = useStyles();
   const baseState = state as BaseInterpretedLaunchState;
   const baseService = service as BaseLaunchService;
   const [isError, setIsError] = useState<boolean>(false);
   const nodeExecutionDataQuery = useNodeExecutionDataQuery({
-    id: nodeExecution.id,
+    id: nodeExecution?.id,
   });
   // Any time the inputs change (even if it's just re-ordering), we must
   // change the form key so that the inputs component will re-mount.
@@ -57,9 +60,9 @@ export const ResumeSignalForm: React.FC<ResumeSignalFormProps> = ({
   }, [state.context.parsedInputs]);
 
   useEffect(() => {
-    const newNodeExecution = nodeExecutionsById[nodeExecutionId.nodeId];
+    const newNodeExecution = nodeExecutionsById[nodeExecutionScopeId];
     setNodeExecution(newNodeExecution);
-  }, [nodeExecutionId.nodeId]);
+  }, [nodeExecutionScopeId]);
 
   return (
     <>

--- a/packages/oss-console/src/components/WorkflowGraph/transformerWorkflowToDag.tsx
+++ b/packages/oss-console/src/components/WorkflowGraph/transformerWorkflowToDag.tsx
@@ -451,7 +451,6 @@ const parseWorkflow = ({
   }
 
   const templateNodeList = context.template.nodes;
-
   /* Build Nodes from template */
   for (let i = 0; i < templateNodeList.length; i++) {
     const compiledNode: CompiledNode = templateNodeList[i];
@@ -473,6 +472,28 @@ const parseWorkflow = ({
       dNode,
       compiledNode: templateNodeList[i],
     };
+  }
+
+  /* Build failure node and add downstream connection for edges building */
+  const failureNode = { ...context.template.failureNode, failureNode: true };
+  if (failureNode && failureNode.id) {
+    parseNode({
+      node: failureNode as CompiledNode,
+      root,
+      nodeMetadataMap,
+      staticExecutionIdsMap,
+      compiledWorkflowClosure,
+    });
+    nodeMap[failureNode.id] = {
+      dNode: root.nodes[root.nodes.length - 1],
+      compiledNode: failureNode as CompiledNode,
+    };
+    if (!context.connections.downstream[startNodeId].ids.includes(failureNode.id)) {
+      context.connections.downstream[startNodeId].ids.push(failureNode.id);
+      context.connections.downstream[failureNode.id] = {
+        ids: [endNodeId],
+      };
+    }
   }
 
   /* Build Edges */

--- a/packages/oss-console/src/components/flytegraph/ReactFlow/PausedTasksComponent.tsx
+++ b/packages/oss-console/src/components/flytegraph/ReactFlow/PausedTasksComponent.tsx
@@ -94,6 +94,7 @@ export const PausedTasksComponent: React.FC<PausedTasksComponentProps> = ({
           nodeExecutionId={nodeExecutionsById[selectedNode.scopedId].id}
           showLaunchForm={showResumeForm}
           setShowLaunchForm={setShowResumeForm}
+          nodeExecutionScopeId={selectedNode.scopedId}
         />
       ) : null}
     </div>

--- a/packages/oss-console/src/components/flytegraph/ReactFlow/customNodeComponents.tsx
+++ b/packages/oss-console/src/components/flytegraph/ReactFlow/customNodeComponents.tsx
@@ -315,6 +315,7 @@ const ReactFlowGateNodeInner = ({ data }: RFNode) => {
           nodeExecutionId={nodeExecution?.id}
           showLaunchForm={showResumeForm}
           setShowLaunchForm={setShowResumeForm}
+          nodeExecutionScopeId={nodeExecution?.scopedId}
         />
       )}
     </div>


### PR DESCRIPTION
# TL;DR

![image](https://github.com/user-attachments/assets/4b142a37-6092-41a7-8125-183e7ca44734)

<img width="1379" alt="image" src="https://github.com/user-attachments/assets/872530ac-2486-4371-b2bb-7bc688e929ac">

Fix the issue that user can't resume paused execution for workflow with overridden values.

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/5642

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
