### PR TITLE
Add project and domain filters in order to hit DB index #patch

### DIFF
--- a/packages/oss-console/src/components/Entities/generators.ts
+++ b/packages/oss-console/src/components/Entities/generators.ts
@@ -8,11 +8,21 @@ export const executionFilterGenerator: {
   [k in ResourceType]: (id: ResourceIdentifier, version?: string) => FilterOperation[];
 } = {
   [ResourceType.DATASET]: noFilters,
-  [ResourceType.LAUNCH_PLAN]: ({ name }, version) => [
+  [ResourceType.LAUNCH_PLAN]: ({ name, project, domain }, version) => [
     {
       key: 'launch_plan.name',
       operation: FilterOperationName.EQ,
       value: name,
+    },
+    {
+      key: 'launch_plan.project',
+      operation: FilterOperationName.EQ,
+      value: project,
+    },
+    {
+      key: 'launch_plan.domain',
+      operation: FilterOperationName.EQ,
+      value: domain,
     },
     ...(version
       ? [
@@ -24,11 +34,21 @@ export const executionFilterGenerator: {
         ]
       : []),
   ],
-  [ResourceType.TASK]: ({ name }, version) => [
+  [ResourceType.TASK]: ({ name, project, domain }, version) => [
     {
       key: 'task.name',
       operation: FilterOperationName.EQ,
       value: name,
+    },
+    {
+      key: 'task.project',
+      operation: FilterOperationName.EQ,
+      value: project,
+    },
+    {
+      key: 'task.domain',
+      operation: FilterOperationName.EQ,
+      value: domain,
     },
     ...(version
       ? [
@@ -41,11 +61,21 @@ export const executionFilterGenerator: {
       : []),
   ],
   [ResourceType.UNSPECIFIED]: noFilters,
-  [ResourceType.WORKFLOW]: ({ name }, version) => [
+  [ResourceType.WORKFLOW]: ({ name, project, domain }, version) => [
     {
       key: 'workflow.name',
       operation: FilterOperationName.EQ,
       value: name,
+    },
+    {
+      key: 'workflow.project',
+      operation: FilterOperationName.EQ,
+      value: project,
+    },
+    {
+      key: 'workflow.domain',
+      operation: FilterOperationName.EQ,
+      value: domain,
     },
     ...(version
       ? [

--- a/packages/oss-console/src/components/Workflow/SearchableWorkflowNameList.tsx
+++ b/packages/oss-console/src/components/Workflow/SearchableWorkflowNameList.tsx
@@ -286,6 +286,16 @@ const WorkflowCard = ({ item, inView }: { item: NamedEntity; inView: boolean }) 
             operation: FilterOperationName.EQ,
             value: item.id.name,
           },
+          {
+            key: 'workflow.project',
+            operation: FilterOperationName.EQ,
+            value: item.id.project,
+          },
+          {
+            key: 'workflow.domain',
+            operation: FilterOperationName.EQ,
+            value: item.id.domain,
+          },
         ],
       }),
       enabled: !!inView && !!item.id.name,


### PR DESCRIPTION
# TL;DR
This addresses the issue described in https://github.com/flyteorg/flyte/issues/6428 where DB queries don't use the indexes on the `workflows`, `tasks` and `lanuchplans` table. This slows down the UI significantly and spikes the CPU usage of the database server.

## Type
 - [x] Bug Fix (Performance)
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The index in the database is over the three columns `(name, project, domain)` - not JUST `name`. Therefore when filtering, we need to pass all these values in order to leverage the index.

## Tracking Issue

fixes https://github.com/flyteorg/flyte/issues/6428
