### PR TITLE
feat: Launch Form Msgpack IDL Supporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "@commitlint/cli": "^17.3.0",
     "@commitlint/config-conventional": "^17.3.0",
+    "@msgpack/msgpack": "^3.0.0-beta2",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/commit-analyzer": "^8.0.1",
     "@semantic-release/exec": "^6.0.3",

--- a/packages/oss-console/src/components/Launch/LaunchForm/LaunchFormComponents/StructInput.tsx
+++ b/packages/oss-console/src/components/Launch/LaunchForm/LaunchFormComponents/StructInput.tsx
@@ -61,7 +61,6 @@ export const StructInput: FC<InputProps> = (props) => {
     typeDefinition: { literalType },
     value = '',
     hasCollectionParent,
-    initialValue,
   } = props;
 
   const { jsonFormRenderable, parsedJson } = useMemo(() => {
@@ -100,16 +99,6 @@ export const StructInput: FC<InputProps> = (props) => {
     onChange(JSON.stringify(formData));
     setParamData(formData);
   }, []);
-
-  useEffect(() => {
-    if (!jsonFormRenderable && initialValue) {
-      const value = initialValue.scalar?.binary?.value;
-      if (value) {
-        const parsedValue = msgpack.decode(value);
-        onChange(JSON.stringify(parsedValue));
-      }
-    }
-  }, [jsonFormRenderable, initialValue]);
 
   return jsonFormRenderable ? (
     <StyledCard error={error} label={label} name={name}>

--- a/packages/oss-console/src/components/Launch/LaunchForm/LaunchFormComponents/StructInput.tsx
+++ b/packages/oss-console/src/components/Launch/LaunchForm/LaunchFormComponents/StructInput.tsx
@@ -1,7 +1,8 @@
-import React, { FC, useCallback, useMemo, useState } from 'react';
+import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { Form } from '@rjsf/mui';
 import validator from '@rjsf/validator-ajv8';
 import styled from '@mui/system/styled';
+import * as msgpack from '@msgpack/msgpack';
 import { InputProps } from '../types';
 import { protobufValueToPrimitive, PrimitiveType } from '../inputHelpers/struct';
 import { StyledCard } from './StyledCard';
@@ -60,6 +61,7 @@ export const StructInput: FC<InputProps> = (props) => {
     typeDefinition: { literalType },
     value = '',
     hasCollectionParent,
+    initialValue,
   } = props;
 
   const { jsonFormRenderable, parsedJson } = useMemo(() => {
@@ -98,6 +100,16 @@ export const StructInput: FC<InputProps> = (props) => {
     onChange(JSON.stringify(formData));
     setParamData(formData);
   }, []);
+
+  useEffect(() => {
+    if (!jsonFormRenderable && initialValue) {
+      const value = initialValue.scalar?.binary?.value;
+      if (value) {
+        const parsedValue = msgpack.decode(value);
+        onChange(JSON.stringify(parsedValue));
+      }
+    }
+  }, [jsonFormRenderable, initialValue]);
 
   return jsonFormRenderable ? (
     <StyledCard error={error} label={label} name={name}>

--- a/packages/oss-console/src/components/Launch/LaunchForm/inputHelpers/struct.ts
+++ b/packages/oss-console/src/components/Launch/LaunchForm/inputHelpers/struct.ts
@@ -1,5 +1,6 @@
 import Protobuf from '@clients/common/flyteidl/protobuf';
 import Core from '@clients/common/flyteidl/core';
+import * as msgpack from '@msgpack/msgpack';
 import { InputType, InputValue } from '../types';
 import { structPath } from './constants';
 import { ConverterInput, InputHelper, InputValidatorParams } from './types';
@@ -90,9 +91,25 @@ function objectToProtobufStruct(obj: Dictionary<any>): Protobuf.IStruct {
   return { fields };
 }
 
-function fromLiteral(literal: Core.ILiteral): InputValue {
-  const structValue = extractLiteralWithCheck<Protobuf.IStruct>(literal, structPath);
+function parseBinary(binary: Core.IBinary): string {
+  if (!binary.value) {
+    throw new Error('Binary value is empty');
+  }
 
+  if (binary.tag === 'msgpack') {
+    return JSON.stringify(msgpack.decode(binary.value));
+  }
+
+  // unsupported binary type, it might be temporary
+  return '';
+}
+
+function fromLiteral(literal: Core.ILiteral): InputValue {
+  if (literal.scalar?.binary) {
+    return parseBinary(literal.scalar.binary);
+  }
+
+  const structValue = extractLiteralWithCheck<Protobuf.IStruct>(literal, structPath);
   const finalValue = formatParameterValues(InputType.Struct, protobufStructToObject(structValue));
   return finalValue;
 }

--- a/packages/oss-console/src/components/Literals/helpers.ts
+++ b/packages/oss-console/src/components/Literals/helpers.ts
@@ -96,7 +96,7 @@ function processBinary(binary?: Core.IBinary | null) {
 
   return {
     tag: `${tag}`,
-    value: "(unsupported tag type)",
+    value: "(binary data now shown)",
   };
 }
 

--- a/packages/oss-console/src/components/Literals/helpers.ts
+++ b/packages/oss-console/src/components/Literals/helpers.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-use-before-define */
 import Protobuf from '@clients/common/flyteidl/protobuf';
 import Core from '@clients/common/flyteidl/core';
+import * as msgpack from '@msgpack/msgpack';
 import Long from 'long';
 import cloneDeep from 'lodash/cloneDeep';
 import { formatDateUTC, protobufDurationToHMS } from '../../common/formatters';
@@ -77,6 +78,13 @@ function processBinary(binary?: Core.IBinary | null) {
 
   if (!tag) {
     return 'invalid binary';
+  }
+
+  if (tag === 'msgpack' && binary.value) {
+    return {
+      tag: 'msgpack',
+      value: msgpack.decode(binary.value),
+    };
   }
 
   return {

--- a/packages/oss-console/src/components/Literals/helpers.ts
+++ b/packages/oss-console/src/components/Literals/helpers.ts
@@ -96,7 +96,7 @@ function processBinary(binary?: Core.IBinary | null) {
 
   return {
     tag: `${tag}`,
-    value: "(binary data now shown)",
+    value: "(binary data not shown)",
   };
 }
 

--- a/packages/oss-console/src/components/Literals/helpers.ts
+++ b/packages/oss-console/src/components/Literals/helpers.ts
@@ -95,7 +95,8 @@ function processBinary(binary?: Core.IBinary | null) {
   }
 
   return {
-    tag: `${tag} (binary data not shown)`,
+    tag: `${tag}`,
+    value: "(unsupported tag type)",
   };
 }
 

--- a/packages/oss-console/src/components/Literals/helpers.ts
+++ b/packages/oss-console/src/components/Literals/helpers.ts
@@ -80,7 +80,14 @@ function processBinary(binary?: Core.IBinary | null) {
     return 'invalid binary';
   }
 
-  if (tag === 'msgpack' && binary.value) {
+  if (!binary.value) {
+    return {
+      tag: `${tag}`,
+      value: '(empty)',
+    };
+  }
+
+  if (tag === 'msgpack') {
     return {
       tag: 'msgpack',
       value: msgpack.decode(binary.value),

--- a/packages/oss-console/src/components/Literals/test/helpers/genScalarBinaryTestCase.mock.ts
+++ b/packages/oss-console/src/components/Literals/test/helpers/genScalarBinaryTestCase.mock.ts
@@ -13,12 +13,9 @@ const scalarBinaryTestCases: TestCaseList<Core.IBinary> = {
     value: { value: encode(testJson), tag: 'msgpack' },
     expected: { result_var: { tag: 'msgpack', value: testJson } },
   },
-  UNSUPPORTED_TAG: {
-    value: { tag: 'tag2', value: new Uint8Array([1, 2, 3, 4]) },
-    expected: { result_var: {
-      tag: "tag2",
-      value: "(unsupported tag type)",
-    }},
+  WITH_VAL: {
+    value: { value: new Uint8Array(), tag: 'tag1' },
+    expected: { result_var: { tag: 'tag1', value: '(binary data now shown)' } },
   },
   EMPTY_VALUE: {
     value: { tag: 'msgpack' },

--- a/packages/oss-console/src/components/Literals/test/helpers/genScalarBinaryTestCase.mock.ts
+++ b/packages/oss-console/src/components/Literals/test/helpers/genScalarBinaryTestCase.mock.ts
@@ -1,15 +1,29 @@
 import Core from '@clients/common/flyteidl/core';
+import { encode } from '@msgpack/msgpack';
 import { TestCaseList } from '../types';
 
+const testJson = {
+  test1: 1,
+  test2: '2',
+  test3: true,
+};
+
 const scalarBinaryTestCases: TestCaseList<Core.IBinary> = {
-  WITH_VAL: {
-    value: { value: new Uint8Array(), tag: 'tag1' },
-    expected: { result_var: { tag: 'tag1 (binary data not shown)' } },
+  NORMAL_MSGPACK: {
+    value: { value: encode(testJson), tag: 'msgpack' },
+    expected: { result_var: { tag: 'msgpack', value: testJson } },
   },
-  INT_WITH_SMALL_LOW: {
-    value: { tag: 'tag2' },
-    expected: { result_var: { tag: 'tag2 (binary data not shown)' } },
+  UNSUPPORTED_TAG: {
+    value: { tag: 'tag2', value: new Uint8Array([1, 2, 3, 4]) },
+    expected: { result_var: {
+      tag: "tag2",
+      value: "(unsupported tag type)",
+    }},
   },
+  EMPTY_VALUE: {
+    value: { tag: 'msgpack' },
+    expected: { result_var: { tag: 'msgpack', value: "(empty)" } },
+  }
 };
 
 export default scalarBinaryTestCases;

--- a/packages/oss-console/src/components/Literals/test/helpers/genScalarBinaryTestCase.mock.ts
+++ b/packages/oss-console/src/components/Literals/test/helpers/genScalarBinaryTestCase.mock.ts
@@ -15,12 +15,12 @@ const scalarBinaryTestCases: TestCaseList<Core.IBinary> = {
   },
   WITH_VAL: {
     value: { value: new Uint8Array(), tag: 'tag1' },
-    expected: { result_var: { tag: 'tag1', value: '(binary data now shown)' } },
+    expected: { result_var: { tag: 'tag1', value: '(binary data not shown)' } },
   },
   EMPTY_VALUE: {
     value: { tag: 'msgpack' },
-    expected: { result_var: { tag: 'msgpack', value: "(empty)" } },
-  }
+    expected: { result_var: { tag: 'msgpack', value: '(empty)' } },
+  },
 };
 
 export default scalarBinaryTestCases;

--- a/packages/oss-console/src/test/setupTests.ts
+++ b/packages/oss-console/src/test/setupTests.ts
@@ -1,4 +1,7 @@
 import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+
+Object.assign(global, { TextDecoder, TextEncoder });
 
 jest.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({
   prism: {},

--- a/script/test/jest-setup.ts
+++ b/script/test/jest-setup.ts
@@ -1,1 +1,5 @@
 import '@testing-library/jest-dom';
+
+import { TextEncoder, TextDecoder } from 'util';
+
+Object.assign(global, { TextDecoder, TextEncoder });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3501,6 +3501,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@msgpack/msgpack@npm:^3.0.0-beta2":
+  version: 3.0.0-beta2
+  resolution: "@msgpack/msgpack@npm:3.0.0-beta2"
+  checksum: d86e5d48146051952d6bea35a6cf733a401cf65ad5614d79689aa48c7076021737ca2c782978dd1b6c0c9c45888b246e379e45ae906179e3a0e8ef4ee6f221c1
+  languageName: node
+  linkType: hard
+
 "@mswjs/cookies@npm:^0.2.2":
   version: 0.2.2
   resolution: "@mswjs/cookies@npm:0.2.2"
@@ -14907,6 +14914,7 @@ __metadata:
   dependencies:
     "@commitlint/cli": ^17.3.0
     "@commitlint/config-conventional": ^17.3.0
+    "@msgpack/msgpack": ^3.0.0-beta2
     "@semantic-release/changelog": ^5.0.1
     "@semantic-release/commit-analyzer": ^8.0.1
     "@semantic-release/exec": ^6.0.3


### PR DESCRIPTION
# TL;DR
Add msgpack IDL support for the launch form, including input displaying and relaunch input recovering.
<img width="814" alt="image" src="https://github.com/user-attachments/assets/cef8a14b-20b3-4240-82a2-fbde78739d17">
<img width="578" alt="image" src="https://github.com/user-attachments/assets/cfbf79c9-1990-4097-af82-8145b123f8a7">
Test case: hhttps://localhost.dogfood.cloud-staging.union.ai:8080/console/projects/flytesnacks/domains/development/executions/acj8vfbt8722wg4q46nv

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin


