### PR TITLE
feat: Streaming Decks

### DIFF
--- a/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionDetailsActions/FlyteDeckButton.tsx
+++ b/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionDetailsActions/FlyteDeckButton.tsx
@@ -58,7 +58,6 @@ export const FlyteDeckButton: FC<FlyteDeckButtonProps> = ({
         variant="outlined"
         color="primary"
         onClick={() => setShowDeck(true)}
-        disabled={phase !== NodeExecutionPhase.SUCCEEDED}
       >
         {flyteDeckText || t('flyteDeck')}
       </Button>

--- a/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionDetailsActions/FlyteDeckButton.tsx
+++ b/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionDetailsActions/FlyteDeckButton.tsx
@@ -97,7 +97,7 @@ export const FlyteDeckButton: FC<FlyteDeckButtonProps> = ({
               }}
               py={2}
             >
-              {t('flyteDeck')}
+              {flyteDeckText || t('flyteDeck')}
               <IconButton onClick={() => downloadLink.fetch()}>
                 <RefreshIcon />
               </IconButton>

--- a/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionDetailsActions/FlyteDeckButton.tsx
+++ b/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionDetailsActions/FlyteDeckButton.tsx
@@ -8,6 +8,8 @@ import Grid from '@mui/material/Grid';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
 import DialogContent from '@mui/material/DialogContent';
+import { useDownloadLink } from '@clients/oss-console/components/hooks/useDataProxy';
+import RefreshIcon from '@mui/icons-material/Refresh';
 import t from '../strings';
 import { WorkflowNodeExecution } from '../../contexts';
 import { NodeExecutionPhase } from '../../../../models/Execution/enums';
@@ -52,13 +54,11 @@ export const FlyteDeckButton: FC<FlyteDeckButtonProps> = ({
     setSetFullScreen(!fullScreen);
   };
 
+  const downloadLink = useDownloadLink(nodeExecution?.id);
+
   return nodeExecution?.closure?.deckUri ? (
     <>
-      <Button
-        variant="outlined"
-        color="primary"
-        onClick={() => setShowDeck(true)}
-      >
+      <Button variant="outlined" color="primary" onClick={() => setShowDeck(true)}>
         {flyteDeckText || t('flyteDeck')}
       </Button>
       <Dialog
@@ -90,10 +90,17 @@ export const FlyteDeckButton: FC<FlyteDeckButtonProps> = ({
                 fontSize: '24px',
                 lineHeight: '32px',
                 marginBlock: 0,
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                gap: 1,
               }}
               py={2}
             >
               {t('flyteDeck')}
+              <IconButton onClick={() => downloadLink.fetch()}>
+                <RefreshIcon />
+              </IconButton>
             </Typography>
           </Grid>
           <Grid item>
@@ -108,7 +115,7 @@ export const FlyteDeckButton: FC<FlyteDeckButtonProps> = ({
             overflow: 'hidden',
           }}
         >
-          <ExecutionNodeDeck nodeExecutionId={nodeExecution.id} />
+          <ExecutionNodeDeck nodeExecutionId={nodeExecution.id} downloadLink={downloadLink} />
         </DialogContent>
       </Dialog>
     </>

--- a/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionNodeDeck.tsx
+++ b/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionNodeDeck.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Core from '@clients/common/flyteidl/core';
+import NotFoundError from '@clients/common/Errors/NotFoundError';
 import { LoadingSpinner } from '@clients/primitives/LoadingSpinner';
 import { useDownloadLink } from '../../hooks/useDataProxy';
 import { WaitForData } from '../../common/WaitForData';
@@ -26,6 +27,22 @@ export const ExecutionNodeDeck: React.FC<{
     'allow-top-navigation-by-user-activation',
     'allow-downloads',
   ].join(' ');
+
+  if (downloadLink?.lastError instanceof NotFoundError) {
+    return (
+      <div style={{ textAlign: 'center' }}>
+        <h1>The deck will be ready soon. Please try again later.</h1>
+        <p>
+          If you're using the real-time deck, it's because the 'publish'
+          function has not been invoked yet.
+        </p>
+        <p>
+          If you're not using the real-time deck, it's because the corresponding
+          task is still in progress.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <WaitForData {...downloadLink} loadingComponent={LoadingSpinner}>

--- a/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionNodeDeck.tsx
+++ b/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionNodeDeck.tsx
@@ -40,6 +40,22 @@ export const ExecutionNodeDeck: React.FC<{
           If you're not using the real-time deck, it's because the corresponding
           task is still in progress.
         </p>
+        <button
+          onClick={() => window.location.reload()}
+          style={{
+            marginTop: '20px',
+            padding: '10px 20px',
+            fontSize: '16px',
+            fontWeight: 'bold',
+            color: '#fff',
+            backgroundColor: '#a31aff',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: 'pointer',
+          }}
+        >
+          Refresh
+        </button>
       </div>
     );
   }

--- a/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionNodeDeck.tsx
+++ b/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionNodeDeck.tsx
@@ -9,8 +9,8 @@ import { WaitForData } from '../../common/WaitForData';
 export const ExecutionNodeDeck: React.FC<{
   nodeExecutionId: Core.NodeExecutionIdentifier;
   className?: string;
-}> = ({ nodeExecutionId, className = '' }) => {
-  const downloadLink = useDownloadLink(nodeExecutionId);
+  downloadLink: ReturnType<typeof useDownloadLink>;
+}> = ({ className = '', downloadLink }) => {
   const iFrameSrc = downloadLink?.value?.signedUrl?.[0];
 
   // Taken from https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox
@@ -40,22 +40,6 @@ export const ExecutionNodeDeck: React.FC<{
           If you're not using the real-time deck, it's because the corresponding task is still in
           progress.
         </p>
-        <button
-          onClick={() => downloadLink.fetch()}
-          style={{
-            marginTop: '20px',
-            padding: '10px 20px',
-            fontSize: '16px',
-            fontWeight: 'bold',
-            color: '#fff',
-            backgroundColor: '#a31aff',
-            border: 'none',
-            borderRadius: '4px',
-            cursor: 'pointer',
-          }}
-        >
-          Refresh
-        </button>
       </div>
     );
   }

--- a/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionNodeDeck.tsx
+++ b/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionNodeDeck.tsx
@@ -28,7 +28,11 @@ export const ExecutionNodeDeck: React.FC<{
     'allow-downloads',
   ].join(' ');
 
-  if (downloadLink?.lastError instanceof NotFoundError) {
+  /**
+   * if the download link query has an error other than 404, we show a 'pretty' message to the user.
+   * else: we show the built in DataError handler passed to the WaitForQuery component.
+   */
+  if (downloadLink?.lastError && !(downloadLink?.lastError instanceof NotFoundError)) {
     return (
       <div style={{ textAlign: 'center' }}>
         <h1>The deck will be ready soon. Please try again later.</h1>
@@ -44,6 +48,7 @@ export const ExecutionNodeDeck: React.FC<{
     );
   }
 
+  // 404 or no error case
   return (
     <WaitForData {...downloadLink} loadingComponent={LoadingSpinner}>
       <iframe

--- a/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionNodeDeck.tsx
+++ b/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionNodeDeck.tsx
@@ -33,15 +33,15 @@ export const ExecutionNodeDeck: React.FC<{
       <div style={{ textAlign: 'center' }}>
         <h1>The deck will be ready soon. Please try again later.</h1>
         <p>
-          If you're using the real-time deck, it's because the 'publish'
-          function has not been invoked yet.
+          If you're using the real-time deck, it's because the 'publish' function has not been
+          invoked yet.
         </p>
         <p>
-          If you're not using the real-time deck, it's because the corresponding
-          task is still in progress.
+          If you're not using the real-time deck, it's because the corresponding task is still in
+          progress.
         </p>
         <button
-          onClick={() => window.location.reload()}
+          onClick={() => downloadLink.fetch()}
           style={{
             marginTop: '20px',
             padding: '10px 20px',


### PR DESCRIPTION
# TL;DR
Show flyte deck when running phase and terminal phase (include failed) 

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

This pull request (PR) introduces several enhancements and fixes to the FlyteDeckButton and ExecutionNodeDeck components in the Flyte console. Here's a summary of the changes:

1. **FlyteDeckButton Component:**
   - Added a `RefreshIcon` button to allow users to refresh the deck content.
   - Integrated a `useDownloadLink` hook to manage the download link for the deck.
   - Removed the `disabled` state from the button that opens the deck, allowing it to be clicked regardless of the node execution phase.
   - Updated the `ExecutionNodeDeck` component to accept a `downloadLink` prop.

2. **ExecutionNodeDeck Component:**
   - Added error handling for `NotFoundError` to display a user-friendly message when the deck is not yet available.
   - Modified the component to use the `downloadLink` prop instead of creating a new instance within the component.

This PR enhances the FlyteDeckButton and ExecutionNodeDeck components to improve user interaction and error handling.


## Tracking Issue

## Follow-up issue
_NA_

## Example

#### NEW FLYTEKIT, NO DECK, RUNNING With Deck, SUCCEED, and FAILED

https://github.com/user-attachments/assets/aa222e09-69da-44ac-b946-bb3d2b0a264b

#### OLD FLYTEKIT, NO DECK, RUNNING With Deck, SUCCEED, and FAILED

https://github.com/user-attachments/assets/a66f17b3-084c-4c51-ba62-9a82b4c89ced