### PR TITLE
feat: Pre-emptively decode binary literals

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   "dependencies": {
     "@commitlint/cli": "^17.3.0",
     "@commitlint/config-conventional": "^17.3.0",
-    "@msgpack/msgpack": "^3.0.0-beta2",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/commit-analyzer": "^8.0.1",
     "@semantic-release/exec": "^6.0.3",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -24,7 +24,7 @@
     "tslib": "^2.4.1"
   },
   "dependencies": {
-    "@flyteorg/flyteidl": "^1.10.7",
+    "@flyteorg/flyteidl": "^1.13.5",
     "@protobuf-ts/runtime": "^2.6.0",
     "@protobuf-ts/runtime-rpc": "^2.6.0"
   },

--- a/packages/common/src/flyteidl/google.ts
+++ b/packages/common/src/flyteidl/google.ts
@@ -1,0 +1,5 @@
+import { google } from '@flyteorg/flyteidl/gen/pb-js/flyteidl';
+
+/** Message classes for google entities */
+
+export default google;

--- a/packages/oss-console/package.json
+++ b/packages/oss-console/package.json
@@ -79,6 +79,7 @@
     "lossless-json": "^1.0.3",
     "memoize-one": "^5.0.0",
     "moment-timezone": "^0.5.28",
+    "msgpackr": "^1.11.2",
     "msw": "^1.3.2",
     "notistack": "^3.0.1",
     "object-hash": "^1.3.1",

--- a/packages/oss-console/src/App/index.tsx
+++ b/packages/oss-console/src/App/index.tsx
@@ -1,4 +1,5 @@
 import '../common/setupProtobuf';
+import '../common/decodeMsgPackLiterals';
 import React, { PropsWithChildren } from 'react';
 import Collapse from '@mui/material/Collapse';
 import { FlyteApiProvider } from '@clients/flyte-api/ApiProvider';

--- a/packages/oss-console/src/common/decodeMsgPackLiterals.ts
+++ b/packages/oss-console/src/common/decodeMsgPackLiterals.ts
@@ -1,0 +1,64 @@
+import core from '@clients/common/flyteidl/core';
+import google from '@clients/common/flyteidl/google';
+import $protobuf from 'protobufjs';
+import { unpack } from 'msgpackr';
+import isNil from 'lodash/isNil';
+import entries from 'lodash/entries';
+
+// Convert a JavaScript object to Protobuf Struct
+function convertToStruct(obj: any) {
+  const struct = new google.protobuf.Struct({
+    fields: {},
+  });
+
+  entries(obj).forEach(([key, value]) => {
+    struct.fields[key] = convertToValue(value);
+  });
+
+  return struct;
+}
+
+// Convert values to Protobuf Value type
+function convertToValue(value: any) {
+  const protoValue = new google.protobuf.Value();
+
+  if (Array.isArray(value)) {
+    const listValues = value.map(convertToValue);
+    protoValue.listValue = new google.protobuf.ListValue({ values: listValues });
+  } else if (typeof value === 'object' && value !== null) {
+    protoValue.structValue = convertToStruct(value);
+  } else if (typeof value === 'string') {
+    protoValue.stringValue = value;
+  } else if (typeof value === 'number') {
+    protoValue.numberValue = value;
+  } else if (typeof value === 'boolean') {
+    protoValue.boolValue = value;
+  } else if (value === null) {
+    protoValue.nullValue = google.protobuf.NullValue.NULL_VALUE;
+  }
+
+  return protoValue;
+}
+
+const originalLiteralDecode = core.Literal.decode;
+// Overriding the decode method of Literal to convert msgpack binary literals to protobuf structs
+core.Literal.decode = (reader: $protobuf.Reader | Uint8Array, length?: number) => {
+  const result = originalLiteralDecode(reader, length);
+
+  if (result?.scalar?.binary?.tag === 'msgpack') {
+    // We know that a binary literal with tag 'msgpack' is a STRUCT
+    const value = result?.scalar?.binary?.value;
+    const msgpackResult = isNil(value) ? value : unpack(value);
+    // Convert the msgpack result to a protobuf struct
+    const protobufStruct = convertToStruct(msgpackResult);
+
+    return {
+      metadata: result.metadata,
+      hash: result.hash,
+      scalar: {
+        generic: protobufStruct,
+      },
+    } as core.Literal;
+  }
+  return result;
+};

--- a/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionLabels.tsx
+++ b/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionLabels.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Chip from '@mui/material/Chip';
 import makeStyles from '@mui/styles/makeStyles';
 
-type ValuesType = {[p: string]: string};
+type ValuesType = { [p: string]: string };
 interface Props {
   values: ValuesType;
 }
