### PR TITLE
Feat: [feature][QoL] Adds user to the execution details page

### DIFF
--- a/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionMetadata.tsx
+++ b/packages/oss-console/src/components/Executions/ExecutionDetails/ExecutionMetadata.tsx
@@ -71,7 +71,7 @@ export const ExecutionMetadata: React.FC<{}> = () => {
   const workflowId = execution?.closure?.workflowId;
 
   const { labels } = execution.spec;
-  const { referenceExecution, systemMetadata, parentNodeExecution } = execution.spec.metadata;
+  const { referenceExecution, systemMetadata, parentNodeExecution, principal } = execution.spec.metadata;
   const cluster = systemMetadata?.executionCluster ?? dashedValueString;
 
   const details: DetailItem[] = [
@@ -84,6 +84,10 @@ export const ExecutionMetadata: React.FC<{}> = () => {
     {
       label: ExecutionMetadataLabels.cluster,
       value: cluster,
+    },
+    {
+      label: ExecutionMetadataLabels.principal,
+      value: principal || dashedValueString,
     },
     {
       label: ExecutionMetadataLabels.time,

--- a/packages/oss-console/src/components/Executions/ExecutionDetails/constants.ts
+++ b/packages/oss-console/src/components/Executions/ExecutionDetails/constants.ts
@@ -14,6 +14,7 @@ export enum ExecutionMetadataLabels {
   overwriteCache = 'Overwrite cached outputs',
   parent = 'Parent',
   labels = 'Labels',
+  principal = 'Created by',
 }
 
 export const tabs = {


### PR DESCRIPTION
# TL;DR
This adds `principal` on the execution details page.   

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Often time; we want to show the user who started the wf executions. While the data bering returned from the Flyte Admin API in the response; it's not rendered anywhere in the UI. This PR adds the user on the execution details page

### before
<img width="1962" height="522" alt="Screenshot 2025-07-24 at 3 04 03 PM" src="https://github.com/user-attachments/assets/c8e576c8-ab54-4635-9964-9987b7714cff" />

### after  
<img width="1961" height="800" alt="Screenshot 2025-07-24 at 4 27 36 PM" src="https://github.com/user-attachments/assets/74db34fa-d677-4cee-b17a-5765f45dc941" />


## Tracking Issue
_NA_

## Follow-up issue
_NA_