@@ -12,21 +12,20 @@ const useStyles = makeStyles({
     display: 'flex',
     flexWrap: 'wrap',
     width: '100%',
-    maxWidth: '420px'
+    maxWidth: '420px',
   },
   chip: {
     margin: '2px 2px 2px 0',
   },
 });
 
-
-export const ExecutionLabels: React.FC<Props> = ({values}) => {
+export const ExecutionLabels: React.FC<Props> = ({ values }) => {
   const classes = useStyles();
   return (
     <div className={classes.chipContainer}>
       {Object.entries(values).map(([key, value]) => (
         <Chip
-          color='info'
+          color="info"
           key={key}
           label={value ? `${key}: ${value}` : key}
           className={classes.chip}

--- a/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionMetadata.tsx
+++ b/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionMetadata.tsx
@@ -71,11 +71,7 @@ export const ExecutionMetadata: React.FC<{}> = () => {
   const workflowId = execution?.closure?.workflowId;
 
   const { labels } = execution.spec;
-  const {
-    referenceExecution,
-    systemMetadata ,
-    parentNodeExecution,
-  } = execution.spec.metadata;
+  const { referenceExecution, systemMetadata, parentNodeExecution } = execution.spec.metadata;
   const cluster = systemMetadata?.executionCluster ?? dashedValueString;
 
   const details: DetailItem[] = [
@@ -130,11 +126,13 @@ export const ExecutionMetadata: React.FC<{}> = () => {
   if (labels != null && labels.values != null) {
     details.push({
       label: ExecutionMetadataLabels.labels,
-      value: (
-        Object.entries(labels.values).length > 0 ? 
-          <ExecutionLabels values={labels.values} /> : dashedValueString
-      )
-    })
+      value:
+        Object.entries(labels.values).length > 0 ? (
+          <ExecutionLabels values={labels.values} />
+        ) : (
+          dashedValueString
+        ),
+    });
   }
 
   return (

--- a/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionNodeURL.tsx
+++ b/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionNodeURL.tsx
@@ -34,14 +34,14 @@ export const ExecutionNodeURL: React.FC<{
 
   const config =
     // eslint-disable-next-line no-nested-ternary
-    env.CODE_SNIPPET_USE_AUTO_CONFIG === "true"
+    env.CODE_SNIPPET_USE_AUTO_CONFIG === 'true'
       ? 'Config.auto()'
       : isHttps
       ? // https snippet
         `Config.for_endpoint("${window.location.host}")`
       : // http snippet
         `Config.for_endpoint("${window.location.host}", True)`;
-    const code = `from flytekit.remote.remote import FlyteRemote
+  const code = `from flytekit.remote.remote import FlyteRemote
 from flytekit.configuration import Config
 remote = FlyteRemote(
     ${config},

--- a/packages/oss-console/src/components/Executions/ExecutionDetails/test/ExecutionLabels.test.tsx
+++ b/packages/oss-console/src/components/Executions/ExecutionDetails/test/ExecutionLabels.test.tsx
@@ -4,27 +4,31 @@ import '@testing-library/jest-dom';
 import { ExecutionLabels } from '../ExecutionLabels';
 
 jest.mock('@mui/material/Chip', () => (props: any) => (
-  <div data-testid="chip" {...props}>{props.label}</div>
+  <div data-testid="chip" {...props}>
+    {props.label}
+  </div>
 ));
 
 describe('ExecutionLabels', () => {
   it('renders chips with key-value pairs correctly', () => {
     const values = {
       'random/uuid': 'f8b9ff18-4811-4bcc-aefd-4f4ec4de469d',
-      'bar': 'baz',
-      'foo': '',
+      bar: 'baz',
+      foo: '',
     };
 
     render(<ExecutionLabels values={values} />);
 
-    expect(screen.getByText('random/uuid: f8b9ff18-4811-4bcc-aefd-4f4ec4de469d')).toBeInTheDocument();
+    expect(
+      screen.getByText('random/uuid: f8b9ff18-4811-4bcc-aefd-4f4ec4de469d'),
+    ).toBeInTheDocument();
     expect(screen.getByText('bar: baz')).toBeInTheDocument();
     expect(screen.getByText('foo')).toBeInTheDocument();
   });
 
   it('applies correct styles to chip container', () => {
     const values = {
-      'key': 'value',
+      key: 'value',
     };
 
     const { container } = render(<ExecutionLabels values={values} />);
@@ -38,9 +42,9 @@ describe('ExecutionLabels', () => {
 
   it('renders correct number of chips', () => {
     const values = {
-      'key1': 'value1',
-      'key2': 'value2',
-      'key3': 'value3',
+      key1: 'value1',
+      key2: 'value2',
+      key3: 'value3',
     };
 
     render(<ExecutionLabels values={values} />);

--- a/packages/oss-console/src/components/Executions/ExecutionDetails/test/ExecutionMetadata.test.tsx
+++ b/packages/oss-console/src/components/Executions/ExecutionDetails/test/ExecutionMetadata.test.tsx
@@ -15,7 +15,7 @@ const durationTestId = `metadata-${ExecutionMetadataLabels.duration}`;
 const interruptibleTestId = `metadata-${ExecutionMetadataLabels.interruptible}`;
 const overwriteCacheTestId = `metadata-${ExecutionMetadataLabels.overwriteCache}`;
 const relatedToTestId = `metadata-${ExecutionMetadataLabels.relatedTo}`;
-const parentNodeExecutionTestId = `metadata-${ExecutionMetadataLabels.parent}`
+const parentNodeExecutionTestId = `metadata-${ExecutionMetadataLabels.parent}`;
 const labelsTestId = `metadata-${ExecutionMetadataLabels.labels}`;
 
 jest.mock('../../../../models/Launch/api', () => ({
@@ -113,15 +113,15 @@ describe('ExecutionMetadata', () => {
   it('shows related to if metadata is available', () => {
     const { getByTestId } = renderMetadata();
     expect(getByTestId(relatedToTestId)).toHaveTextContent('name');
-  })
+  });
 
   it('shows parent execution if metadata is available', () => {
     const { getByTestId } = renderMetadata();
     expect(getByTestId(parentNodeExecutionTestId)).toHaveTextContent('name');
-  })
+  });
 
   it('shows labels if spec has them', () => {
     const { getByTestId } = renderMetadata();
-    expect(getByTestId(labelsTestId)).toHaveTextContent("key: value");
-  })
+    expect(getByTestId(labelsTestId)).toHaveTextContent('key: value');
+  });
 });

--- a/packages/oss-console/src/components/Launch/LaunchForm/LaunchFormComponents/StructInput.tsx
+++ b/packages/oss-console/src/components/Launch/LaunchForm/LaunchFormComponents/StructInput.tsx
@@ -1,8 +1,7 @@
-import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { FC, useCallback, useMemo, useState } from 'react';
 import { Form } from '@rjsf/mui';
 import validator from '@rjsf/validator-ajv8';
 import styled from '@mui/system/styled';
-import * as msgpack from '@msgpack/msgpack';
 import { InputProps } from '../types';
 import { protobufValueToPrimitive, PrimitiveType } from '../inputHelpers/struct';
 import { StyledCard } from './StyledCard';

--- a/packages/oss-console/src/components/Launch/LaunchForm/inputHelpers/struct.ts
+++ b/packages/oss-console/src/components/Launch/LaunchForm/inputHelpers/struct.ts
@@ -1,6 +1,5 @@
 import Protobuf from '@clients/common/flyteidl/protobuf';
 import Core from '@clients/common/flyteidl/core';
-import * as msgpack from '@msgpack/msgpack';
 import { InputType, InputValue } from '../types';
 import { structPath } from './constants';
 import { ConverterInput, InputHelper, InputValidatorParams } from './types';
@@ -91,25 +90,9 @@ function objectToProtobufStruct(obj: Dictionary<any>): Protobuf.IStruct {
   return { fields };
 }
 
-function parseBinary(binary: Core.IBinary): string {
-  if (!binary.value) {
-    throw new Error('Binary value is empty');
-  }
-
-  if (binary.tag === 'msgpack') {
-    return JSON.stringify(msgpack.decode(binary.value));
-  }
-
-  // unsupported binary type, it might be temporary
-  return '';
-}
-
 function fromLiteral(literal: Core.ILiteral): InputValue {
-  if (literal.scalar?.binary) {
-    return parseBinary(literal.scalar.binary);
-  }
-
   const structValue = extractLiteralWithCheck<Protobuf.IStruct>(literal, structPath);
+
   const finalValue = formatParameterValues(InputType.Struct, protobufStructToObject(structValue));
   return finalValue;
 }

--- a/packages/oss-console/src/components/Launch/LaunchForm/inputHelpers/struct.ts
+++ b/packages/oss-console/src/components/Launch/LaunchForm/inputHelpers/struct.ts
@@ -7,7 +7,7 @@ import { extractLiteralWithCheck, formatParameterValues } from './utils';
 
 export type PrimitiveType = string | number | boolean | null | object;
 
-function asValueWithKind(value: Protobuf.IValue): Protobuf.Value {
+export function asValueWithKind(value: Protobuf.IValue): Protobuf.Value {
   return value instanceof Protobuf.Value ? value : Protobuf.Value.create(value);
 }
 

--- a/packages/oss-console/src/components/Literals/helpers.ts
+++ b/packages/oss-console/src/components/Literals/helpers.ts
@@ -10,9 +10,16 @@ import isNil from 'lodash/isNil';
 import { formatDateUTC, protobufDurationToHMS } from '../../common/formatters';
 import { timestampToDate } from '../../common/utils';
 import { BlobDimensionality, SchemaColumnType } from '../../models/Common/types';
-import { asValueWithKind } from '../Launch/LaunchForm/inputHelpers/struct';
 
 const DEFAULT_UNSUPPORTED = 'This type is not yet supported';
+
+
+export function asValueWithKind(value: Protobuf.IValue): Protobuf.Value {
+  if (typeof value === 'object' && 'kind' in value) {
+    return value as Protobuf.Value;
+  }
+  return Protobuf.Value.create({ ...value });
+}
 
 // PRIMITIVE
 function processPrimitive(primitive?: (Core.IPrimitive & Pick<Core.Primitive, 'value'>) | null) {

--- a/packages/oss-console/src/components/Literals/helpers.ts
+++ b/packages/oss-console/src/components/Literals/helpers.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-use-before-define */
 import Protobuf from '@clients/common/flyteidl/protobuf';
 import Core from '@clients/common/flyteidl/core';
-import * as msgpack from '@msgpack/msgpack';
 import Long from 'long';
 import cloneDeep from 'lodash/cloneDeep';
 import { formatDateUTC, protobufDurationToHMS } from '../../common/formatters';
@@ -80,23 +79,8 @@ function processBinary(binary?: Core.IBinary | null) {
     return 'invalid binary';
   }
 
-  if (!binary.value) {
-    return {
-      tag: `${tag}`,
-      value: '(empty)',
-    };
-  }
-
-  if (tag === 'msgpack') {
-    return {
-      tag: 'msgpack',
-      value: msgpack.decode(binary.value),
-    };
-  }
-
   return {
-    tag: `${tag}`,
-    value: "(binary data not shown)",
+    tag: `${tag} (binary data not shown)`,
   };
 }
 

--- a/packages/oss-console/src/components/Literals/helpers.ts
+++ b/packages/oss-console/src/components/Literals/helpers.ts
@@ -1,11 +1,16 @@
+'use client';
+
 /* eslint-disable no-use-before-define */
 import Protobuf from '@clients/common/flyteidl/protobuf';
 import Core from '@clients/common/flyteidl/core';
 import Long from 'long';
 import cloneDeep from 'lodash/cloneDeep';
+import has from 'lodash/has';
+import isNil from 'lodash/isNil';
 import { formatDateUTC, protobufDurationToHMS } from '../../common/formatters';
 import { timestampToDate } from '../../common/utils';
 import { BlobDimensionality, SchemaColumnType } from '../../models/Common/types';
+import { asValueWithKind } from '../Launch/LaunchForm/inputHelpers/struct';
 
 const DEFAULT_UNSUPPORTED = 'This type is not yet supported';
 
@@ -15,25 +20,26 @@ function processPrimitive(primitive?: (Core.IPrimitive & Pick<Core.Primitive, 'v
     return 'invalid primitive';
   }
 
-  const type = primitive.value;
-
-  switch (type) {
-    case 'datetime':
-      return formatDateUTC(timestampToDate(primitive.datetime as Protobuf.Timestamp));
-    case 'duration':
-      return protobufDurationToHMS(primitive.duration as Protobuf.Duration);
-    case 'integer': {
-      return Long.fromValue(primitive.integer as Long).toNumber();
-    }
-    case 'boolean':
-      return primitive.boolean;
-    case 'floatValue':
-      return primitive.floatValue;
-    case 'stringValue':
-      return `${primitive.stringValue}`;
-    default:
-      return 'unknown';
+  if (has(primitive, 'datetime')) {
+    return formatDateUTC(timestampToDate(primitive.datetime as Protobuf.Timestamp));
   }
+
+  if (has(primitive, 'duration')) {
+    return protobufDurationToHMS(primitive.duration as Protobuf.Duration);
+  }
+  if (has(primitive, 'integer')) {
+    return Long.fromValue(primitive.integer as Long).toNumber();
+  }
+  if (has(primitive, 'boolean')) {
+    return primitive.boolean;
+  }
+  if (has(primitive, 'floatValue')) {
+    return primitive.floatValue;
+  }
+  if (has(primitive, 'stringValue')) {
+    return `${primitive.stringValue}`;
+  }
+  return 'unknown';
 }
 
 // BLOB
@@ -172,21 +178,22 @@ function processProtobufStructValue(struct?: Protobuf.IStruct | null) {
 }
 
 function processGenericValue(value: Protobuf.IValue & Pick<Protobuf.Value, 'kind'>) {
-  const { kind } = value;
+  const finalValue = asValueWithKind(value);
+  const { kind } = finalValue;
 
   switch (kind) {
     case 'nullValue':
       return '(empty)';
     case 'listValue': {
-      const list = value.listValue;
+      const list = finalValue.listValue;
       return list?.values?.map((x) => processGenericValue(x));
     }
     case 'structValue':
-      return processProtobufStructValue(value?.structValue);
+      return processProtobufStructValue(finalValue?.structValue);
     case 'numberValue':
     case 'stringValue':
     case 'boolValue':
-      return value[kind];
+      return finalValue[kind];
     default:
       return 'unknown';
   }
@@ -247,26 +254,31 @@ function processLiteralType(
 ) {
   const type = literalType?.type;
 
-  switch (type) {
-    case 'simple':
-      return processSimpleType(literalType?.simple);
-    case 'schema':
-      return `schema (${processSchemaType(literalType?.schema, true)})`;
-    case 'collectionType':
-      return `collection of ${processLiteralType(literalType?.collectionType)}`;
-    case 'mapValueType':
-      return `map value of ${processLiteralType(literalType?.mapValueType)}`;
-    case 'blob':
-      return processBlobType(literalType?.blob);
-    case 'enumType':
-      return `enum (${processEnumType(literalType?.enumType)})`;
-    case 'structuredDatasetType':
-      return processStructuredDatasetType(literalType?.structuredDatasetType);
-    case 'unionType':
-      return processUnionType(literalType?.unionType, true);
-    default:
-      return DEFAULT_UNSUPPORTED;
+  if (has(literalType, 'simple')) {
+    return processSimpleType(literalType?.simple);
   }
+  if (has(literalType, 'schema')) {
+    return `schema (${processSchemaType(literalType?.schema, true)})`;
+  }
+  if (has(literalType, 'collectionType')) {
+    return `collection of ${processLiteralType(literalType?.collectionType)}`;
+  }
+  if (has(literalType, 'mapValueType')) {
+    return `map value of ${processLiteralType(literalType?.mapValueType)}`;
+  }
+  if (has(literalType, 'blob')) {
+    return processBlobType(literalType?.blob);
+  }
+  if (has(literalType, 'enumType')) {
+    return `enum (${processEnumType(literalType?.enumType)})`;
+  }
+  if (has(literalType, 'structuredDatasetType')) {
+    return processStructuredDatasetType(literalType?.structuredDatasetType);
+  }
+  if (has(literalType, 'unionType')) {
+    return processUnionType(literalType?.unionType, true);
+  }
+  return DEFAULT_UNSUPPORTED;
 }
 
 function processStructuredDatasetType(structuredDatasetType?: Core.IStructuredDatasetType | null) {
@@ -312,30 +324,36 @@ function processStructuredDataset(structuredDataSet?: Core.IStructuredDataset | 
 }
 
 function processScalar(scalar?: (Core.IScalar & Pick<Core.Scalar, 'value'>) | null) {
-  const type = scalar?.value;
-
-  switch (type) {
-    case 'primitive':
-      return processPrimitive(scalar?.primitive);
-    case 'blob':
-      return processBlob(scalar?.blob);
-    case 'binary':
-      return processBinary(scalar?.binary);
-    case 'schema':
-      return processSchema(scalar?.schema);
-    case 'noneType':
-      return processNone(scalar?.noneType);
-    case 'error':
-      return processError(scalar?.error);
-    case 'generic':
-      return processGeneric(scalar?.generic);
-    case 'structuredDataset':
-      return processStructuredDataset(scalar?.structuredDataset);
-    case 'union':
-      return processUnion(scalar?.union as Core.IUnion);
-    default:
-      return DEFAULT_UNSUPPORTED;
+  if (has(scalar, 'primitive')) {
+    return processPrimitive(scalar?.primitive);
   }
+
+  if (has(scalar, 'blob')) {
+    return processBlob(scalar?.blob);
+  }
+  if (has(scalar, 'binary')) {
+    return processBinary(scalar?.binary);
+  }
+  if (has(scalar, 'schema')) {
+    return processSchema(scalar?.schema);
+  }
+  if (has(scalar, 'noneType')) {
+    return processNone(scalar?.noneType);
+  }
+  if (has(scalar, 'error')) {
+    return processError(scalar?.error);
+  }
+  if (has(scalar, 'generic')) {
+    return processGeneric(scalar?.generic);
+  }
+  if (has(scalar, 'structuredDataset')) {
+    return processStructuredDataset(scalar?.structuredDataset);
+  }
+  if (has(scalar, 'union')) {
+    return processUnion(scalar?.union as Core.IUnion);
+  }
+
+  return DEFAULT_UNSUPPORTED;
 }
 
 function processCollection(collection?: Core.ILiteralCollection | null, mapTaskIndex?: number) {
@@ -362,26 +380,42 @@ function processMap(map?: Core.ILiteralMap | null, mapTaskIndex?: number) {
   return transformLiterals(literals, mapTaskIndex);
 }
 
-function processLiteral(
-  literal?: Core.ILiteral & Pick<Core.Literal, 'value'>,
+function processOffloadedLiteral(
+  offloadedLiteral?: Core.ILiteralOffloadedMetadata | null,
   mapTaskIndex?: number,
 ) {
-  const type = literal?.value;
+  const uri = offloadedLiteral?.uri;
 
+  if (isNil(uri) || uri === '') {
+    return 'invalid offloaded literal';
+  }
+
+  return {
+    offloaded_uri: uri,
+  };
+}
+
+function processLiteral(literal?: Core.ILiteral, mapTaskIndex?: number): any {
   if (!literal) {
     return 'invalid literal';
   }
 
-  switch (type) {
-    case 'scalar':
-      return processScalar(literal.scalar);
-    case 'collection':
-      return processCollection(literal.collection, mapTaskIndex);
-    case 'map':
-      return processMap(literal.map, mapTaskIndex);
-    default:
-      return DEFAULT_UNSUPPORTED;
+  if (has(literal, 'scalar')) {
+    return processScalar(literal.scalar);
   }
+
+  if (has(literal, 'collection')) {
+    return processCollection(literal.collection, mapTaskIndex);
+  }
+
+  if (has(literal, 'map')) {
+    return processMap(literal.map, mapTaskIndex);
+  }
+
+  if (has(literal, 'offloadedMetadata')) {
+    return processOffloadedLiteral(literal.offloadedMetadata, mapTaskIndex);
+  }
+  return DEFAULT_UNSUPPORTED;
 }
 
 export function transformLiterals(json: { [k: string]: Core.ILiteral }, mapTaskIndex?: number) {

--- a/packages/oss-console/src/components/Literals/test/helpers/genScalarBinaryTestCase.mock.ts
+++ b/packages/oss-console/src/components/Literals/test/helpers/genScalarBinaryTestCase.mock.ts
@@ -1,25 +1,14 @@
 import Core from '@clients/common/flyteidl/core';
-import { encode } from '@msgpack/msgpack';
 import { TestCaseList } from '../types';
 
-const testJson = {
-  test1: 1,
-  test2: '2',
-  test3: true,
-};
-
 const scalarBinaryTestCases: TestCaseList<Core.IBinary> = {
-  NORMAL_MSGPACK: {
-    value: { value: encode(testJson), tag: 'msgpack' },
-    expected: { result_var: { tag: 'msgpack', value: testJson } },
-  },
   WITH_VAL: {
     value: { value: new Uint8Array(), tag: 'tag1' },
-    expected: { result_var: { tag: 'tag1', value: '(binary data not shown)' } },
+    expected: { result_var: { tag: 'tag1 (binary data not shown)' } },
   },
-  EMPTY_VALUE: {
-    value: { tag: 'msgpack' },
-    expected: { result_var: { tag: 'msgpack', value: '(empty)' } },
+  INT_WITH_SMALL_LOW: {
+    value: { tag: 'tag2' },
+    expected: { result_var: { tag: 'tag2 (binary data not shown)' } },
   },
 };
 

--- a/packages/oss-console/src/models/__mocks__/executionsData.ts
+++ b/packages/oss-console/src/models/__mocks__/executionsData.ts
@@ -25,7 +25,7 @@ export const MOCK_EXECUTION_ID = {
   project: 'project',
   domain: 'domain',
   name: 'name',
-}
+};
 
 export function fixedDuration(): Protobuf.Duration {
   return {
@@ -84,13 +84,13 @@ export function generateExecutionMetadata(): ExecutionMetadata {
       executionCluster: 'flyte',
     },
     referenceExecution: {
-      ...MOCK_EXECUTION_ID
+      ...MOCK_EXECUTION_ID,
     },
     parentNodeExecution: {
       nodeId: 'node',
       executionId: {
-        ...MOCK_EXECUTION_ID
-      }
+        ...MOCK_EXECUTION_ID,
+      },
     },
   };
 }
@@ -102,9 +102,9 @@ export const createMockExecutionSpec: () => ExecutionSpec = () => ({
   metadata: generateExecutionMetadata(),
   labels: {
     values: {
-      "key": "value"
-    }
-  }
+      key: 'value',
+    },
+  },
 });
 
 export const createMockExecution: (id?: string | number) => Execution = (id = 1) => {

--- a/packages/oss-console/src/test/setupTests.ts
+++ b/packages/oss-console/src/test/setupTests.ts
@@ -1,7 +1,4 @@
 import '@testing-library/jest-dom';
-import { TextEncoder, TextDecoder } from 'util';
-
-Object.assign(global, { TextDecoder, TextEncoder });
 
 jest.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({
   prism: {},

--- a/packages/oss-console/src/test/setupTests.ts
+++ b/packages/oss-console/src/test/setupTests.ts
@@ -16,7 +16,7 @@ const axiosMock = jest.mock('axios', () => ({
       response: {
         use: jest.fn(),
       },
-    }
+    },
   }),
   defaults: {
     transformRequest: [],

--- a/script/test/jest-setup.ts
+++ b/script/test/jest-setup.ts
@@ -1,5 +1,1 @@
 import '@testing-library/jest-dom';
-
-import { TextEncoder, TextDecoder } from 'util';
-
-Object.assign(global, { TextDecoder, TextEncoder });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2092,7 +2092,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@clients/common@workspace:packages/common"
   dependencies:
-    "@flyteorg/flyteidl": ^1.10.7
+    "@flyteorg/flyteidl": ^1.13.5
     "@protobuf-ts/runtime": ^2.6.0
     "@protobuf-ts/runtime-rpc": ^2.6.0
   peerDependencies:
@@ -2249,6 +2249,7 @@ __metadata:
     lossless-json: ^1.0.3
     memoize-one: ^5.0.0
     moment-timezone: ^0.5.28
+    msgpackr: ^1.11.2
     msw: ^1.3.2
     notistack: ^3.0.1
     object-hash: ^1.3.1
@@ -2941,10 +2942,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@flyteorg/flyteidl@npm:^1.10.7":
-  version: 1.10.7
-  resolution: "@flyteorg/flyteidl@npm:1.10.7"
-  checksum: fa559d1b5fc676a220fdfdad1a689affcc7e34e375e9755153f14f44e41a1637414ccf43b5eeab8b4d8cd3b1f5d36d30ae5d75922e391f45d50e0b3f593fb8bb
+"@flyteorg/flyteidl@npm:^1.13.5":
+  version: 1.13.5
+  resolution: "@flyteorg/flyteidl@npm:1.13.5"
+  checksum: 5cb365d5e415dd63e08bcc18dca64e5ac6343182e6ffdcc3176bac9be4dd4bfc2a944c6cdde93c8d3673fe13dd5db47255fc60c187f7d1880ae06c7700f6b711
   languageName: node
   linkType: hard
 
@@ -3498,6 +3499,48 @@ __metadata:
     call-me-maybe: ^1.0.1
     glob-to-regexp: ^0.3.0
   checksum: d3b82b29368821154ce8e10bef5ccdbfd070d3e9601643c99ea4607e56f3daeaa4e755dd6d2355da20762c695c1b0570543d9f84b48f70c211ec09c4aaada2e1
+  languageName: node
+  linkType: hard
+
+"@msgpackr-extract/msgpackr-extract-darwin-arm64@npm:3.0.3":
+  version: 3.0.3
+  resolution: "@msgpackr-extract/msgpackr-extract-darwin-arm64@npm:3.0.3"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@msgpackr-extract/msgpackr-extract-darwin-x64@npm:3.0.3":
+  version: 3.0.3
+  resolution: "@msgpackr-extract/msgpackr-extract-darwin-x64@npm:3.0.3"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@msgpackr-extract/msgpackr-extract-linux-arm64@npm:3.0.3":
+  version: 3.0.3
+  resolution: "@msgpackr-extract/msgpackr-extract-linux-arm64@npm:3.0.3"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@msgpackr-extract/msgpackr-extract-linux-arm@npm:3.0.3":
+  version: 3.0.3
+  resolution: "@msgpackr-extract/msgpackr-extract-linux-arm@npm:3.0.3"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@msgpackr-extract/msgpackr-extract-linux-x64@npm:3.0.3":
+  version: 3.0.3
+  resolution: "@msgpackr-extract/msgpackr-extract-linux-x64@npm:3.0.3"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@msgpackr-extract/msgpackr-extract-win32-x64@npm:3.0.3":
+  version: 3.0.3
+  resolution: "@msgpackr-extract/msgpackr-extract-win32-x64@npm:3.0.3"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -12964,6 +13007,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"detect-libc@npm:^2.0.1":
+  version: 2.0.3
+  resolution: "detect-libc@npm:2.0.3"
+  checksum: 2ba6a939ae55f189aea996ac67afceb650413c7a34726ee92c40fb0deb2400d57ef94631a8a3f052055eea7efb0f99a9b5e6ce923415daa3e68221f963cfc27d
+  languageName: node
+  linkType: hard
+
 "detect-newline@npm:^3.0.0":
   version: 3.1.0
   resolution: "detect-newline@npm:3.1.0"
@@ -20689,6 +20739,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"msgpackr-extract@npm:^3.0.2":
+  version: 3.0.3
+  resolution: "msgpackr-extract@npm:3.0.3"
+  dependencies:
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": 3.0.3
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": 3.0.3
+    "@msgpackr-extract/msgpackr-extract-linux-arm": 3.0.3
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": 3.0.3
+    "@msgpackr-extract/msgpackr-extract-linux-x64": 3.0.3
+    "@msgpackr-extract/msgpackr-extract-win32-x64": 3.0.3
+    node-gyp: latest
+    node-gyp-build-optional-packages: 5.2.2
+  dependenciesMeta:
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64":
+      optional: true
+    "@msgpackr-extract/msgpackr-extract-darwin-x64":
+      optional: true
+    "@msgpackr-extract/msgpackr-extract-linux-arm":
+      optional: true
+    "@msgpackr-extract/msgpackr-extract-linux-arm64":
+      optional: true
+    "@msgpackr-extract/msgpackr-extract-linux-x64":
+      optional: true
+    "@msgpackr-extract/msgpackr-extract-win32-x64":
+      optional: true
+  bin:
+    download-msgpackr-prebuilds: bin/download-prebuilds.js
+  checksum: 3b5ae152821feff843380f0b091afbebd80bd224e644f4410abd33d05da3159eb8b0d45c7dcf7d5226ce1d5c71cd68052f066788f46ea7a3cd8791a1c740a079
+  languageName: node
+  linkType: hard
+
+"msgpackr@npm:^1.11.2":
+  version: 1.11.2
+  resolution: "msgpackr@npm:1.11.2"
+  dependencies:
+    msgpackr-extract: ^3.0.2
+  dependenciesMeta:
+    msgpackr-extract:
+      optional: true
+  checksum: 53b30ddd68fd98ae95690017787f3b54414191314f3d36329cc01c073ec35fece87c86de731ef521d1f1b8adeb294008184ad0266d3a0e62cf0867dc728dcbd1
+  languageName: node
+  linkType: hard
+
 "msw@npm:^1.3.2":
   version: 1.3.2
   resolution: "msw@npm:1.3.2"
@@ -20911,6 +21004,19 @@ __metadata:
   version: 1.3.1
   resolution: "node-forge@npm:1.3.1"
   checksum: 08fb072d3d670599c89a1704b3e9c649ff1b998256737f0e06fbd1a5bf41cae4457ccaee32d95052d80bbafd9ffe01284e078c8071f0267dc9744e51c5ed42a9
+  languageName: node
+  linkType: hard
+
+"node-gyp-build-optional-packages@npm:5.2.2":
+  version: 5.2.2
+  resolution: "node-gyp-build-optional-packages@npm:5.2.2"
+  dependencies:
+    detect-libc: ^2.0.1
+  bin:
+    node-gyp-build-optional-packages: bin.js
+    node-gyp-build-optional-packages-optional: optional.js
+    node-gyp-build-optional-packages-test: build-test.js
+  checksum: 3c10d7380901ab5febcd153d2632917fe7507edb15a3405e9ef19801834a4c2162459a67b9944887f737f8718baeb4aaf0002c829a8214011930f2de80e4b42f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3501,13 +3501,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@msgpack/msgpack@npm:^3.0.0-beta2":
-  version: 3.0.0-beta2
-  resolution: "@msgpack/msgpack@npm:3.0.0-beta2"
-  checksum: d86e5d48146051952d6bea35a6cf733a401cf65ad5614d79689aa48c7076021737ca2c782978dd1b6c0c9c45888b246e379e45ae906179e3a0e8ef4ee6f221c1
-  languageName: node
-  linkType: hard
-
 "@mswjs/cookies@npm:^0.2.2":
   version: 0.2.2
   resolution: "@mswjs/cookies@npm:0.2.2"
@@ -14914,7 +14907,6 @@ __metadata:
   dependencies:
     "@commitlint/cli": ^17.3.0
     "@commitlint/config-conventional": ^17.3.0
-    "@msgpack/msgpack": ^3.0.0-beta2
     "@semantic-release/changelog": ^5.0.1
     "@semantic-release/commit-analyzer": ^8.0.1
     "@semantic-release/exec": ^6.0.3


### PR DESCRIPTION

# TL;DR
Decodes msgpack structs and turns them into flyte literals

<img width="616" alt="image" src="https://github.com/user-attachments/assets/87e874be-aab3-4105-b944-08a7b1be4805">

<img width="810" alt="image" src="https://github.com/user-attachments/assets/ec9ed320-1d20-4333-8b3c-1a8c18966b08">

# TEST
* `ADMIN_API_URL=https://dogfood.cloud-staging.union.ai BASE_HREF=https://dogfood.cloud-staging.union.ai yarn start`
* go to https://localhost.dogfood.cloud-staging.union.ai:8080/console/projects/flytesnacks/domains/development/executions/axfdc2b8m8mchw72v2wp/nodes

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Decodes msgpack structs and turns them into flyte literals

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
